### PR TITLE
Add self-play loop and eval utilities

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -347,7 +347,7 @@ To reproduce the toy run step by step:
 
 ## A-8 Integrated Self-Play & Skill Transfer
 
-- The orchestrator in `src/self_play_skill_loop.py` will alternate `self_play_env.rollout_env()` with `robot_skill_transfer.transfer_skills()`.
+- The orchestrator in `src/self_play_skill_loop.py` alternates `self_play_env.rollout_env()` with `robot_skill_transfer.transfer_skills()`.
 - Each cycle logs rewards and fine-tunes policies on a small batch of real examples.
 
 ## A-9 Automated PR Conflict Checks
@@ -382,7 +382,7 @@ To reproduce the toy run step by step:
 
 ## M-4 Cross-Modal Data Ingestion Pipeline
 
-- `src/data_ingest.py` will align text, image and audio pairs from open datasets.
+- `src/data_ingest.py` aligns text, image and audio pairs from open datasets.
 - Augmentation helpers generate crops and transcripts for training the multi-modal world model.
 
 ## Research workflow

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -66,3 +66,7 @@ from .embodied_calibration import (
     calibrate,
 )
 from .lora_quant import LoRAQuantLinear, apply_quant_lora
+from .self_play_skill_loop import SelfPlaySkillConfig, self_play_skill_loop
+from .pr_conflict_checker import list_conflicts
+from .eval_harness import gather_metrics, summarize
+from .data_ingest import IngestConfig, align_modalities, generate_augmentations

--- a/src/data_ingest.py
+++ b/src/data_ingest.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple, Any
+
+import random
+import torch
+
+
+@dataclass
+class IngestConfig:
+    crop_size: int = 32
+    noise_std: float = 0.01
+
+
+def align_modalities(
+    texts: Iterable[str], images: Iterable[torch.Tensor], audios: Iterable[torch.Tensor]
+) -> List[Tuple[str, torch.Tensor, torch.Tensor]]:
+    """Return paired text, image and audio items."""
+    triples = list(zip(texts, images, audios))
+    if not triples:
+        raise ValueError("input iterables must have equal length")
+    return triples
+
+
+def generate_augmentations(
+    triples: Iterable[Tuple[str, torch.Tensor, torch.Tensor]], cfg: IngestConfig
+) -> List[Tuple[str, torch.Tensor, torch.Tensor]]:
+    """Apply simple crops and noise for data augmentation."""
+    aug_triples = []
+    for text, img, aud in triples:
+        h, w = img.shape[-2:]
+        if h > cfg.crop_size and w > cfg.crop_size:
+            top = random.randint(0, h - cfg.crop_size)
+            left = random.randint(0, w - cfg.crop_size)
+            img = img[..., top : top + cfg.crop_size, left : left + cfg.crop_size]
+        aud = aud + cfg.noise_std * torch.randn_like(aud)
+        aug_triples.append((text, img, aud))
+    return aug_triples
+
+
+__all__ = ["IngestConfig", "align_modalities", "generate_augmentations"]

--- a/src/eval_harness.py
+++ b/src/eval_harness.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import torch
+
+from .moe_router import HashRouter
+from .flash_attention3 import _HAS_FLASH3
+
+
+@dataclass
+class EvalResult:
+    name: str
+    value: Any
+    target: Any
+    passed: bool
+
+
+def gather_metrics() -> Dict[str, EvalResult]:
+    """Collect simple benchmark metrics."""
+    results: Dict[str, EvalResult] = {}
+
+    router = HashRouter(num_experts=8)
+    dummy = torch.randn(4, 16, 32)
+    assign = router(dummy)
+    std = router.load_balance_std(assign)
+    results["S-1"] = EvalResult("S-1", std, 0.03, std <= 0.03)
+
+    results["S-2"] = EvalResult("S-2", _HAS_FLASH3, True, bool(_HAS_FLASH3))
+
+    return results
+
+
+def summarize(results: Dict[str, EvalResult]) -> str:
+    lines = ["Algorithm  Result  Target  Pass"]
+    for res in results.values():
+        lines.append(
+            f"{res.name:8} {res.value!s:7} {res.target!s:7} {'PASS' if res.passed else 'FAIL'}"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    metrics = gather_metrics()
+    print(summarize(metrics))
+
+
+if __name__ == "__main__":
+    main()
+
+__all__ = ["gather_metrics", "summarize"]

--- a/src/pr_conflict_checker.py
+++ b/src/pr_conflict_checker.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Dict, List
+
+from .pull_request_monitor import list_open_prs
+
+
+def _check_conflict(branch_ref: str, base: str = "HEAD") -> bool:
+    """Return True if merging ``branch_ref`` into ``base`` would conflict."""
+    subprocess.run(["git", "fetch", "origin", branch_ref], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    base_commit = subprocess.check_output(["git", "merge-base", base, "FETCH_HEAD"]).decode().strip()
+    proc = subprocess.run(
+        ["git", "merge-tree", base_commit, base, "FETCH_HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    return "<<<<<<<" in proc.stdout
+
+
+def list_conflicts(repo: str, token: str | None = None) -> List[Dict[str, Any]]:
+    """List open PRs for ``repo`` and whether they have merge conflicts."""
+    prs = list_open_prs(repo, token)
+    results = []
+    for pr in prs:
+        ref = f"pull/{pr['number']}/head"
+        conflicts = _check_conflict(ref)
+        results.append({"number": pr["number"], "title": pr["title"], "conflicts": conflicts})
+    return results
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Check PRs for merge conflicts")
+    parser.add_argument("repo", help="<owner>/<repo> to query")
+    parser.add_argument("--token", default=None, help="GitHub token")
+    args = parser.parse_args()
+
+    for info in list_conflicts(args.repo, args.token):
+        status = "conflicts" if info["conflicts"] else "clean"
+        print(f"#{info['number']} {info['title']} - {status}")
+
+
+if __name__ == "__main__":
+    main()
+
+__all__ = ["list_conflicts"]

--- a/src/self_play_skill_loop.py
+++ b/src/self_play_skill_loop.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Tuple
+
+import torch
+
+from .self_play_env import SimpleEnv, rollout_env
+from .robot_skill_transfer import SkillTransferConfig, VideoPolicyDataset, SkillTransferModel, transfer_skills
+
+
+@dataclass
+class SelfPlaySkillConfig:
+    """Configuration for the integrated loop."""
+
+    cycles: int = 3
+    rollout_steps: int = 20
+
+
+def self_play_skill_loop(
+    env: SimpleEnv,
+    policy: Callable[[torch.Tensor], torch.Tensor],
+    transfer_cfg: SkillTransferConfig,
+    real_dataset: VideoPolicyDataset,
+    cfg: SelfPlaySkillConfig | None = None,
+) -> Tuple[SkillTransferModel, List[List[float]]]:
+    """Alternate self-play rollouts with skill transfer training.
+
+    Returns the final trained policy and reward history.
+    """
+
+    if cfg is None:
+        cfg = SelfPlaySkillConfig()
+    rewards_history: List[List[float]] = []
+    current_policy = policy
+    model: SkillTransferModel | None = None
+
+    for _ in range(cfg.cycles):
+        _, rewards = rollout_env(env, current_policy, steps=cfg.rollout_steps)
+        rewards_history.append(rewards)
+        model = transfer_skills(transfer_cfg, real_dataset)
+        current_policy = model
+
+    return model if model is not None else policy, rewards_history
+
+
+__all__ = ["SelfPlaySkillConfig", "self_play_skill_loop"]


### PR DESCRIPTION
## Summary
- implement `self_play_skill_loop` for alternating rollouts and skill transfer
- add PR conflict checker using `git merge-base`
- create simple evaluation harness collecting metrics
- provide cross-modal data ingestion helpers
- export modules and document features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy, torch, aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_6862bf5afb308331afa916320790f925