### PR TITLE
Show full failing output in autobench

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -194,7 +194,7 @@ print(model.breakpoint, model.predict(params))
 ## A-2 AutoBench Harness
 
 - `src/autobench.py` runs each test module in its own subprocess to sandbox imports.
-- `summarize_results()` returns a concise scoreboard and shows the first few lines of failing output.
+- `summarize_results()` returns a concise scoreboard and shows the full output from failing modules.
 - The command line interface `python -m src.autobench` prints this summary for the specified directory.
 
 ## A-3 Meta-RL Refactor Agent

--- a/src/autobench.py
+++ b/src/autobench.py
@@ -40,7 +40,7 @@ def summarize_results(results: Dict[str, BenchResult]) -> str:
         status = "PASS" if res.passed else "FAIL"
         lines.append(f"{name}: {status}")
         if not res.passed and res.output:
-            snippet = "\n".join(res.output.strip().splitlines()[:3])
+            snippet = res.output.strip()
             if snippet:
                 lines.append(snippet)
     return "\n".join(lines)

--- a/tests/test_autobench.py
+++ b/tests/test_autobench.py
@@ -39,9 +39,8 @@ class TestAutoBench(unittest.TestCase):
         self.assertIn("Passed 1/2 modules", summary)
         self.assertIn("a.py: PASS", summary)
         self.assertIn("b.py: FAIL", summary)
-        self.assertIn("Line1", summary)
-        self.assertIn("Line3", summary)
-        self.assertNotIn("Line4", summary)
+        for line in ["Line1", "Line2", "Line3", "Line4"]:
+            self.assertIn(line, summary)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- dump entire stdout/stderr from failing modules in `summarize_results`
- update tests to assert all lines appear
- document that full failure output is shown

## Testing
- `pytest tests/test_autobench.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686051dc47c48331b82cdeead8204ad9