### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ Run the scripts directly with `python` to see parameter and FLOP estimates.
 1. Install requirements: `pip install -r requirements.txt`.
 2. Install the package in editable mode: `pip install -e .`.
 3. Run tests with `pytest`.
+
+## CI
+
+Automated tests run on GitHub Actions. The workflow installs the project in editable mode and executes `pytest`.
+See [.github/workflows/test.yml](.github/workflows/test.yml) for details.


### PR DESCRIPTION
## Summary
- run tests in GitHub Actions using a cached Python setup
- document the workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6860824d39c0833182835a32cc9089c9