### PR TITLE
Integrate LoRA quantization utilities

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -138,6 +138,18 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
   See `docs/Implementation.md` and `docs/load_balance.md` for details.
 - `src/pull_request_monitor.py` now supports asynchronous GitHub queries using
   `aiohttp` for faster monitoring of open pull requests.
+- `src/lora_quant.py` provides 4-bit LoRA adapters and `apply_quant_lora()` to
+  inject them into existing models.
+- `src/cross_modal_fusion.py` encodes text, images and audio in a shared space
+  with a contrastive training helper.
+- `src/multimodal_world_model.py` unifies these embeddings with actions for
+  world-model rollouts.
+- `src/world_model_rl.py` contains a tiny model-based RL loop and evaluation
+  helpers.
+- `src/robot_skill_transfer.py` maps demonstration frames to control commands.
+- `src/self_play_env.py` and `src/embodied_calibration.py` offer a sandbox for
+  self-play and a sensor calibration routine.
+- `src/formal_verifier.py` checks model snapshots against custom invariants.
 
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -65,3 +65,4 @@ from .embodied_calibration import (
     CalibrationModel,
     calibrate,
 )
+from .lora_quant import LoRAQuantLinear, apply_quant_lora

--- a/src/lora_quant.py
+++ b/src/lora_quant.py
@@ -1,0 +1,99 @@
+import math
+from typing import Iterable, Sequence
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+__all__ = ["LoRAQuantLinear", "apply_quant_lora"]
+
+
+def _quantize_4bit(t: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a tensor to int4 with symmetric scaling.
+
+    Returns the quantized values (stored in int8) and the scale factor.
+    """
+    scale = t.abs().max() / 7.0 + 1e-8
+    q = torch.round(t / scale).clamp(-8, 7).to(torch.int8)
+    return q, scale
+
+
+def _dequantize_4bit(q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    return q.float() * scale
+
+
+class LoRAQuantLinear(nn.Module):
+    """Linear layer with a 4-bit LoRA adapter."""
+
+    def __init__(self, base: nn.Linear, r: int = 4, alpha: float = 1.0, dropout: float = 0.0):
+        super().__init__()
+        self.base = base
+        self.r = r
+        self.alpha = alpha
+        self.scale = alpha / r if r > 0 else 1.0
+        self.dropout = nn.Dropout(dropout) if dropout > 0 else None
+
+        if r > 0:
+            self.lora_a = nn.Parameter(torch.zeros(r, base.in_features))
+            self.lora_b = nn.Parameter(torch.zeros(base.out_features, r))
+            nn.init.kaiming_uniform_(self.lora_a, a=math.sqrt(5))
+            nn.init.zeros_(self.lora_b)
+        else:
+            self.register_parameter("lora_a", None)
+            self.register_parameter("lora_b", None)
+        # buffers for quantised weights when not training
+        self.register_buffer("qa", None)
+        self.register_buffer("qb", None)
+        self.register_buffer("scale_a", None)
+        self.register_buffer("scale_b", None)
+
+    def quantize(self):
+        """Quantize LoRA weights and store them as buffers."""
+        if self.r == 0:
+            return
+        self.qa, self.scale_a = _quantize_4bit(self.lora_a.detach())
+        self.qb, self.scale_b = _quantize_4bit(self.lora_b.detach())
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.base(x)
+        if self.r == 0:
+            return out
+        if self.training or self.qa is None:
+            a = self.lora_a
+            b = self.lora_b
+        else:
+            a = _dequantize_4bit(self.qa, self.scale_a)
+            b = _dequantize_4bit(self.qb, self.scale_b)
+        if self.dropout is not None:
+            x = self.dropout(x)
+        lora_out = F.linear(x, b @ a, bias=None) * self.scale
+        return out + lora_out
+
+
+def apply_quant_lora(model: nn.Module, target_modules: Sequence[str], r: int = 4,
+                     alpha: float = 1.0, dropout: float = 0.0) -> nn.Module:
+    """Wrap ``target_modules`` in ``model`` with ``LoRAQuantLinear``.
+
+    Parameters
+    ----------
+    model:
+        The model whose modules will be replaced in-place.
+    target_modules:
+        Iterable of attribute names (e.g. ``["q_proj", "v_proj"]``) to adapt.
+    r:
+        Rank of the LoRA adapters.
+    alpha:
+        LoRA scaling factor.
+    dropout:
+        Optional dropout probability for the injected adapters.
+    """
+    for name, module in model.named_modules():
+        for tgt in target_modules:
+            if name.endswith(tgt) and isinstance(module, nn.Linear):
+                parent_name = name.rsplit(".", 1)[0]
+                parent = model
+                if parent_name:
+                    for attr in parent_name.split("."):
+                        parent = getattr(parent, attr)
+                setattr(parent, tgt, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
+    return model

--- a/tests/test_lora_quant.py
+++ b/tests/test_lora_quant.py
@@ -1,0 +1,28 @@
+import unittest
+import torch
+from torch import nn
+from asi.lora_quant import LoRAQuantLinear, apply_quant_lora
+
+
+class Dummy(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(4, 2)
+
+
+class TestLoRAQuant(unittest.TestCase):
+    def test_apply_and_forward(self):
+        model = Dummy()
+        apply_quant_lora(model, ["fc"], r=2)
+        self.assertIsInstance(model.fc, LoRAQuantLinear)
+        x = torch.randn(3, 4)
+        y = model.fc(x)
+        self.assertEqual(y.shape, (3, 2))
+        model.fc.quantize()
+        with torch.no_grad():
+            y2 = model.fc(x)
+        self.assertEqual(y2.shape, (3, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new `lora_quant.py` module with 4-bit LoRA adapter
- export LoRA helpers in `src/__init__.py`
- document multimodal and RL utilities in `docs/Plan.md`
- add unit test for LoRA quantization

## Testing
- `python -m py_compile src/lora_quant.py tests/test_lora_quant.py`
- `pytest tests/test_lora_quant.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6861ff7a3eac8331a028f9f8e3f40c76