### PR TITLE
Expand LaTeX transpiler features

### DIFF
--- a/tests/test_paper_to_code.py
+++ b/tests/test_paper_to_code.py
@@ -1,6 +1,12 @@
 import unittest
+import importlib.machinery
+import importlib.util
 
-from asi.paper_to_code import transpile
+loader = importlib.machinery.SourceFileLoader('paper_to_code', 'src/paper_to_code.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+paper_to_code = importlib.util.module_from_spec(spec)
+loader.exec_module(paper_to_code)
+transpile = paper_to_code.transpile
 
 
 class TestPaperToCode(unittest.TestCase):
@@ -19,6 +25,40 @@ class TestPaperToCode(unittest.TestCase):
             "for i in 1..N:",
             "    x = x + i",
             "return x",
+        ])
+        self.assertEqual(transpile(latex).strip(), expected)
+
+    def test_function_and_math(self):
+        latex = r"""
+        \begin{algorithm}
+        \Function{Add}{a, b}
+        \State result = \(a + b\)
+        \Return{result}
+        \EndFunction
+        \end{algorithm}
+        """
+        expected = "\n".join([
+            "def Add(a, b):",
+            "    result = a + b",
+            "    return result",
+        ])
+        self.assertEqual(transpile(latex).strip(), expected)
+
+    def test_repeat_until(self):
+        latex = r"""
+        \begin{algorithm}
+        \State x = 0
+        \Repeat
+        \State x = x + 1
+        \Until{x > 3}
+        \end{algorithm}
+        """
+        expected = "\n".join([
+            "x = 0",
+            "while True:",
+            "    x = x + 1",
+            "    if x > 3:",
+            "        break",
         ])
         self.assertEqual(transpile(latex).strip(), expected)
 


### PR DESCRIPTION
## Summary
- support `\Function`, `\Procedure`, `\Repeat`/`\Until` and basic math wrappers
- update unit tests for `paper_to_code`

## Testing
- `pytest -q tests/test_paper_to_code.py`

------
https://chatgpt.com/codex/tasks/task_e_6860697b32a883319f14e2464e8584f7