### PR TITLE
Add save/load for hierarchical memory

### DIFF
--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 from typing import Iterable, Any, Tuple, List
+from pathlib import Path
 
 from .streaming_compression import StreamingCompressor
 from .vector_store import VectorStore
@@ -30,3 +31,32 @@ class HierarchicalMemory:
         comp_t = torch.from_numpy(comp_vecs)
         decoded = self.compressor.decoder(comp_t)
         return decoded, meta
+
+    def save(self, path: str | Path) -> None:
+        """Persist compressor state and vector store to ``path``."""
+        p = Path(path)
+        p.mkdir(parents=True, exist_ok=True)
+        comp_state = {
+            "state_dict": self.compressor.state_dict(),
+            "buffer": [t.cpu() for t in self.compressor.buffer.data],
+            "count": self.compressor.buffer.count,
+            "capacity": self.compressor.buffer.capacity,
+        }
+        torch.save(comp_state, p / "compressor.pt")
+        self.store.save(p / "vectors.npz")
+
+    @classmethod
+    def load(cls, path: str | Path) -> "HierarchicalMemory":
+        """Load a saved ``HierarchicalMemory`` from ``save()`` output."""
+        p = Path(path)
+        comp_state = torch.load(p / "compressor.pt", map_location="cpu")
+        state_dict = comp_state["state_dict"]
+        dim = state_dict["encoder.weight"].shape[1]
+        compressed_dim = state_dict["encoder.weight"].shape[0]
+        capacity = int(comp_state.get("capacity", 0))
+        mem = cls(dim, compressed_dim, capacity)
+        mem.compressor.load_state_dict(state_dict)
+        mem.compressor.buffer.data = [t for t in comp_state["buffer"]]
+        mem.compressor.buffer.count = int(comp_state["count"])
+        mem.store = VectorStore.load(p / "vectors.npz")
+        return mem

--- a/tests/test_hierarchical_memory.py
+++ b/tests/test_hierarchical_memory.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+import tempfile
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import torch
 
@@ -17,6 +18,20 @@ class TestHierarchicalMemory(unittest.TestCase):
         self.assertEqual(out.shape, (1, 4))
         self.assertEqual(len(meta), 1)
         self.assertIn(meta[0], ["a", "b", "c"])
+
+    def test_save_and_load(self):
+        torch.manual_seed(0)
+        mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=5)
+        data = torch.randn(4, 4)
+        mem.add(data, metadata=list(range(4)))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mem.save(tmpdir)
+            loaded = HierarchicalMemory.load(tmpdir)
+            q = data[1]
+            out1, meta1 = mem.search(q, k=2)
+            out2, meta2 = loaded.search(q, k=2)
+            self.assertTrue(torch.allclose(out1, out2, atol=1e-6, rtol=1e-6))
+            self.assertEqual(meta1, meta2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enable persistence for `HierarchicalMemory`
- test saving and loading of hierarchical memory state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685b5c2486908331bb914c1a4565c3d1