### PR TITLE
Fix unused import

### DIFF
--- a/src/topk_sparse_attention.py
+++ b/src/topk_sparse_attention.py
@@ -1,5 +1,4 @@
 import torch
-from torch import nn
 from typing import Tuple
 
 


### PR DESCRIPTION
## Summary
- remove unused `nn` import from topk sparse attention

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685b5bfc255883319e97253486d2f70b