### PR TITLE
Extend scaling-law helper to multiple breakpoints

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -103,6 +103,16 @@ The helper searches over candidate breakpoints and performs linear regression in
 log space on either side. The resulting model can forecast loss beyond the
 training range.
 
+Pass a list to ``break_compute`` to fit multiple breakpoints. Each segment's
+``(slope, intercept)`` pair is stored in ``model.params``:
+
+```python
+model = BreakpointScalingLaw([5e7, 5e8])
+model.fit(params, loss)
+print('breaks:', model.break_compute)
+print('segments:', model.params)
+```
+
 `src/scaling_breakpoint.py` offers a compact variant `fit_breakpoint()` which
 returns a dataclass `BreakpointModel` with slopes and intercepts on either side
 of the break. Use it when you just need predictions without storing the full

--- a/src/scaling_law.py
+++ b/src/scaling_law.py
@@ -1,11 +1,14 @@
 import numpy as np
+from itertools import combinations
+from collections.abc import Iterable
 
 class BreakpointScalingLaw:
-    """Simple log-log breakpoint model for loss vs. compute."""
+    """Piecewise log-log scaling model supporting multiple breakpoints."""
 
-    def __init__(self, break_compute=None):
+    def __init__(self, break_compute: float | Iterable[float] | None = None):
         self.break_compute = break_compute
-        self.params = None  # [(slope1, intercept1), (slope2, intercept2)]
+        # list of (slope, intercept) per segment
+        self.params: list[tuple[float, float]] | None = None
 
     def _fit_segment(self, x, y):
         A = np.vstack([x, np.ones_like(x)]).T
@@ -17,25 +20,71 @@ class BreakpointScalingLaw:
         loss = np.asarray(loss, dtype=float)
         log_c = np.log10(compute)
         log_l = np.log10(loss)
-        if self.break_compute is None:
-            idx = len(compute) // 2
+
+        if isinstance(self.break_compute, Iterable) and not isinstance(
+            self.break_compute, (float, int)
+        ):
+            num_breaks = len(list(self.break_compute))
+        elif self.break_compute is None:
+            num_breaks = 1
         else:
-            idx = np.searchsorted(compute, self.break_compute)
-            idx = max(1, min(idx, len(compute) - 1))
-        self.break_compute = compute[idx]
-        slope1, intercept1 = self._fit_segment(log_c[:idx], log_l[:idx])
-        slope2, intercept2 = self._fit_segment(log_c[idx:], log_l[idx:])
-        self.params = [(slope1, intercept1), (slope2, intercept2)]
+            num_breaks = 1
+
+        best_err = float("inf")
+        best_breaks = None
+        best_params = None
+        n = len(compute)
+        indices = range(1, n)
+        for breaks in combinations(indices, num_breaks):
+            seg_params = []
+            err = 0.0
+            start = 0
+            valid = True
+            for b in list(breaks) + [n]:
+                if b - start < 2:
+                    valid = False
+                    break
+                slope, intercept = self._fit_segment(log_c[start:b], log_l[start:b])
+                seg_params.append((slope, intercept))
+                pred = slope * log_c[start:b] + intercept
+                err += ((log_l[start:b] - pred) ** 2).mean()
+                start = b
+            if not valid:
+                continue
+            if err < best_err:
+                best_err = err
+                best_breaks = [compute[i] for i in breaks]
+                best_params = seg_params
+
+        if best_breaks is None:
+            raise ValueError("Insufficient data to fit model")
+
+        self.break_compute = best_breaks[0] if num_breaks == 1 else best_breaks
+        self.params = best_params
 
     def predict(self, compute):
         if self.params is None:
             raise RuntimeError("Model is not fitted")
         compute = np.asarray(compute, dtype=float)
         log_c = np.log10(compute)
-        slope1, intercept1 = self.params[0]
-        slope2, intercept2 = self.params[1]
-        break_mask = compute < self.break_compute
+
+        breaks = self.break_compute
+        if isinstance(breaks, Iterable) and not isinstance(breaks, (float, int)):
+            bps = list(breaks)
+        else:
+            bps = [breaks]
+
         pred = np.empty_like(log_c)
-        pred[break_mask] = slope1 * log_c[break_mask] + intercept1
-        pred[~break_mask] = slope2 * log_c[~break_mask] + intercept2
+        start_mask = compute < bps[0] if bps else np.full_like(compute, True, dtype=bool)
+        slope, intercept = self.params[0]
+        pred[start_mask] = slope * log_c[start_mask] + intercept
+        prev_bp = bps[0] if bps else None
+        for i in range(1, len(self.params)):
+            slope, intercept = self.params[i]
+            if i < len(bps):
+                mask = (compute >= prev_bp) & (compute < bps[i])
+                prev_bp = bps[i]
+            else:
+                mask = compute >= prev_bp
+            pred[mask] = slope * log_c[mask] + intercept
         return 10 ** pred

--- a/tests/test_scaling_law.py
+++ b/tests/test_scaling_law.py
@@ -37,6 +37,31 @@ class TestBreakpointScalingLaw(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             model.predict([1, 10])
 
+    def test_two_breakpoints(self):
+        compute = np.logspace(0, 3, 30)
+        b1, b2 = 10, 20
+        breaks = [compute[b1], compute[b2]]
+        slopes = [-0.5, -0.3, -0.1]
+        intercepts = [2.0, 1.5, 1.0]
+        log_c = np.log10(compute)
+        log_loss = np.empty_like(log_c)
+        log_loss[:b1] = slopes[0] * log_c[:b1] + intercepts[0]
+        log_loss[b1:b2] = slopes[1] * log_c[b1:b2] + intercepts[1]
+        log_loss[b2:] = slopes[2] * log_c[b2:] + intercepts[2]
+        loss = 10 ** log_loss
+
+        model = BreakpointScalingLaw(break_compute=breaks)
+        model.fit(compute, loss)
+
+        self.assertEqual(len(model.params), 3)
+        np.testing.assert_allclose(model.break_compute, breaks, rtol=1e-6, atol=1e-6)
+        for (s, i), s_exp, i_exp in zip(model.params, slopes, intercepts):
+            np.testing.assert_allclose(s, s_exp, rtol=1e-6, atol=1e-6)
+            np.testing.assert_allclose(i, i_exp, rtol=1e-6, atol=1e-6)
+
+        preds = model.predict(compute)
+        np.testing.assert_allclose(preds, loss, rtol=1e-5, atol=1e-8)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support multiple breakpoints in `BreakpointScalingLaw`
- test fitting with two breakpoints
- document new usage in Implementation notes

## Testing
- `pip install -r requirements.txt` *(fails: libtorch load error)*
- `PYTHONPATH=$PWD pytest tests/test_scaling_law.py::TestBreakpointScalingLaw::test_two_breakpoints -q` *(fails: cannot load libtorch)*


------
https://chatgpt.com/codex/tasks/task_e_68607c43bee48331b8d94e5734f5a9b1