### PR TITLE
Add failing output to summarize_results

### DIFF
--- a/src/autobench.py
+++ b/src/autobench.py
@@ -39,6 +39,10 @@ def summarize_results(results: Dict[str, BenchResult]) -> str:
     for name, res in sorted(results.items()):
         status = "PASS" if res.passed else "FAIL"
         lines.append(f"{name}: {status}")
+        if not res.passed and res.output:
+            snippet = "\n".join(res.output.strip().splitlines()[:3])
+            if snippet:
+                lines.append(snippet)
     return "\n".join(lines)
 
 

--- a/tests/test_autobench.py
+++ b/tests/test_autobench.py
@@ -33,12 +33,15 @@ class TestAutoBench(unittest.TestCase):
     def test_summarize_results(self):
         results = {
             "a.py": BenchResult(True, ""),
-            "b.py": BenchResult(False, ""),
+            "b.py": BenchResult(False, "Line1\nLine2\nLine3\nLine4"),
         }
         summary = summarize_results(results)
         self.assertIn("Passed 1/2 modules", summary)
         self.assertIn("a.py: PASS", summary)
         self.assertIn("b.py: FAIL", summary)
+        self.assertIn("Line1", summary)
+        self.assertIn("Line3", summary)
+        self.assertNotIn("Line4", summary)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- display first three lines of failing test output in `summarize_results`
- extend unit test to check for failing output lines

## Testing
- `pytest tests/test_autobench.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685cb641ce248331ac40d2122b6863d3