### PR TITLE
Improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ This repository experiments with algorithms needed for self-improving AI. The bi
 ## Setup
 
 1. Use Python 3.10 or newer with PyTorch installed.
-2. Optional: `pip install flash-attn` to enable the FlashAttention-3 wrapper in `src/flash_attention3.py`.
-3. Run `pip install -e .` to enable imports from the `asi` package.
+2. Install dependencies with `pip install -r requirements.txt`.
+3. Optional: `pip install flash-attn` to enable the FlashAttention-3 wrapper in `src/flash_attention3.py`.
+4. Run `pip install -e .` to enable imports from the `asi` package.
 
 Run the scripts directly with `python` to see parameter and FLOP estimates.
 


### PR DESCRIPTION
## Summary
- expand README setup steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685f31d151448331a1c51a9e8a1d2161