### PR TITLE
Add evaluation harness

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -155,6 +155,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 - `src/self_play_env.py` and `src/embodied_calibration.py` offer a sandbox for
   self-play and a sensor calibration routine.
 - `src/formal_verifier.py` checks model snapshots against custom invariants.
+- `src/eval_harness.py` aggregates metrics from all modules and prints a pass/fail scoreboard.
 
 ### Recommended next steps
 

--- a/src/eval_harness.py
+++ b/src/eval_harness.py
@@ -1,0 +1,253 @@
+"""Goal-oriented evaluation harness for Plan.md modules."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import re
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Tuple
+
+import numpy as np
+import torch
+
+
+# ---------------------------------------------------------------------------
+# Module discovery
+# ---------------------------------------------------------------------------
+
+def parse_modules(plan_path: str | Path = "docs/Plan.md") -> list[str]:
+    """Return unique module names mentioned in ``plan_path``."""
+    text = Path(plan_path).read_text(encoding="utf-8")
+    mods = re.findall(r"`src/([\w_]+)\.py`", text)
+    return sorted(set(mods))
+
+
+# ---------------------------------------------------------------------------
+# Individual module evaluators
+# ---------------------------------------------------------------------------
+
+def _eval_import_only(module: str) -> Tuple[bool, str]:
+    importlib.import_module(f"asi.{module}")
+    return True, "imported"
+
+
+def _eval_moe_router() -> Tuple[bool, str]:
+    from asi import moe_router
+
+    router = moe_router.HashRouter(num_experts=8)
+    x = torch.randn(2, 16, 4)
+    assign = router(x)
+    std = router.load_balance_std(assign)
+    return std < 0.5, f"load_balance_std={std:.3f}"
+
+
+def _eval_flash_attention3() -> Tuple[bool, str]:
+    from asi import flash_attention3 as fa3
+
+    q = torch.randn(1, 4, 8)
+    k = torch.randn(1, 4, 8)
+    v = torch.randn(1, 4, 8)
+    out = fa3.flash_attention_3(q, k, v)
+    return out.shape == q.shape, f"shape={tuple(out.shape)}"
+
+
+def _eval_scaling_law() -> Tuple[bool, str]:
+    from asi.scaling_law import BreakpointScalingLaw
+
+    compute = np.logspace(0, 2, 8)
+    loss = 1.0 / np.sqrt(compute)
+    model = BreakpointScalingLaw()
+    model.fit(compute, loss)
+    pred = model.predict(compute)
+    err = float(np.abs(pred - loss).mean())
+    return err < 1e-3, f"err={err:.2e}"
+
+
+def _eval_scaling_breakpoint() -> Tuple[bool, str]:
+    from asi.scaling_breakpoint import fit_breakpoint
+
+    x = np.array([1, 10, 100, 1000], dtype=float)
+    y = np.log10(x) * -0.5 + 2.0
+    model = fit_breakpoint(x, y)
+    pred = model.predict(x)
+    err = float(np.abs(pred - y).mean())
+    return err < 1e-3, f"err={err:.2e}"
+
+
+def _eval_retnet_retention() -> Tuple[bool, str]:
+    from asi.retnet_retention import RetNetRetention
+
+    q = torch.randn(1, 4, 8)
+    k = torch.randn(1, 4, 8)
+    v = torch.randn(1, 4, 8)
+    mod = RetNetRetention(num_heads=2)
+    out = mod(q, k, v)
+    return out.shape == q.shape, f"shape={tuple(out.shape)}"
+
+
+def _eval_mamba_block() -> Tuple[bool, str]:
+    from asi.mamba_block import MambaBlock
+
+    block = MambaBlock(dim=8)
+    x = torch.randn(1, 3, 8)
+    out = block(x)
+    return out.shape == x.shape, f"shape={tuple(out.shape)}"
+
+
+def _eval_hyena_filter() -> Tuple[bool, str]:
+    from asi.hyena_filter import HyenaFilter
+
+    filt = HyenaFilter(filter_length=4)
+    x = torch.randn(1, 6, 8)
+    out = filt(x)
+    return out.shape == x.shape, f"shape={tuple(out.shape)}"
+
+
+def _eval_streaming_compression() -> Tuple[bool, str]:
+    from asi.streaming_compression import StreamingCompressor
+
+    comp = StreamingCompressor(dim=8, compressed_dim=4, capacity=10)
+    x = torch.randn(5, 8)
+    comp.add(x)
+    c = comp.compressed()
+    return c.shape[1] == 4, f"compressed_dim={c.shape[1]}"
+
+
+def _eval_vector_store() -> Tuple[bool, str]:
+    from asi.vector_store import VectorStore
+
+    store = VectorStore(dim=4)
+    vec = np.ones((2, 4), dtype=np.float32)
+    store.add(vec)
+    out, _ = store.search(vec[0])
+    return out.shape == (2, 4), f"retrieved={out.shape[0]}"
+
+
+def _eval_hierarchical_memory() -> Tuple[bool, str]:
+    from asi.hierarchical_memory import HierarchicalMemory
+
+    mem = HierarchicalMemory(dim=8, compressed_dim=4, capacity=10)
+    x = torch.randn(2, 8)
+    mem.add(x)
+    retrieved, _ = mem.search(x[0], k=1)
+    return retrieved.shape[-1] == 8, f"size={len(mem)}"
+
+
+def _eval_link_slot_attention() -> Tuple[bool, str]:
+    from asi.hierarchical_memory import HierarchicalMemory
+    from asi.link_slot_attention import LinkSlotAttention
+
+    mem = HierarchicalMemory(dim=8, compressed_dim=4, capacity=5)
+    lsa = LinkSlotAttention(mem, dim=8, k_top=1)
+    x = torch.randn(1, 3, 8)
+    out = lsa(x)
+    return out.shape == x.shape, f"shape={tuple(out.shape)}"
+
+
+def _eval_megabyte_patching() -> Tuple[bool, str]:
+    from asi.megabyte_patching import MegaBytePatching
+
+    patcher = MegaBytePatching(patch_size=4, dim=8)
+    x = torch.randint(0, 256, (1, 5))
+    out = patcher(x)
+    return out.size(-1) == 8, f"patches={out.size(1)}"
+
+
+def _eval_topk_sparse_attention() -> Tuple[bool, str]:
+    from asi.topk_sparse_attention import topk_sparse_attention
+
+    q = torch.randn(1, 2, 4)
+    k = torch.randn(1, 3, 4)
+    v = torch.randn(1, 3, 4)
+    out = topk_sparse_attention(q, k, v, k_top=2)
+    return out.shape == q.shape, f"shape={tuple(out.shape)}"
+
+
+def _eval_paper_to_code() -> Tuple[bool, str]:
+    from asi.paper_to_code import transpile
+
+    latex = "\\Function{add}{a,b}\n\\Return{a+b}"
+    py = transpile(latex)
+    return "return" in py, "transpiled"
+
+
+def _eval_autobench() -> Tuple[bool, str]:
+    from asi.autobench import run_autobench
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "test_x.py"
+        p.write_text(
+            "import unittest\n\nclass T(unittest.TestCase):\n    def test_ok(self):\n        self.assertTrue(True)\n\nif __name__=='__main__':\n    unittest.main()\n"
+        )
+        results = run_autobench(tmp)
+    ok = list(results.values())[0].passed
+    return ok, "sandboxed"
+
+
+EVALUATORS: Dict[str, Callable[[], Tuple[bool, str]]] = {
+    "moe_router": _eval_moe_router,
+    "flash_attention3": _eval_flash_attention3,
+    "scaling_law": _eval_scaling_law,
+    "scaling_breakpoint": _eval_scaling_breakpoint,
+    "retnet_retention": _eval_retnet_retention,
+    "mamba_block": _eval_mamba_block,
+    "hyena_filter": _eval_hyena_filter,
+    "streaming_compression": _eval_streaming_compression,
+    "vector_store": _eval_vector_store,
+    "hierarchical_memory": _eval_hierarchical_memory,
+    "link_slot_attention": _eval_link_slot_attention,
+    "megabyte_patching": _eval_megabyte_patching,
+    "topk_sparse_attention": _eval_topk_sparse_attention,
+    "paper_to_code": _eval_paper_to_code,
+    "autobench": _eval_autobench,
+}
+
+
+# ---------------------------------------------------------------------------
+# Runner utilities
+# ---------------------------------------------------------------------------
+
+def evaluate_modules(modules: Iterable[str]) -> Dict[str, Tuple[bool, str]]:
+    """Evaluate ``modules`` and return their status."""
+    results: Dict[str, Tuple[bool, str]] = {}
+    for mod in modules:
+        fn = EVALUATORS.get(mod, lambda: _eval_import_only(mod))
+        try:
+            passed, info = fn()
+        except Exception as exc:  # pragma: no cover - diagnostic path
+            passed, info = False, f"error: {exc}"
+        results[mod] = (passed, info)
+    return results
+
+
+def format_results(results: Dict[str, Tuple[bool, str]]) -> str:
+    total = len(results)
+    passed = sum(1 for ok, _ in results.values() if ok)
+    lines = [f"Passed {passed}/{total} modules"]
+    for mod, (ok, info) in sorted(results.items()):
+        status = "PASS" if ok else "FAIL"
+        lines.append(f"{mod}: {status} - {info}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Evaluate project modules")
+    parser.add_argument(
+        "--plan", default="docs/Plan.md", help="Path to Plan.md listing modules"
+    )
+    args = parser.parse_args(argv)
+
+    mods = parse_modules(args.plan)
+    results = evaluate_modules(mods)
+    print(format_results(results))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/lora_quant.py
+++ b/src/lora_quant.py
@@ -90,10 +90,13 @@ def apply_quant_lora(model: nn.Module, target_modules: Sequence[str], r: int = 4
     for name, module in model.named_modules():
         for tgt in target_modules:
             if name.endswith(tgt) and isinstance(module, nn.Linear):
-                parent_name = name.rsplit(".", 1)[0]
+                if "." in name:
+                    parent_name, child = name.rsplit(".", 1)
+                else:
+                    parent_name, child = "", name
                 parent = model
                 if parent_name:
                     for attr in parent_name.split("."):
                         parent = getattr(parent, attr)
-                setattr(parent, tgt, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
+                setattr(parent, child, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
     return model

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,21 @@
+import unittest
+
+from asi.eval_harness import parse_modules, evaluate_modules
+
+
+class TestEvalHarness(unittest.TestCase):
+    def test_parse_modules(self):
+        mods = parse_modules("docs/Plan.md")
+        self.assertIn("moe_router", mods)
+        self.assertIn("formal_verifier", mods)
+
+    def test_evaluate_subset(self):
+        subset = ["moe_router", "flash_attention3", "scaling_law"]
+        results = evaluate_modules(subset)
+        for name in subset:
+            self.assertIn(name, results)
+            self.assertTrue(results[name][0], name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `src/eval_harness.py` for goal-oriented metrics
- fix LoRA quantization replacement logic
- document eval harness in Plan
- add unit tests for the harness

## Testing
- `pip install -q -r requirements.txt`
- `pip install -e .`
- `pytest tests/test_eval_harness.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862bf1077a48331b6bdd54a67f86d05