### PR TITLE
Add async context manager to vector store

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -168,7 +168,9 @@ print(model.breakpoint, model.predict(params))
 - `src/async_vector_store.py` adds `AsyncFaissVectorStore` which wraps the
   disk-backed FAISS index with a thread pool. `add_async()` and `search_async()`
   submit operations to background workers, while `aadd()` and `asearch()`
-  provide `asyncio` interfaces.
+  provide `asyncio` interfaces. It can also be used with
+  ``async with AsyncFaissVectorStore(...) as store:`` to automatically shut down
+  the worker pool.
 - `src/hierarchical_memory.py` combines `StreamingCompressor` with either the
   in-memory `VectorStore` or a new `FaissVectorStore`. Passing a path hooks the
   memory to a persistent FAISS index so distant tokens are written to disk

--- a/src/async_vector_store.py
+++ b/src/async_vector_store.py
@@ -53,3 +53,11 @@ class AsyncFaissVectorStore(FaissVectorStore):
 
     def __exit__(self, exc_type, exc, tb) -> None:
         self.close()
+
+    async def __aenter__(self) -> "AsyncFaissVectorStore":
+        """Enter the async context manager."""
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Exit the async context manager and close resources."""
+        self.close()

--- a/tests/test_async_vector_store.py
+++ b/tests/test_async_vector_store.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+import asyncio
 import numpy as np
 
 from asi.async_vector_store import AsyncFaissVectorStore
@@ -21,6 +22,15 @@ class TestAsyncFaissVectorStore(unittest.TestCase):
             store.add_async(np.array([[1.0, 0.0]])).result()
             vecs, _ = store.search_async(np.array([1.0, 0.0]), k=1).result()
             np.testing.assert_allclose(vecs, np.array([[1.0, 0.0]], dtype=np.float32))
+
+    def test_async_with_context_manager(self):
+        async def run():
+            async with AsyncFaissVectorStore(dim=2) as store:
+                await store.aadd(np.array([[1.0, 0.0]]))
+                vecs, _ = await store.asearch(np.array([1.0, 0.0]), k=1)
+                np.testing.assert_allclose(vecs, np.array([[1.0, 0.0]], dtype=np.float32))
+
+        asyncio.run(run())
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support `async with` for `AsyncFaissVectorStore`
- document async context manager usage
- test async context manager behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6861b9efab6c833198afd98d1f966b51