### PR TITLE
Document scaling breakpoint helper

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -101,6 +101,18 @@ The helper searches over candidate breakpoints and performs linear regression in
 log space on either side. The resulting model can forecast loss beyond the
 training range.
 
+`src/scaling_breakpoint.py` offers a compact variant `fit_breakpoint()` which
+returns a dataclass `BreakpointModel` with slopes and intercepts on either side
+of the break. Use it when you just need predictions without storing the full
+fitting helper:
+
+```python
+from src.scaling_breakpoint import fit_breakpoint
+
+model = fit_breakpoint(params, loss)
+print(model.breakpoint, model.predict(params))
+```
+
 ## C-1 RetNet Retention Kernel
 
 - `src/retnet_retention.py` implements a minimal retention module.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -87,6 +87,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 - `scripts/benchmark_moe.py` and `scripts/moe_vs_dense.py` estimate FLOPs with and without routing; both now accept `--router switch`.
 - `src/scaling_law.py` implements a `BreakpointScalingLaw` model for the **S-3**
   scaling-law breakpoint task.
+- `src/scaling_breakpoint.py` provides a light-weight `fit_breakpoint()` helper
+  that returns a dataclass `BreakpointModel` with piecewise slopes.
 - `src/retnet_retention.py` implements a RetNet-style retention kernel for **C-1**.
 - `src/mamba_block.py` provides a simplified Mamba state-space block for **C-2**.
 - `src/hyena_filter.py` implements the implicit-FFT filter for **C-3**.


### PR DESCRIPTION
## Summary
- describe `fit_breakpoint` helper for S-3 scaling law
- note new helper in the Plan overview

## Testing
- `pytest -k scaling_breakpoint -q` *(fails: OSError: libtorch_global_deps.so not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f236746e083319e31468932831eb3