### PR TITLE
Add roadmap features for distributed memory and evaluation

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -325,6 +325,11 @@ To reproduce the toy run step by step:
 - `src/hierarchical_memory.py` and `src/link_slot_attention.py` provide a two-tier memory backed by FAISS.
 - The store compresses vectors before writing them to disk and loads the nearest neighbours on demand.
 
+## C-8 Distributed Hierarchical Memory Backend
+
+- Planned extension of `src/hierarchical_memory.py` with an optional gRPC service.
+- The store will expose `push_remote()` and `query_remote()` so multiple nodes share one vector database.
+
 ## A-5 Multi-Modal World Model
 
 - `src/multimodal_world_model.py` now implements a unified transformer that ingests text, images and low-level actions.
@@ -339,6 +344,21 @@ To reproduce the toy run step by step:
 
 - `src/self_play_env.py` defines a minimal environment and agent loop for automated skill discovery.
 - `rollout_env()` runs the simulator and logs rewards so new policies can be trained from the generated traces.
+
+## A-8 Integrated Self-Play & Skill Transfer
+
+- The orchestrator in `src/self_play_skill_loop.py` will alternate `self_play_env.rollout_env()` with `robot_skill_transfer.transfer_skills()`.
+- Each cycle logs rewards and fine-tunes policies on a small batch of real examples.
+
+## A-9 Automated PR Conflict Checks
+
+- `src/pr_conflict_checker.py` reuses `pull_request_monitor.list_open_prs()` and runs `git merge-base` to detect conflicts.
+- Summaries appear in the AutoBench-style scoreboard.
+
+## A-10 Goal-Oriented Evaluation Harness
+
+- `src/eval_harness.py` gathers benchmark metrics from each module and compares them with the targets in `docs/Plan.md`.
+- Running `python -m src.eval_harness` prints a pass/fail table for the whole project.
 
 ## L-5 Formal Verification Harness
 
@@ -359,3 +379,8 @@ To reproduce the toy run step by step:
 
 - `src/embodied_calibration.py` adapts sensor and actuator parameters from a small set of real-world samples.
 - `calibrate()` aligns simulation and hardware spaces so policies trained in simulation remain effective after deployment.
+
+## M-4 Cross-Modal Data Ingestion Pipeline
+
+- `src/data_ingest.py` will align text, image and audio pairs from open datasets.
+- Augmentation helpers generate crops and transcripts for training the multi-modal world model.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -29,6 +29,7 @@ Citations point to the most recent public work so you can drill straight into th
 | **C-5** | **Top-k Sparse Attention for inference**        | Select k≈64 most-relevant keys each step                           | 20 %b/word latency cut at 1 M tokens; accuracy drop <0.5 pp ([arxiv.org][11])                                                |
 | **C-6** | **RWKV infinite-context training loop**         | Constant-memory recurrence with token-shift trick                  | Train 7 B RWKV on 4 M-token samples, VRAM ≤80 GB; effective context ≥2 M at inference ([wiki.rwkv.com][12], [arxiv.org][13]) |
 | **C-7** | **Hierarchical Retrieval Memory**         | Cache long-tail tokens in a disk-backed vector DB                     | Retrieval hit rate ≥85 % at 1 M tokens |
+| **C-8** | **Distributed Hierarchical Memory Backend** | Share the vector store across nodes via a gRPC service | Throughput scales to 4+ nodes with <1.2× single-node latency |
 
 **Path to “trillion-token” context:** combine *C-1/2/3* for linear-or-sub-linear scaling, add **hierarchical retrieval** (store distant tokens in an external vector DB and re-inject on-demand).  Recurrence handles the whole stream; retrieval gives random access—context length becomes limited only by storage, not RAM.
 
@@ -45,6 +46,9 @@ Citations point to the most recent public work so you can drill straight into th
 | **A-5** | **Multi-Modal World Model (Generalist)** | Jointly learn text, image and action dynamics     | ≥50 % success on multi-modal RL benchmarks; retrieval ≤2 × text-only baseline ([arxiv.org][23]) |
 | **A-6** | **Embodied Skill Transfer (RT-2)**        | Map web-scale demonstrations to robot policies    | 80 % task success on a 100-skill benchmark after <1 h fine-tuning ([arxiv.org][24]) |
 | **A-7** | **Self-Play World Model**                 | Train an environment simulator for iterative skill discovery | Achieve >20 % improvement on held-out tasks in 1 month |
+| **A-8** | **Integrated Self-Play & Skill Transfer** | Alternate self-play rollouts with real-world fine-tuning | >30 % improvement over running either loop alone |
+| **A-9** | **Automated PR Conflict Checks** | Summarize merge conflicts for all open pull requests | Detection completes in <2 min per repo |
+| **A-10** | **Goal-Oriented Evaluation Harness** | Benchmark each algorithm against its success criteria | Single command prints pass/fail scoreboard |
 
 ---
 
@@ -67,6 +71,7 @@ Citations point to the most recent public work so you can drill straight into th
 | **M-1** | **Cross-Modal Fusion Architecture**     | Learn a single latent space for text, images and audio                              | ≥85 % F1 on zero-shot image↔text retrieval; audio caption BLEU within 5 % of SOTA |
 | **M-2** | **World-Model RL Bridge**               | Train a generative world model from logs and run model-based RL for fast policy updates | Real robot tasks reach 90 % of offline policy reward after <10k physical steps   |
 | **M-3** | **Self-Calibration for Embodied Agents**| Adapt sensors and actuators from small real-world samples                           | Simulation-trained policies retain ≥80 % success with <1k labelled real samples   |
+| **M-4** | **Cross-Modal Data Ingestion Pipeline** | Pair text, images and audio from open datasets with augmentations | Prepare 1 M aligned triples in under 1 h with retrieval F1 near baseline |
 
 ---
 


### PR DESCRIPTION
## Summary
- expand roadmap with cross-modal ingestion pipeline and other planned features
- describe future modules in implementation notes

## Testing
- `grep -n "M-4" -n docs/Implementation.md`

------
https://chatgpt.com/codex/tasks/task_e_6862b7135e1c833193df1a36263db31b