### PR TITLE
Add async FAISS vector store

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -153,6 +153,10 @@ print(model.breakpoint, model.predict(params))
   to a compressed `.npz` file.
 - This serves as a minimal prototype for the *hierarchical retrieval* memory
   described in the Plan.
+- `src/async_vector_store.py` adds `AsyncFaissVectorStore` which wraps the
+  disk-backed FAISS index with a thread pool. `add_async()` and `search_async()`
+  submit operations to background workers, while `aadd()` and `asearch()`
+  provide `asyncio` interfaces.
 - `src/hierarchical_memory.py` combines `StreamingCompressor` with either the
   in-memory `VectorStore` or a new `FaissVectorStore`. Passing a path hooks the
   memory to a persistent FAISS index so distant tokens are written to disk

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12,6 +12,7 @@ from .deliberative_alignment import DeliberativeAligner
 from .streaming_compression import ReservoirBuffer, StreamingCompressor
 from .hierarchical_memory import HierarchicalMemory
 from .vector_store import VectorStore, FaissVectorStore
+from .async_vector_store import AsyncFaissVectorStore
 from .iter_align import IterativeAligner
 from .critic_rlhf import CriticScorer, CriticRLHFTrainer
 from .chunkwise_retrainer import ChunkWiseRetrainer

--- a/src/async_vector_store.py
+++ b/src/async_vector_store.py
@@ -1,0 +1,44 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor, Future
+from pathlib import Path
+from typing import Iterable, Any, Tuple
+
+import numpy as np
+
+from .vector_store import FaissVectorStore
+
+
+class AsyncFaissVectorStore(FaissVectorStore):
+    """FAISS vector store with async add/search using threads."""
+
+    def __init__(self, dim: int, path: str | Path | None = None, workers: int = 2) -> None:
+        super().__init__(dim=dim, path=path)
+        self._executor = ThreadPoolExecutor(max_workers=workers)
+
+    def add_async(self, vectors: np.ndarray, metadata: Iterable[Any] | None = None) -> Future:
+        """Schedule ``add`` on a background thread."""
+        return self._executor.submit(super().add, vectors, metadata)
+
+    def search_async(self, query: np.ndarray, k: int = 5) -> Future:
+        """Schedule ``search`` on a background thread."""
+        return self._executor.submit(super().search, query, k)
+
+    async def aadd(self, vectors: np.ndarray, metadata: Iterable[Any] | None = None) -> None:
+        """Awaitable ``add`` wrapper using ``asyncio``."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(self._executor, super().add, vectors, metadata)
+
+    async def asearch(self, query: np.ndarray, k: int = 5) -> Tuple[np.ndarray, list[Any]]:
+        """Awaitable ``search`` wrapper using ``asyncio``."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, super().search, query, k)
+
+    def close(self) -> None:
+        """Shut down the thread pool and persist to disk if needed."""
+        self._executor.shutdown(wait=True)
+
+    def __enter__(self) -> "AsyncFaissVectorStore":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()

--- a/tests/test_async_vector_store.py
+++ b/tests/test_async_vector_store.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+import unittest
+import numpy as np
+
+from asi.async_vector_store import AsyncFaissVectorStore
+
+
+class TestAsyncFaissVectorStore(unittest.TestCase):
+    def test_async_add_and_search(self):
+        store = AsyncFaissVectorStore(dim=2)
+        store.add_async(np.array([[1.0, 0.0], [0.0, 1.0]]), metadata=["a", "b"]).result()
+        future = store.search_async(np.array([0.0, 1.0]), k=1)
+        vecs, meta = future.result()
+        np.testing.assert_allclose(vecs, np.array([[0.0, 1.0]], dtype=np.float32))
+        self.assertEqual(meta, ["b"])
+        store.close()
+
+    def test_async_context_manager(self):
+        with AsyncFaissVectorStore(dim=2) as store:
+            store.add_async(np.array([[1.0, 0.0]])).result()
+            vecs, _ = store.search_async(np.array([1.0, 0.0]), k=1).result()
+            np.testing.assert_allclose(vecs, np.array([[1.0, 0.0]], dtype=np.float32))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `AsyncFaissVectorStore` with thread-based async methods
- expose the new store in the package init
- document asynchronous vector store in Implementation notes
- test async add/search functionality

## Testing
- `pytest tests/test_async_vector_store.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685f51d49d5083318d244c66d687597d