### PR TITLE
Fix top-k bound check

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -160,6 +160,7 @@ training range.
 
 - `src/topk_sparse_attention.py` defines a `topk_sparse_attention` function that selects the highest-scoring keys per query.
 - This provides a lightweight inference-time approximation to full attention for the **C-5** task.
+- `k_top` must not exceed `seq_k`; a `ValueError` is raised otherwise.
 
 ## C-6 RWKV Infinite-Context Loop
 

--- a/src/topk_sparse_attention.py
+++ b/src/topk_sparse_attention.py
@@ -15,6 +15,10 @@ def topk_sparse_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, k_t
         Tensor of shape ``(batch, seq_q, dim)`` with attended outputs.
     """
     dim = q.size(-1)
+    if k_top > k.size(1):
+        raise ValueError(
+            f"k_top {k_top} exceeds sequence length {k.size(1)}"
+        )
     scores = torch.matmul(q, k.transpose(-1, -2)) / dim ** 0.5
     topk_scores, indices = torch.topk(scores, k_top, dim=-1)
 

--- a/tests/test_topk_sparse_attention.py
+++ b/tests/test_topk_sparse_attention.py
@@ -17,5 +17,12 @@ class TestTopkSparseAttention(unittest.TestCase):
         out_full = topk_sparse_attention(q, k, v, k_top=k.size(1))
         self.assertTrue(torch.allclose(out_full, full_out, atol=1e-5, rtol=1e-5))
 
+    def test_invalid_k_top(self):
+        q = torch.randn(1, 2, 4)
+        k = torch.randn(1, 3, 4)
+        v = torch.randn(1, 3, 4)
+        with self.assertRaises(ValueError):
+            topk_sparse_attention(q, k, v, k_top=4)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- validate `k_top` in `topk_sparse_attention`
- test oversized `k_top`
- document the restriction in Implementation notes

## Testing
- `pip install -e . -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685efa230828833182fd6604b20870cc