### PR TITLE
Add requirements file for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository experiments with algorithms needed for self-improving AI. The bi
 
 ## Setup
 
-1. Use Python 3.10 or newer with PyTorch installed.
+1. Use Python 3.10 or newer and run `pip install -r requirements.txt` to install dependencies.
 2. Optional: `pip install flash-attn` to enable the FlashAttention-3 wrapper in `src/flash_attention3.py`.
 
 Run the scripts directly with `python` to see parameter and FLOP estimates.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+torch
+# optional: flash-attn for FlashAttention-3 support


### PR DESCRIPTION
## Summary
- document dependencies in `requirements.txt`
- update README setup instructions to install from requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685b5bf447548331bca2ef61f91a873e