### PR TITLE
Update ASI plan with new roadmap tasks

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -125,6 +125,11 @@ model = fit_breakpoint(params, loss)
 print(model.breakpoint, model.predict(params))
 ```
 
+## S-4 4-bit Quantized LoRA Training
+
+- `src/lora_quant.py` implements a small LoRA adapter stored in int4 precision.
+- `apply_quant_lora()` injects these adapters into an existing network so most parameters stay frozen during fine-tuning.
+
 ## C-1 RetNet Retention Kernel
 
 - `src/retnet_retention.py` implements a minimal retention module.
@@ -239,6 +244,11 @@ To reproduce the toy run step by step:
    result to `model.memory` before resuming training. Reloading ensures previous
    retrievals remain available so the context effectively persists across runs.
 
+## C-7 Hierarchical Retrieval Memory
+
+- `src/hierarchical_memory.py` and `src/link_slot_attention.py` provide a two-tier memory backed by FAISS.
+- The store compresses vectors before writing them to disk and loads the nearest neighbours on demand.
+
 ## A-1 Paper-to-Code Transpiler
 
 - `src/paper_to_code.py` offers a minimal transpiler from LaTeX pseudo-code to
@@ -278,6 +288,11 @@ To reproduce the toy run step by step:
   ```
 - See `docs/Plan.md` task **A-4** for context and goals.
 
+## A-5 Self-Play World Model
+
+- `src/self_play_env.py` defines a minimal environment and agent loop for automated skill discovery.
+- The helper `rollout_env()` runs the simulator and logs rewards so new policies can be trained from the generated traces.
+
 ## Pull Request Monitoring
 
 - `src/pull_request_monitor.py` lists open pull requests and checks mergeability.
@@ -314,3 +329,8 @@ To reproduce the toy run step by step:
   and updates action values.
 - `select_action()` returns the highest-valued action with optional
   epsilon-greedy exploration.
+
+## L-5 Formal Verification Harness
+
+- `src/formal_verifier.py` sketches a small property checker that loads model snapshots and symbolically executes critical routines.
+- `verify_model()` asserts invariants like gradient norms and output bounds before the model is released.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -12,6 +12,7 @@ Citations point to the most recent public work so you can drill straight into th
 | **S-1** | **Sparse Mixture-of-Experts Routing (Switch-type)** | Activate ≤2 experts/token with *O*(1) router cost; keep cross-expert load-balance ≤3 % std-dev | 10 × parameter-count growth *without* >1.3 × training FLOPs ([medium.com][1])                            |
 | **S-2** | **FlashAttention-3 kernel**                         | Exact soft-max attention in fused CUDA/ROCm kernel with block-wise recomputation               | ≥90 % GPU util. for 8 k→1 M tokens, Wall-time speed-up ≥2 × over FA-2 ([tridao.me][2])                   |
 | **S-3** | **Scaling-law breakpoint model**                    | Predict test-loss vs (model, data, compute) past the current “diminishing-returns knee”        | Empirically fit to ≥3 new models above 3 T params; error <10 % ([businessinsider.com][3], [time.com][4]) |
+| **S-4** | **4-bit Quantized LoRA Training** | Train LoRA-adapted models entirely in 4-bit weights | ≤50 % memory of FP16 baseline at equal accuracy on 1 B+ params |
 
 **Take-away:**  Parameter-scaling alone still improves raw capability, but returns are now *sub-linear*; the industry is already in the knee of the curve.  Architectural and data-efficiency gains (S-1, S-2) therefore matter more than brute size.
 
@@ -27,6 +28,7 @@ Citations point to the most recent public work so you can drill straight into th
 | **C-4** | **MegaByte hierarchical patching**              | Two-level decoder that chunks bytes then words                     | Predict 1 M-byte sequence with perplexity ≤1.05× GPT-J but 3× fewer FLOPs ([arxiv.org][9], [huggingface.co][10])             |
 | **C-5** | **Top-k Sparse Attention for inference**        | Select k≈64 most-relevant keys each step                           | 20 %b/word latency cut at 1 M tokens; accuracy drop <0.5 pp ([arxiv.org][11])                                                |
 | **C-6** | **RWKV infinite-context training loop**         | Constant-memory recurrence with token-shift trick                  | Train 7 B RWKV on 4 M-token samples, VRAM ≤80 GB; effective context ≥2 M at inference ([wiki.rwkv.com][12], [arxiv.org][13]) |
+| **C-7** | **Hierarchical Retrieval Memory** | Cache long-tail tokens in a disk-backed vector DB | Retrieval hit rate ≥85 % at 1 M tokens |
 
 **Path to “trillion-token” context:** combine *C-1/2/3* for linear-or-sub-linear scaling, add **hierarchical retrieval** (store distant tokens in an external vector DB and re-inject on-demand).  Recurrence handles the whole stream; retrieval gives random access—context length becomes limited only by storage, not RAM.
 
@@ -40,6 +42,7 @@ Citations point to the most recent public work so you can drill straight into th
 | **A-2** | **AutoBench Harness**                    | Sandbox every imported module, tag wins/losses    | Coverage ≥95 % pass; dashboard latency <2 min                                                                      |
 | **A-3** | **Meta-RL Refactor Agent**               | Decide “replace / refactor / rollback” on modules | ≥15 % average benchmark uplift in 30 days                                                                          |
 | **A-4** | **Quantum Amplitude-Estimation HPO**     | Use QAE to sample hyper-params with √N speed-up   | Same accuracy with ≤30 % wall-clock time vs classical Bayesian search ([arxiv.org][16])                            |
+| **A-5** | **Self-Play World Model** | Train an environment simulator for iterative skill discovery | Achieve >20 % improvement on held-out tasks in 1 month |
 
 ---
 
@@ -51,6 +54,7 @@ Citations point to the most recent public work so you can drill straight into th
 | **L-2** | **Deliberative Alignment**                              | Chain-of-thought check against explicit policy text           | Red-team jailbreak rate <2 % on AdvBench ([openai.com][19])                                  |
 | **L-3** | **Iterative Constitutional Self-Alignment (IterAlign)** | Auto-draft rules, critique, self-refine                       | 3-round loop closes ≥70 % harmful loopholes each cycle ([ui.adsabs.harvard.edu][20])         |
 | **L-4** | **Critic-in-the-Loop RLHF**                             | Use a stronger “CriticGPT” to grade outputs                   | Bug-catch rate +60 % vs human-only RLHF ([wired.com][21])                                    |
+| **L-5** | **Formal Verification Harness** | Prove critical safety invariants over model updates | 95 % of release candidates pass property checks |
 
 ---
 


### PR DESCRIPTION
## Summary
- add new tasks S-4, C-7, A-5 and L-5 to the main roadmap
- describe prototype modules for quantized LoRA, hierarchical memory,
  a self-play world model and formal verification harness

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch and other deps)*

------
https://chatgpt.com/codex/tasks/task_e_6861e7ede7408331b46b330f5d36a9c3