### PR TITLE
Fix HierarchicalMemory device handling

### DIFF
--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -27,10 +27,11 @@ class HierarchicalMemory:
             q = q[0]
         comp_vecs, meta = self.store.search(q, k)
         if comp_vecs.shape[0] == 0:
-            return torch.empty(0, query.size(-1)), meta
+            empty = torch.empty(0, query.size(-1), device=query.device)
+            return empty, meta
         comp_t = torch.from_numpy(comp_vecs)
         decoded = self.compressor.decoder(comp_t)
-        return decoded, meta
+        return decoded.to(query.device), meta
 
     def save(self, path: str | Path) -> None:
         """Persist compressor state and vector store to ``path``."""

--- a/tests/test_hierarchical_memory.py
+++ b/tests/test_hierarchical_memory.py
@@ -13,6 +13,7 @@ class TestHierarchicalMemory(unittest.TestCase):
         mem.add(data, metadata=["a", "b", "c"])
         out, meta = mem.search(data[0], k=1)
         self.assertEqual(out.shape, (1, 4))
+        self.assertEqual(out.device, data[0].device)
         self.assertEqual(len(meta), 1)
         self.assertIn(meta[0], ["a", "b", "c"])
 


### PR DESCRIPTION
## Summary
- ensure `HierarchicalMemory.search` returns tensors on the query device
- verify the tensor device in the hierarchical memory tests

## Testing
- `pytest tests/test_hierarchical_memory.py::TestHierarchicalMemory::test_add_and_search -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685cb63fcfe483318a226789128f9c91