### PR TITLE
Add Bayesian quantum HPO option

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -194,8 +194,9 @@ training range.
   quantum amplitude estimation routine.
 - Call `QAEHyperparamSearch.search()` with a candidate parameter set and an
   evaluation function that returns `True` on success. The helper repeatedly
-  estimates the success probability via `amplitude_estimate()` and returns the
-  best performing setting.
+  estimates the success probability via either `amplitude_estimate()` or the
+  Bayesian variant `amplitude_estimate_bayesian()` and returns the best
+  performing setting.
 - See `docs/Plan.md` task **A-4** for context and goals.
 
 ## L-1 Collective Constitutional AI

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,11 @@
 
 from .autobench import run_autobench, BenchResult
 from .meta_rl_refactor import MetaRLRefactorAgent
-from .quantum_hpo import QAEHyperparamSearch, amplitude_estimate
+from .quantum_hpo import (
+    QAEHyperparamSearch,
+    amplitude_estimate,
+    amplitude_estimate_bayesian,
+)
 from .collective_constitution import CollectiveConstitution
 from .deliberative_alignment import DeliberativeAligner
 from .streaming_compression import ReservoirBuffer, StreamingCompressor

--- a/src/quantum_hpo.py
+++ b/src/quantum_hpo.py
@@ -18,6 +18,34 @@ def amplitude_estimate(oracle: Callable[[], bool], shots: int = 32) -> float:
     return successes / shots
 
 
+def amplitude_estimate_bayesian(
+    oracle: Callable[[], bool], shots: int = 32, alpha: float = 0.5, beta: float = 0.5
+) -> float:
+    """Estimate success probability using a Beta prior.
+
+    This follows the maximum-likelihood amplitude estimation approach by
+    updating a Beta distribution with ``alpha`` and ``beta`` hyperparameters.
+
+    Args:
+        oracle: Boolean-returning evaluation function.
+        shots: Number of oracle calls to sample.
+        alpha: Prior successes in the Beta distribution.
+        beta: Prior failures in the Beta distribution.
+
+    Returns:
+        Posterior mean estimate of success probability.
+
+    Raises:
+        ValueError: If ``shots`` or hyperparameters are not positive.
+    """
+    if shots <= 0:
+        raise ValueError("shots must be positive")
+    if alpha <= 0 or beta <= 0:
+        raise ValueError("alpha and beta must be positive")
+    successes = sum(1 for _ in range(shots) if oracle())
+    return (successes + alpha) / (shots + alpha + beta)
+
+
 class QAEHyperparamSearch:
     """Hyper-parameter search using simulated amplitude estimation."""
 
@@ -25,12 +53,16 @@ class QAEHyperparamSearch:
         self.eval_func = eval_func
         self.param_space = list(param_space)
 
-    def search(self, num_samples: int = 10, shots: int = 32) -> Tuple[Any, float]:
+    def search(
+        self, num_samples: int = 10, shots: int = 32, method: str = "standard"
+    ) -> Tuple[Any, float]:
         """Evaluate a subset of parameters and return the best one.
 
         Args:
             num_samples: Number of parameter settings to evaluate.
             shots: Number of oracle calls per setting.
+            method: ``"standard"`` uses ``amplitude_estimate`` while
+                ``"bayesian"`` applies ``amplitude_estimate_bayesian``.
         Returns:
             Tuple of (best_param, estimated_probability).
         """
@@ -38,7 +70,14 @@ class QAEHyperparamSearch:
         best_param = None
         best_prob = -1.0
         for param in candidates:
-            prob = amplitude_estimate(lambda: self.eval_func(param), shots)
+            if method == "bayesian":
+                prob = amplitude_estimate_bayesian(
+                    lambda: self.eval_func(param), shots
+                )
+            elif method == "standard":
+                prob = amplitude_estimate(lambda: self.eval_func(param), shots)
+            else:
+                raise ValueError(f"Unknown method: {method}")
             if prob > best_prob:
                 best_prob = prob
                 best_param = param

--- a/tests/test_quantum_amplitude.py
+++ b/tests/test_quantum_amplitude.py
@@ -4,7 +4,7 @@ import unittest
 import random
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
-from quantum_hpo import amplitude_estimate
+from quantum_hpo import amplitude_estimate, amplitude_estimate_bayesian
 
 
 class TestAmplitudeEstimate(unittest.TestCase):
@@ -19,6 +19,13 @@ class TestAmplitudeEstimate(unittest.TestCase):
         oracle = lambda: random.random() < 0.5
         prob = amplitude_estimate(oracle, shots=1000)
         self.assertAlmostEqual(prob, 0.5, delta=0.05)
+
+    def test_bayesian_matches_frequency(self):
+        random.seed(1)
+        oracle = lambda: random.random() < 0.3
+        est_std = amplitude_estimate(oracle, shots=200)
+        est_bayes = amplitude_estimate_bayesian(oracle, shots=200)
+        self.assertAlmostEqual(est_bayes, est_std, delta=0.05)
 
 
 if __name__ == "__main__":

--- a/tests/test_quantum_hpo.py
+++ b/tests/test_quantum_hpo.py
@@ -20,6 +20,18 @@ class TestQuantumHPO(unittest.TestCase):
         self.assertEqual(best_param, 2)
         self.assertGreater(est, 0.7)
 
+    def test_search_bayesian_method(self):
+        probs = {0: 0.2, 1: 0.4, 2: 0.8}
+
+        def eval_func(p):
+            return random.random() < probs[p]
+
+        random.seed(2)
+        search = QAEHyperparamSearch(eval_func, probs.keys())
+        best_param, est = search.search(num_samples=3, shots=40, method="bayesian")
+        self.assertEqual(best_param, 2)
+        self.assertGreater(est, 0.6)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `quantum_hpo` with `amplitude_estimate_bayesian` and optional Bayesian search
- export new helper from the `asi` package
- document the updated API in Implementation docs
- test Bayesian amplitude estimation and search

## Testing
- `pytest tests/test_quantum_amplitude.py tests/test_quantum_hpo.py -q`
- ❌ `pytest -q` *(fails: missing heavy dependencies like torch)*

------
https://chatgpt.com/codex/tasks/task_e_685f1cd90cec8331960bee6df993ac81