### PR TITLE
Add link-slot memory attention

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -100,6 +100,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
   hierarchical context. With a database path it hooks into FAISS so far-past
   tokens reload from disk automatically. Search results remain on the
   same device as the query.
+- `src/link_slot_attention.py` implements retrieval-augmented attention that
+  fetches top-k vectors from the hierarchical memory for each token.
 - `src/megabyte_patching.py` adds a hierarchical byte patcher for **C-4**.
 - `src/topk_sparse_attention.py` implements a top-k inference kernel for **C-5**.
 - `src/paper_to_code.py` transpiles LaTeX pseudo-code to Python for **A-1**.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16,4 +16,5 @@ from .iter_align import IterativeAligner
 from .critic_rlhf import CriticScorer, CriticRLHFTrainer
 from .chunkwise_retrainer import ChunkWiseRetrainer
 from .scaling_law import BreakpointScalingLaw
+from .link_slot_attention import LinkSlotAttention
 

--- a/src/link_slot_attention.py
+++ b/src/link_slot_attention.py
@@ -1,0 +1,33 @@
+import torch
+from torch import nn
+
+from .hierarchical_memory import HierarchicalMemory
+from .topk_sparse_attention import topk_sparse_attention
+
+
+class LinkSlotAttention(nn.Module):
+    """Retrieve top-k neighbors from ``HierarchicalMemory`` and attend to them."""
+
+    def __init__(self, memory: HierarchicalMemory, dim: int, k_top: int = 4) -> None:
+        super().__init__()
+        self.memory = memory
+        self.dim = dim
+        self.k_top = k_top
+        self.query_proj = nn.Linear(dim, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Augment sequence ``x`` with retrieval attention."""
+        batch, seq, _ = x.shape
+        outputs = []
+        for t in range(seq):
+            q = self.query_proj(x[:, t])
+            retrieved, _ = self.memory.search(q.detach(), k=self.k_top)
+            if retrieved.numel() == 0:
+                out = x[:, t]
+            else:
+                mem = retrieved.unsqueeze(0).expand(batch, -1, -1)
+                k_top = min(self.k_top, mem.size(1))
+                out = topk_sparse_attention(q.unsqueeze(1), mem, mem, k_top).squeeze(1)
+            self.memory.add(q.detach())
+            outputs.append(out)
+        return torch.stack(outputs, dim=1)

--- a/tests/test_link_slot_attention.py
+++ b/tests/test_link_slot_attention.py
@@ -1,0 +1,27 @@
+import unittest
+import torch
+
+from asi.hierarchical_memory import HierarchicalMemory
+from asi.link_slot_attention import LinkSlotAttention
+
+
+class TestLinkSlotAttention(unittest.TestCase):
+    def test_forward_shape(self):
+        torch.manual_seed(0)
+        memory = HierarchicalMemory(dim=4, compressed_dim=2, capacity=5)
+        module = LinkSlotAttention(memory, dim=4, k_top=2)
+        x = torch.randn(1, 3, 4)
+        out = module(x)
+        self.assertEqual(out.shape, x.shape)
+
+    def test_memory_growth(self):
+        torch.manual_seed(0)
+        memory = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+        module = LinkSlotAttention(memory, dim=4, k_top=1)
+        x = torch.randn(1, 2, 4)
+        module(x)
+        self.assertGreaterEqual(len(memory.store), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `LinkSlotAttention` for retrieval-augmented attention
- expose new module in `asi.__init__`
- document new capability in `docs/Plan.md`
- test link-slot attention functionality

## Testing
- `pip install numpy torch faiss-cpu`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4aabec64833199d039fca2428d9c