### PR TITLE
Add MoE balance penalty

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -8,7 +8,9 @@ This repository includes starter modules for the first two algorithms listed in 
   - `HashRouter` uses hash-based gating to activate at most two experts per token.
   - `SwitchRouter` employs a learned linear gate and selects the top-k experts.
   Both expose `load_balance_std` and `expert_utilization` to inspect token distribution.
-- `src/moe_layer.py` implements a small MoE feed-forward block using these routers.
+- `src/moe_layer.py` implements a small MoE feed-forward block using these routers. It accepts an optional
+  `balance_weight` which multiplies the `balance_loss()` penalty derived from the router's assignments and
+  returns it alongside the layer output.
 
 ## S-2 FlashAttention-3 Kernel
 

--- a/tests/test_moe_layer.py
+++ b/tests/test_moe_layer.py
@@ -11,6 +11,13 @@ class TestMoELayer(unittest.TestCase):
         out = layer(x)
         self.assertEqual(out.shape, x.shape)
 
+    def test_balance_penalty(self):
+        layer = MoELayer(dim=8, hidden=16, num_experts=4, router="switch", balance_weight=0.1)
+        x = torch.randn(2, 5, 8)
+        out, penalty = layer(x)
+        self.assertEqual(out.shape, x.shape)
+        self.assertGreaterEqual(penalty.item(), 0.0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_moe_router.py
+++ b/tests/test_moe_router.py
@@ -15,8 +15,9 @@ class TestHashRouter(unittest.TestCase):
     def test_switch_router(self):
         router = SwitchRouter(dim=64, num_experts=8, k=2)
         x = torch.randn(2, 512, 64)
-        assignments = router(x)
+        assignments, weights = router(x)
         self.assertEqual(assignments.shape, (2, 512, 2))
+        self.assertEqual(weights.shape, (2, 512, 2))
         std = router.load_balance_std(assignments)
         self.assertLess(std, 0.5)  # gating may be imbalanced but should compute
 


### PR DESCRIPTION
## Summary
- extend `SwitchRouter.forward` to return assignments and gate weights
- expose a `balance_loss` helper
- allow `MoELayer` to return a weighted load-balance penalty
- test the new behavior and document the option

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686051d99eec8331878676729be207a5