### PR TITLE
Update line length policy in AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This repository contains documentation on algorithms towards self-improving AI. 
 ## Editing guidelines
 
 - Use Markdown formatting.
-- Keep lines under 120 characters where possible.
+- No line length limit, but keep code modular to minimize context.
 - Avoid trailing whitespace.
 - Reference or update `docs/Plan.md` where relevant.
 - Commit messages should start with a short summary in the imperative mood, e.g. `Add section on scalability`.


### PR DESCRIPTION
## Summary
- relax line length rule in `AGENTS.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686082d168b4833192d7c0ba4c827e08