### PR TITLE
Add CLI for Meta RL logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ This repository experiments with algorithms needed for self-improving AI. The bi
 - `scripts/moe_vs_dense.py` benchmarks dense versus Mixture-of-Experts feed-forward layers.
 - `python -m src.paper_to_code` transpiles LaTeX pseudo-code to Python.
 - `python -m src.autobench` runs each test file in isolation and reports a summary.
+- `meta-rl-refactor` parses action/reward logs and suggests the next refactoring step.
+
+Example:
+
+```bash
+meta-rl-refactor sample_log.csv
+```
 
 ## Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ requires-python = ">=3.10"
 package-dir = {"asi" = "src"}
 packages = ["asi"]
 
+[project.scripts]
+meta-rl-refactor = "asi.meta_rl_refactor:main"
+


### PR DESCRIPTION
## Summary
- add `main()` in `meta_rl_refactor.py` to parse action/reward logs
- expose CLI via `meta-rl-refactor` entry point
- test CLI invocation on a sample log
- document CLI usage in README

## Testing
- `pytest tests/test_meta_rl_refactor.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68607c47e2fc8331b70f2c5fda033c10