### PR TITLE
Add async save/load API

### DIFF
--- a/scripts/train_infinite_context.py
+++ b/scripts/train_infinite_context.py
@@ -11,11 +11,11 @@ from asi.chunkwise_retrainer import ChunkWiseRetrainer
 class InfiniteContextModel(nn.Module):
     """Toy language model combining recurrence and retrieval."""
 
-    def __init__(self, vocab_size: int = 100, dim: int = 16) -> None:
+    def __init__(self, vocab_size: int = 100, dim: int = 16, use_async: bool = False) -> None:
         super().__init__()
         self.embed = nn.Embedding(vocab_size, dim)
         self.loop = RWKVLoop(dim)
-        self.memory = HierarchicalMemory(dim=dim, compressed_dim=dim // 2, capacity=50)
+        self.memory = HierarchicalMemory(dim=dim, compressed_dim=dim // 2, capacity=50, use_async=use_async)
         self.link = LinkSlotAttention(self.memory, dim=dim, k_top=2)
         self.out = nn.Linear(dim, vocab_size)
 
@@ -29,10 +29,11 @@ class InfiniteContextModel(nn.Module):
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train toy infinite-context model")
     parser.add_argument("--epochs", type=int, default=1, help="Epochs per chunk")
+    parser.add_argument("--async-memory", action="store_true", help="Use async hierarchical memory")
     args = parser.parse_args()
 
     torch.manual_seed(0)
-    model = InfiniteContextModel()
+    model = InfiniteContextModel(use_async=args.async_memory)
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
     trainer = ChunkWiseRetrainer(model, optimizer, chunk_size=8)
 

--- a/src/async_vector_store.py
+++ b/src/async_vector_store.py
@@ -23,6 +23,17 @@ class AsyncFaissVectorStore(FaissVectorStore):
         """Schedule ``search`` on a background thread."""
         return self._executor.submit(super().search, query, k)
 
+    async def save_async(self, path: str | Path) -> None:
+        """Awaitable ``save`` wrapper using ``asyncio``."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(self._executor, super().save, path)
+
+    @classmethod
+    async def load_async(cls, path: str | Path) -> "AsyncFaissVectorStore":
+        """Awaitable ``load`` wrapper using ``asyncio``."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, cls.load, path)
+
     async def aadd(self, vectors: np.ndarray, metadata: Iterable[Any] | None = None) -> None:
         """Awaitable ``add`` wrapper using ``asyncio``."""
         loop = asyncio.get_running_loop()

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -103,6 +103,11 @@ class HierarchicalMemory:
 
     def save(self, path: str | Path) -> None:
         """Persist compressor state and vector store to ``path``."""
+        if isinstance(self.store, AsyncFaissVectorStore):
+            import asyncio
+
+            asyncio.run(self.save_async(path))
+            return
         path = Path(path)
         path.mkdir(parents=True, exist_ok=True)
         comp_state = {
@@ -120,9 +125,56 @@ class HierarchicalMemory:
         else:
             self.store.save(path / "store.npz")
 
+    async def save_async(self, path: str | Path) -> None:
+        """Asynchronously persist compressor state and vector store."""
+        path = Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+        comp_state = {
+            "dim": self.compressor.encoder.in_features,
+            "compressed_dim": self.compressor.encoder.out_features,
+            "capacity": self.compressor.buffer.capacity,
+            "buffer": [t.cpu() for t in self.compressor.buffer.data],
+            "count": self.compressor.buffer.count,
+            "encoder": self.compressor.encoder.state_dict(),
+            "decoder": self.compressor.decoder.state_dict(),
+        }
+        torch.save(comp_state, path / "compressor.pt")
+        if isinstance(self.store, AsyncFaissVectorStore):
+            await self.store.save_async(path / "store")
+        elif isinstance(self.store, FaissVectorStore):
+            self.store.save(path / "store")
+        else:
+            self.store.save(path / "store.npz")
+
     @classmethod
     def load(cls, path: str | Path, use_async: bool = False) -> "HierarchicalMemory":
         """Load memory from ``save()`` output."""
+        if use_async:
+            import asyncio
+
+            return asyncio.run(cls.load_async(path, use_async=True))
+        path = Path(path)
+        state = torch.load(path / "compressor.pt", map_location="cpu")
+        mem = cls(
+            dim=int(state["dim"]),
+            compressed_dim=int(state["compressed_dim"]),
+            capacity=int(state["capacity"]),
+            use_async=use_async,
+        )
+        mem.compressor.encoder.load_state_dict(state["encoder"])
+        mem.compressor.decoder.load_state_dict(state["decoder"])
+        mem.compressor.buffer.data = [t.clone() for t in state["buffer"]]
+        mem.compressor.buffer.count = int(state["count"])
+        store_dir = path / "store"
+        if store_dir.exists():
+            mem.store = FaissVectorStore.load(store_dir)
+        else:
+            mem.store = VectorStore.load(path / "store.npz")
+        return mem
+
+    @classmethod
+    async def load_async(cls, path: str | Path, use_async: bool = False) -> "HierarchicalMemory":
+        """Asynchronously load memory from ``save_async()`` output."""
         path = Path(path)
         state = torch.load(path / "compressor.pt", map_location="cpu")
         mem = cls(
@@ -138,7 +190,7 @@ class HierarchicalMemory:
         store_dir = path / "store"
         if store_dir.exists():
             if use_async:
-                mem.store = AsyncFaissVectorStore(dim=int(state["compressed_dim"]), path=store_dir)
+                mem.store = await AsyncFaissVectorStore.load_async(store_dir)
             else:
                 mem.store = FaissVectorStore.load(store_dir)
         else:


### PR DESCRIPTION
## Summary
- extend `HierarchicalMemory` with async `save_async` and `load_async`
- use async save/load in sync methods when the async vector store is used
- add matching async methods in `AsyncFaissVectorStore`
- expose `--async-memory` option in `train_infinite_context.py`
- test async save/load of hierarchical memory

## Testing
- `pip install -q -r requirements.txt`
- `pip install -e . -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607c44f2908331b1eb0c4be5563626