### PR TITLE
Validate amplitude_estimate shots

### DIFF
--- a/src/quantum_hpo.py
+++ b/src/quantum_hpo.py
@@ -8,7 +8,12 @@ def amplitude_estimate(oracle: Callable[[], bool], shots: int = 32) -> float:
     This function simulates quantum amplitude estimation by
     measuring the oracle ``shots`` times and returning the
     observed frequency of ``True`` outcomes.
+
+    Raises:
+        ValueError: If ``shots`` is not a positive integer.
     """
+    if shots <= 0:
+        raise ValueError("shots must be positive")
     successes = sum(1 for _ in range(shots) if oracle())
     return successes / shots
 

--- a/tests/test_quantum_amplitude.py
+++ b/tests/test_quantum_amplitude.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from quantum_hpo import amplitude_estimate
+
+
+class TestAmplitudeEstimate(unittest.TestCase):
+    def test_raises_on_non_positive_shots(self):
+        with self.assertRaises(ValueError):
+            amplitude_estimate(lambda: True, shots=0)
+        with self.assertRaises(ValueError):
+            amplitude_estimate(lambda: True, shots=-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quantum_hpo.py
+++ b/tests/test_quantum_hpo.py
@@ -1,7 +1,10 @@
+import os
 import random
+import sys
 import unittest
 
-from asi.quantum_hpo import QAEHyperparamSearch
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from quantum_hpo import QAEHyperparamSearch
 
 
 class TestQuantumHPO(unittest.TestCase):


### PR DESCRIPTION
## Summary
- ensure `amplitude_estimate` rejects non-positive shots
- test that invalid shots raise `ValueError`
- adjust quantum HPO tests to import from local src

## Testing
- `pytest tests/test_quantum_amplitude.py tests/test_quantum_hpo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685efaa3341c83318cc292566b9c5f25