### PR TITLE
Add dropout and gating improvements

### DIFF
--- a/src/mamba_block.py
+++ b/src/mamba_block.py
@@ -5,7 +5,7 @@ from torch import nn
 class MambaBlock(nn.Module):
     """Simplified state-space block for Plan.md C-2."""
 
-    def __init__(self, dim: int) -> None:
+    def __init__(self, dim: int, dropout: float = 0.0, residual: bool = False) -> None:
         super().__init__()
         self.dim = dim
         self.A = nn.Parameter(torch.randn(dim, dim) * 0.1)
@@ -13,6 +13,8 @@ class MambaBlock(nn.Module):
         self.in_proj = nn.Linear(dim, dim)
         self.out_proj = nn.Linear(dim, dim)
         self.gate = nn.Linear(dim, dim)
+        self.drop = nn.Dropout(dropout)
+        self.use_residual = residual
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Process a sequence with recurrent state updates.
@@ -28,7 +30,11 @@ class MambaBlock(nn.Module):
         for t in range(seq):
             inp = self.in_proj(x[:, t])
             gate = torch.sigmoid(self.gate(inp))
-            state = torch.tanh(state @ self.A.t() + inp @ self.B.t())
-            state = gate * state + (1 - gate) * inp
-            outputs.append(self.out_proj(state))
+            blended = gate * state + (1 - gate) * inp
+            state = torch.tanh(blended @ self.A.t() + inp @ self.B.t())
+            state = self.drop(state)
+            out = self.out_proj(state)
+            if self.use_residual:
+                out = out + x[:, t]
+            outputs.append(out)
         return torch.stack(outputs, dim=1)

--- a/tests/test_mamba_block.py
+++ b/tests/test_mamba_block.py
@@ -11,6 +11,32 @@ class TestMambaBlock(unittest.TestCase):
         out = block(x)
         self.assertEqual(out.shape, x.shape)
 
+    def test_dropout(self):
+        torch.manual_seed(0)
+        block = MambaBlock(dim=4, dropout=0.5)
+        x = torch.randn(2, 3, 4)
+        block.eval()
+        out1 = block(x)
+        out2 = block(x)
+        self.assertTrue(torch.allclose(out1, out2))
+        block.train()
+        out3 = block(x)
+        out4 = block(x)
+        self.assertFalse(torch.allclose(out3, out4))
+
+    def test_gating_extremes(self):
+        block = MambaBlock(dim=2)
+        x = torch.randn(1, 2, 2)
+        with torch.no_grad():
+            block.gate.weight.fill_(-100)
+            block.gate.bias.fill_(-100)
+        out_input = block(x)
+        with torch.no_grad():
+            block.gate.weight.fill_(100)
+            block.gate.bias.fill_(100)
+        out_state = block(x)
+        self.assertFalse(torch.allclose(out_input, out_state))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add dropout and optional residual connections to `MambaBlock`
- implement gating mechanism blending prior state with new input
- expand unit tests for dropout and gating behavior

## Testing
- `python -m pytest tests/test_mamba_block.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68606979ae4883319a772908f2c4c366