### PR TITLE
Add parallel search option

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -219,11 +219,12 @@ print(model.breakpoint, model.predict(params))
   estimates the success probability via either `amplitude_estimate()` or the
   Bayesian variant `amplitude_estimate_bayesian()` and returns the best
   performing setting. Passing `early_stop` halts the search once an estimate
-  meets the given probability threshold:
+  meets the given probability threshold. Set `max_workers` to evaluate
+  candidates concurrently:
 
   ```python
   search = QAEHyperparamSearch(eval_func, params)
-  best, prob = search.search(num_samples=5, early_stop=0.8)
+  best, prob = search.search(num_samples=5, early_stop=0.8, max_workers=4)
   ```
 - See `docs/Plan.md` task **A-4** for context and goals.
 

--- a/src/quantum_hpo.py
+++ b/src/quantum_hpo.py
@@ -1,4 +1,5 @@
 import random
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Iterable, Tuple, Any
 
 
@@ -59,6 +60,7 @@ class QAEHyperparamSearch:
         shots: int = 32,
         method: str = "standard",
         early_stop: float | None = None,
+        max_workers: int | None = None,
     ) -> Tuple[Any, float]:
         """Evaluate parameters and return the best one.
 
@@ -69,13 +71,16 @@ class QAEHyperparamSearch:
                 ``"bayesian"`` applies ``amplitude_estimate_bayesian``.
             early_stop: Optional probability threshold for early stopping.
                 Evaluation halts when an estimate meets or exceeds this value.
+            max_workers: If set, evaluate parameters in parallel using a
+                ``ThreadPoolExecutor`` with the given worker count.
 
         Returns:
             Tuple of ``(best_param, estimated_probability)``.
 
         Raises:
             ValueError: If ``num_samples`` or ``shots`` are non-positive, or
-                ``early_stop`` is not between 0 and 1.
+                ``early_stop`` is not between 0 and 1, or ``max_workers`` is
+                not ``None`` and less than 1.
         """
         if num_samples <= 0:
             raise ValueError("num_samples must be positive")
@@ -83,11 +88,14 @@ class QAEHyperparamSearch:
             raise ValueError("shots must be positive")
         if early_stop is not None and not (0.0 <= early_stop <= 1.0):
             raise ValueError("early_stop must be between 0 and 1")
+        if max_workers is not None and max_workers < 1:
+            raise ValueError("max_workers must be positive")
 
         candidates = random.sample(self.param_space, min(num_samples, len(self.param_space)))
         best_param = None
         best_prob = -1.0
-        for param in candidates:
+
+        def evaluate(param: Any) -> Tuple[Any, float]:
             if method == "bayesian":
                 prob = amplitude_estimate_bayesian(
                     lambda: self.eval_func(param), shots
@@ -96,9 +104,26 @@ class QAEHyperparamSearch:
                 prob = amplitude_estimate(lambda: self.eval_func(param), shots)
             else:
                 raise ValueError(f"Unknown method: {method}")
-            if prob > best_prob:
-                best_prob = prob
-                best_param = param
-            if early_stop is not None and prob >= early_stop:
-                break
+            return param, prob
+
+        if max_workers and max_workers > 1:
+            with ThreadPoolExecutor(max_workers=max_workers) as ex:
+                futures = {ex.submit(evaluate, p): p for p in candidates}
+                for fut in as_completed(futures):
+                    param, prob = fut.result()
+                    if prob > best_prob:
+                        best_prob = prob
+                        best_param = param
+                    if early_stop is not None and prob >= early_stop:
+                        for f in futures:
+                            f.cancel()
+                        break
+        else:
+            for param in candidates:
+                param, prob = evaluate(param)
+                if prob > best_prob:
+                    best_prob = prob
+                    best_param = param
+                if early_stop is not None and prob >= early_stop:
+                    break
         return best_param, best_prob

--- a/tests/test_quantum_hpo.py
+++ b/tests/test_quantum_hpo.py
@@ -20,6 +20,18 @@ class TestQuantumHPO(unittest.TestCase):
         self.assertEqual(best_param, 2)
         self.assertGreater(est, 0.7)
 
+    def test_search_parallel_execution(self):
+        probs = {0: 0.3, 1: 0.6, 2: 0.9}
+
+        def eval_func(p):
+            return random.random() < probs[p]
+
+        random.seed(1)
+        search = QAEHyperparamSearch(eval_func, probs.keys())
+        best_param, est = search.search(num_samples=3, shots=30, max_workers=2)
+        self.assertEqual(best_param, 2)
+        self.assertGreaterEqual(est, 0.7)
+
     def test_search_bayesian_method(self):
         probs = {0: 0.2, 1: 0.4, 2: 0.8}
 


### PR DESCRIPTION
## Summary
- allow concurrent candidate evaluation in `QAEHyperparamSearch.search`
- document the new option in `Implementation.md`
- test parallel execution of quantum HPO

## Testing
- `pytest tests/test_quantum_hpo.py::TestQuantumHPO::test_search_parallel_execution -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6860698e8ce883319fcb62591a3e304a