### PR TITLE
Enable async GitHub PR checks

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -117,6 +117,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 - `src/iter_align.py` runs a simple iterative alignment loop for **L-3**.
 - `src/critic_rlhf.py` provides a minimal critic-driven RLHF loop for **L-4**.
   See `docs/Implementation.md` and `docs/load_balance.md` for details.
+- `src/pull_request_monitor.py` now supports asynchronous GitHub queries using
+  `aiohttp` for faster monitoring of open pull requests.
 
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torch
 # disk-backed vector DB
 faiss-cpu
 # optional: flash-attn for FlashAttention-3 support
+aiohttp

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -19,4 +19,9 @@ from .chunkwise_retrainer import ChunkWiseRetrainer
 from .scaling_law import BreakpointScalingLaw
 from .link_slot_attention import LinkSlotAttention
 
-from .pull_request_monitor import list_open_prs, check_mergeable
+from .pull_request_monitor import (
+    list_open_prs,
+    check_mergeable,
+    list_open_prs_async,
+    check_mergeable_async,
+)

--- a/src/pull_request_monitor.py
+++ b/src/pull_request_monitor.py
@@ -2,9 +2,12 @@ import json
 from urllib.request import Request, urlopen
 from typing import List, Dict, Any, Optional
 
+import asyncio
+import aiohttp
+
 
 def _github_api(path: str, token: str | None = None) -> Any:
-    """Call the GitHub API and return parsed JSON."""
+    """Call the GitHub API synchronously and return parsed JSON."""
     url = f"https://api.github.com/{path}"
     headers = {"Accept": "application/vnd.github+json"}
     if token:
@@ -12,6 +15,20 @@ def _github_api(path: str, token: str | None = None) -> Any:
     req = Request(url, headers=headers)
     with urlopen(req) as resp:
         return json.loads(resp.read().decode())
+
+
+async def _github_api_async(path: str, token: str | None = None, session: aiohttp.ClientSession | None = None) -> Any:
+    """Asynchronously call the GitHub API and return parsed JSON."""
+    url = f"https://api.github.com/{path}"
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if session is None:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as resp:
+                return await resp.json()
+    async with session.get(url, headers=headers) as resp:
+        return await resp.json()
 
 
 def list_open_prs(repo: str, token: str | None = None) -> List[Dict[str, Any]]:
@@ -22,9 +39,21 @@ def list_open_prs(repo: str, token: str | None = None) -> List[Dict[str, Any]]:
     return [{"number": pr["number"], "title": pr["title"]} for pr in data]
 
 
+async def list_open_prs_async(repo: str, token: str | None = None) -> List[Dict[str, Any]]:
+    """Asynchronously return a list of open pull requests for ``repo``."""
+    data = await _github_api_async(f"repos/{repo}/pulls?state=open", token)
+    return [{"number": pr["number"], "title": pr["title"]} for pr in data]
+
+
 def check_mergeable(repo: str, pr_number: int, token: str | None = None) -> Optional[bool]:
     """Return whether the pull request can be merged cleanly."""
     pr = _github_api(f"repos/{repo}/pulls/{pr_number}", token)
+    return pr.get("mergeable")
+
+
+async def check_mergeable_async(repo: str, pr_number: int, token: str | None = None) -> Optional[bool]:
+    """Asynchronously return whether the pull request can be merged cleanly."""
+    pr = await _github_api_async(f"repos/{repo}/pulls/{pr_number}", token)
     return pr.get("mergeable")
 
 
@@ -34,12 +63,21 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="List open PRs and mergeability")
     parser.add_argument("repo", help="<owner>/<repo> to query")
     parser.add_argument("--token", help="GitHub token", default=None)
+    parser.add_argument("--use-asyncio", action="store_true", help="Use asyncio for concurrent calls")
     args = parser.parse_args()
 
-    prs = list_open_prs(args.repo, args.token)
-    for pr in prs:
-        mergeable = check_mergeable(args.repo, pr["number"], args.token)
-        print(f"#{pr['number']} {pr['title']} - mergeable: {mergeable}")
+    if args.use_asyncio:
+        async def run() -> None:
+            prs = await list_open_prs_async(args.repo, args.token)
+            results = await asyncio.gather(*(check_mergeable_async(args.repo, pr["number"], args.token) for pr in prs))
+            for pr, mergeable in zip(prs, results):
+                print(f"#{pr['number']} {pr['title']} - mergeable: {mergeable}")
+        asyncio.run(run())
+    else:
+        prs = list_open_prs(args.repo, args.token)
+        for pr in prs:
+            mergeable = check_mergeable(args.repo, pr["number"], args.token)
+            print(f"#{pr['number']} {pr['title']} - mergeable: {mergeable}")
 
 
 if __name__ == "__main__":

--- a/tests/test_pull_request_monitor.py
+++ b/tests/test_pull_request_monitor.py
@@ -2,7 +2,21 @@ import json
 import unittest
 from unittest.mock import patch
 
-from asi.pull_request_monitor import list_open_prs, check_mergeable
+import asyncio
+import importlib.util
+import os
+
+spec = importlib.util.spec_from_file_location(
+    "pull_request_monitor",
+    os.path.join(os.path.dirname(__file__), "..", "src", "pull_request_monitor.py"),
+)
+prmon = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(prmon)
+
+list_open_prs = prmon.list_open_prs
+check_mergeable = prmon.check_mergeable
+list_open_prs_async = prmon.list_open_prs_async
+check_mergeable_async = prmon.check_mergeable_async
 
 
 def fake_urlopen_factory(responses):
@@ -21,19 +35,38 @@ def fake_urlopen_factory(responses):
     return fake_urlopen
 
 
+def fake_async_api_factory(responses):
+    async def fake_api(path, token=None):
+        return responses.pop(0)
+    return fake_api
+
+
 class TestPullRequestMonitor(unittest.TestCase):
     def test_list_open_prs(self):
         responses = [[{"number": 1, "title": "Fix bug"}, {"number": 2, "title": "Add feature"}]]
-        with patch('asi.pull_request_monitor.urlopen', fake_urlopen_factory(responses)):
+        with patch.object(prmon, 'urlopen', fake_urlopen_factory(responses)):
             prs = list_open_prs('owner/repo')
         self.assertEqual(len(prs), 2)
         self.assertEqual(prs[0]['number'], 1)
 
     def test_check_mergeable(self):
         responses = [{"mergeable": True}]
-        with patch('asi.pull_request_monitor.urlopen', fake_urlopen_factory(responses)):
+        with patch.object(prmon, 'urlopen', fake_urlopen_factory(responses)):
             result = check_mergeable('owner/repo', 1)
         self.assertTrue(result)
+
+    def test_list_open_prs_async(self):
+        responses = [[{"number": 1, "title": "Bug"}, {"number": 2, "title": "Feature"}]]
+        with patch.object(prmon, '_github_api_async', fake_async_api_factory(responses)):
+            prs = asyncio.run(list_open_prs_async('owner/repo'))
+        self.assertEqual(len(prs), 2)
+        self.assertEqual(prs[1]['title'], 'Feature')
+
+    def test_check_mergeable_async(self):
+        responses = [{"mergeable": False}]
+        with patch.object(prmon, '_github_api_async', fake_async_api_factory(responses)):
+            result = asyncio.run(check_mergeable_async('owner/repo', 1))
+        self.assertFalse(result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add asynchronous GitHub helpers with `aiohttp`
- expose async helpers from `asi` package
- update Plan docs for new capability
- extend pull request monitor tests with async cases
- require `aiohttp` in requirements

## Testing
- `PYTHONPATH=src python -m unittest tests.test_pull_request_monitor -v`
- `PYTHONPATH=src pytest tests/test_pull_request_monitor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6860698c31ac833194ba57cb87510e40