### PR TITLE
Add base router abstraction

### DIFF
--- a/src/moe_layer.py
+++ b/src/moe_layer.py
@@ -1,12 +1,13 @@
 import torch
 from torch import nn
-from .moe_router import HashRouter, SwitchRouter, balance_loss
+from .moe_router import BaseRouter, HashRouter, SwitchRouter, balance_loss
 
 
 class MoELayer(nn.Module):
     """Minimal Mixture-of-Experts feed-forward block implementing S-1 routing."""
 
-    def __init__(self, dim: int, hidden: int, num_experts: int, router: str = "hash", k: int = 2,
+    def __init__(self, dim: int, hidden: int, num_experts: int,
+                 router: str | BaseRouter = "hash", k: int = 2,
                  balance_weight: float | None = None) -> None:
         super().__init__()
         self.dim = dim
@@ -14,7 +15,9 @@ class MoELayer(nn.Module):
         self.num_experts = num_experts
         self.k = k
         self.balance_weight = balance_weight
-        if router == "switch":
+        if isinstance(router, BaseRouter):
+            self.router = router
+        elif router == "switch":
             self.router = SwitchRouter(dim=dim, num_experts=num_experts, k=k)
         else:
             self.router = HashRouter(num_experts=num_experts, k=k)

--- a/tests/test_moe_layer.py
+++ b/tests/test_moe_layer.py
@@ -2,6 +2,7 @@ import unittest
 import torch
 
 from asi.moe_layer import MoELayer
+from asi.moe_router import HashRouter
 
 
 class TestMoELayer(unittest.TestCase):
@@ -17,6 +18,13 @@ class TestMoELayer(unittest.TestCase):
         out, penalty = layer(x)
         self.assertEqual(out.shape, x.shape)
         self.assertGreaterEqual(penalty.item(), 0.0)
+
+    def test_custom_router_instance(self):
+        router = HashRouter(num_experts=4)
+        layer = MoELayer(dim=8, hidden=16, num_experts=4, router=router)
+        x = torch.randn(1, 3, 8)
+        out = layer(x)
+        self.assertEqual(out.shape, x.shape)
 
 
 if __name__ == '__main__':

--- a/tests/test_moe_router.py
+++ b/tests/test_moe_router.py
@@ -1,11 +1,18 @@
 import unittest
 import torch
 from asi.moe_router import (
+    BaseRouter,
     HashRouter,
     SwitchRouter,
     balance_loss_probs,
     token_drop_rate,
 )
+
+
+class TestBaseRouter(unittest.TestCase):
+    def test_subclasses(self):
+        self.assertTrue(issubclass(HashRouter, BaseRouter))
+        self.assertTrue(issubclass(SwitchRouter, BaseRouter))
 
 class TestHashRouter(unittest.TestCase):
     def test_load_balance(self):


### PR DESCRIPTION
## Summary
- implement `BaseRouter` abstract class
- inherit routers from `BaseRouter`
- allow passing a router instance into `MoELayer`
- update unit tests for new class hierarchy

## Testing
- `pytest tests/test_moe_router.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68608248f8d0833193bb5aafaeaad662