### PR TITLE
Add GitHub PR monitoring utility

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -19,3 +19,4 @@ from .chunkwise_retrainer import ChunkWiseRetrainer
 from .scaling_law import BreakpointScalingLaw
 from .link_slot_attention import LinkSlotAttention
 
+from .pull_request_monitor import list_open_prs, check_mergeable

--- a/src/pull_request_monitor.py
+++ b/src/pull_request_monitor.py
@@ -1,0 +1,46 @@
+import json
+from urllib.request import Request, urlopen
+from typing import List, Dict, Any, Optional
+
+
+def _github_api(path: str, token: str | None = None) -> Any:
+    """Call the GitHub API and return parsed JSON."""
+    url = f"https://api.github.com/{path}"
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = Request(url, headers=headers)
+    with urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def list_open_prs(repo: str, token: str | None = None) -> List[Dict[str, Any]]:
+    """Return a list of open pull requests for ``repo``.
+
+    Each element contains ``number`` and ``title`` keys."""
+    data = _github_api(f"repos/{repo}/pulls?state=open", token)
+    return [{"number": pr["number"], "title": pr["title"]} for pr in data]
+
+
+def check_mergeable(repo: str, pr_number: int, token: str | None = None) -> Optional[bool]:
+    """Return whether the pull request can be merged cleanly."""
+    pr = _github_api(f"repos/{repo}/pulls/{pr_number}", token)
+    return pr.get("mergeable")
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="List open PRs and mergeability")
+    parser.add_argument("repo", help="<owner>/<repo> to query")
+    parser.add_argument("--token", help="GitHub token", default=None)
+    args = parser.parse_args()
+
+    prs = list_open_prs(args.repo, args.token)
+    for pr in prs:
+        mergeable = check_mergeable(args.repo, pr["number"], args.token)
+        print(f"#{pr['number']} {pr['title']} - mergeable: {mergeable}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pull_request_monitor.py
+++ b/tests/test_pull_request_monitor.py
@@ -1,0 +1,40 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from asi.pull_request_monitor import list_open_prs, check_mergeable
+
+
+def fake_urlopen_factory(responses):
+    class FakeResponse:
+        def __init__(self, data):
+            self.data = json.dumps(data).encode()
+        def read(self):
+            return self.data
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+    def fake_urlopen(request):
+        data = responses.pop(0)
+        return FakeResponse(data)
+    return fake_urlopen
+
+
+class TestPullRequestMonitor(unittest.TestCase):
+    def test_list_open_prs(self):
+        responses = [[{"number": 1, "title": "Fix bug"}, {"number": 2, "title": "Add feature"}]]
+        with patch('asi.pull_request_monitor.urlopen', fake_urlopen_factory(responses)):
+            prs = list_open_prs('owner/repo')
+        self.assertEqual(len(prs), 2)
+        self.assertEqual(prs[0]['number'], 1)
+
+    def test_check_mergeable(self):
+        responses = [{"mergeable": True}]
+        with patch('asi.pull_request_monitor.urlopen', fake_urlopen_factory(responses)):
+            result = check_mergeable('owner/repo', 1)
+        self.assertTrue(result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `pull_request_monitor.py` to query GitHub PR status
- expose `list_open_prs` and `check_mergeable` in package
- add unit tests for PR monitor

## Testing
- `pip install numpy torch faiss-cpu`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f5567058c83318a875144cfc7aa3d