### PR TITLE
Resolve merge conflict in PR 118

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -178,12 +178,14 @@ print(model.breakpoint, model.predict(params))
   `load()` helpers now handle both store types, letting large histories rebuild
   from disk with a single call.
 - `HierarchicalMemory` now accepts `use_async=True` to employ
-  `AsyncFaissVectorStore`. `add()`, `delete()`, `search()`, `save()` and
-  `load()` check if an event loop is running. When called from synchronous code
-  they block with ``asyncio.run``. Inside a running loop they return an
-  ``asyncio.Task`` so callers can ``await`` the scheduled operation. The
-  explicit async variants (`aadd`, `adelete`, `asearch`, `save_async`,
-  `load_async`) remain available for direct use.
+ `AsyncFaissVectorStore`. `add()`, `delete()`, `search()`, `save()` and
+ `load()` check if an event loop is running. When called from synchronous code
+ they block with ``asyncio.run``. Inside a running loop they return an
+ ``asyncio.Task`` so callers can ``await`` the scheduled operation. The
+ explicit async variants (`aadd`, `adelete`, `asearch`, `save_async`,
+ `load_async`) remain available for direct use.
+ `HierarchicalMemory` defines `__len__` so `len(mem)` reports the number of
+ stored vectors.
 
 ## C-4 MegaByte Patching
 

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -29,6 +29,10 @@ class HierarchicalMemory:
             else:
                 self.store = FaissVectorStore(dim=compressed_dim, path=db_path)
 
+    def __len__(self) -> int:
+        """Return the number of stored vectors."""
+        return len(self.store)
+
     def add(self, x: torch.Tensor, metadata: Iterable[Any] | None = None) -> None:
         """Compress and store embeddings with optional metadata."""
         if isinstance(self.store, AsyncFaissVectorStore):

--- a/tests/test_hierarchical_memory.py
+++ b/tests/test_hierarchical_memory.py
@@ -75,7 +75,7 @@ class TestHierarchicalMemory(unittest.TestCase):
         data = torch.randn(3, 4)
         mem.add(data, metadata=["a", "b", "c"])
         mem.delete(tag="b")
-        self.assertEqual(len(mem.store), 2)
+        self.assertEqual(len(mem), 2)
 
     def test_delete_persist_faiss(self):
         torch.manual_seed(0)
@@ -84,9 +84,9 @@ class TestHierarchicalMemory(unittest.TestCase):
             data = torch.randn(3, 4)
             mem.add(data, metadata=["x", "y", "z"])
             mem.delete(index=1)
-            self.assertEqual(len(mem.store), 2)
+            self.assertEqual(len(mem), 2)
             mem2 = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10, db_path=tmpdir)
-            self.assertEqual(len(mem2.store), 2)
+            self.assertEqual(len(mem2), 2)
 
     def test_sync_methods_inside_event_loop(self):
         torch.manual_seed(0)


### PR DESCRIPTION
## Summary
- integrate upstream main to fix merge conflict in docs and tests
- add `__len__` helper mention in documentation
- adjust tests to use `len(mem)`

## Testing
- `pip install torch numpy aiohttp -q`
- `PYTHONPATH=. pytest tests/test_hierarchical_memory.py tests/test_pull_request_monitor.py -q` *(fails: ModuleNotFoundError: No module named 'faiss')*

------
https://chatgpt.com/codex/tasks/task_e_6861dcf1b6108331ad1a460ecf9b1305