### PR TITLE
Add tests for fusion and world models

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -334,6 +334,7 @@ To reproduce the toy run step by step:
 
 - `src/multimodal_world_model.py` now implements a unified transformer that ingests text, images and low-level actions.
 - `train_world_model()` fits the model on trajectory data and `rollout()` generates simulated transitions for downstream agents.
+- Unit tests verify training and rollouts on small synthetic trajectories.
 
 ## A-6 Embodied Skill Transfer
 
@@ -369,11 +370,13 @@ To reproduce the toy run step by step:
 
 - `src/cross_modal_fusion.py` embeds text, images and audio in one latent space.
 - `train_fusion_model()` fine-tunes a shared encoder-decoder using CLIP- and Whisper-style objectives and `encode_all()` returns embeddings for retrieval.
+- Unit tests exercise the forward pass, training loop and encoding helper on toy data.
 
 ## M-2 World-Model RL Bridge
 
 - `src/world_model_rl.py` learns a generative world model from logged trajectories and runs model-based RL for rapid policy updates.
 - The prototype interfaces with ``gym``-like data and provides ``rollout_policy()`` for offline rollout generation.
+- Unit tests cover model training and policy rollout on synthetic transitions.
 
 ## M-3 Self-Calibration for Embodied Agents
 

--- a/tests/test_cross_modal_fusion.py
+++ b/tests/test_cross_modal_fusion.py
@@ -1,0 +1,67 @@
+import unittest
+import torch
+from asi.cross_modal_fusion import (
+    CrossModalFusionConfig,
+    CrossModalFusion,
+    MultiModalDataset,
+    train_fusion_model,
+    encode_all,
+)
+
+
+def _tokenizer(text: str):
+    ids = [(ord(c) - 97) % 20 + 1 for c in text]
+    ids = (ids + [0] * 4)[:4]
+    return ids
+
+
+def _make_dataset(n=4):
+    triples = []
+    for i in range(n):
+        text = "test"[i % 4 :] + "a" * (i % 2)
+        img = torch.randn(3, 16, 16)
+        aud = torch.randn(1, 32)
+        triples.append((text, img, aud))
+    return MultiModalDataset(triples, _tokenizer)
+
+
+class TestCrossModalFusion(unittest.TestCase):
+    def test_forward_shapes(self):
+        cfg = CrossModalFusionConfig(
+            vocab_size=32,
+            text_dim=16,
+            img_channels=3,
+            audio_channels=1,
+            latent_dim=8,
+        )
+        model = CrossModalFusion(cfg)
+        ds = _make_dataset(1)
+        tokens, img, aud = ds[0]
+        t, i, a = model(
+            tokens.unsqueeze(0), img.unsqueeze(0), aud.unsqueeze(0)
+        )
+        self.assertEqual(t.shape, (1, 8))
+        self.assertEqual(i.shape, (1, 8))
+        self.assertEqual(a.shape, (1, 8))
+
+    def test_train_and_encode(self):
+        cfg = CrossModalFusionConfig(
+            vocab_size=32,
+            text_dim=16,
+            img_channels=3,
+            audio_channels=1,
+            latent_dim=8,
+        )
+        ds = _make_dataset(6)
+        model = CrossModalFusion(cfg)
+        before = model.text_enc.embed.weight.clone()
+        train_fusion_model(model, ds, epochs=1, batch_size=2)
+        self.assertFalse(torch.allclose(before, model.text_enc.embed.weight))
+        t_vecs, i_vecs, a_vecs = encode_all(model, ds, batch_size=2)
+        self.assertEqual(t_vecs.shape[0], len(ds))
+        self.assertEqual(i_vecs.shape, t_vecs.shape)
+        self.assertEqual(a_vecs.shape, t_vecs.shape)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multimodal_world_model.py
+++ b/tests/test_multimodal_world_model.py
@@ -1,0 +1,49 @@
+import unittest
+import torch
+from asi.multimodal_world_model import (
+    MultiModalWorldModelConfig,
+    MultiModalWorldModel,
+    TrajectoryDataset,
+    train_world_model,
+    rollout,
+)
+
+
+def _tokenizer(text: str):
+    ids = [(ord(c) - 97) % 20 + 1 for c in text]
+    ids = (ids + [0] * 4)[:4]
+    return ids
+
+
+def _make_dataset(n=4):
+    items = []
+    for i in range(n):
+        t = "t" * 4
+        img = torch.randn(3, 16, 16)
+        action = i % 3
+        nt = "n" * 4
+        nimg = torch.randn(3, 16, 16)
+        reward = float(i)
+        items.append((t, img, action, nt, nimg, reward))
+    return TrajectoryDataset(items, _tokenizer)
+
+
+class TestMultiModalWorldModel(unittest.TestCase):
+    def test_train_and_rollout(self):
+        cfg = MultiModalWorldModelConfig(vocab_size=32, img_channels=3, action_dim=3, embed_dim=16)
+        model = MultiModalWorldModel(cfg)
+        ds = _make_dataset(6)
+        before = model.obs_enc.text_emb.weight.clone()
+        train_world_model(model, ds, epochs=1, batch_size=2)
+        self.assertFalse(torch.allclose(before, model.obs_enc.text_emb.weight))
+        tokens, img, _, _, _, _ = ds[0]
+        start_t = tokens.unsqueeze(0)
+        start_i = img.unsqueeze(0)
+        policy = lambda s: torch.zeros(s.size(0), dtype=torch.long)
+        states, rewards = rollout(model, start_t, start_i, policy, steps=3)
+        self.assertEqual(len(states), 3)
+        self.assertEqual(len(rewards), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_world_model_rl.py
+++ b/tests/test_world_model_rl.py
@@ -1,0 +1,35 @@
+import unittest
+import torch
+from asi.world_model_rl import (
+    RLBridgeConfig,
+    TransitionDataset,
+    train_world_model,
+    rollout_policy,
+)
+
+
+def _make_dataset(n=6):
+    data = []
+    for i in range(n):
+        state = torch.randn(5)
+        action = i % 3
+        next_state = state + 0.1
+        reward = float(i)
+        data.append((state, action, next_state, reward))
+    return TransitionDataset(data)
+
+
+class TestWorldModelRL(unittest.TestCase):
+    def test_train_and_rollout(self):
+        cfg = RLBridgeConfig(state_dim=5, action_dim=3, hidden_dim=8, lr=0.01, batch_size=2, epochs=1)
+        ds = _make_dataset(8)
+        model = train_world_model(cfg, ds)
+        init = torch.zeros(5)
+        policy = lambda s: torch.zeros(s.size(0), dtype=torch.long)
+        states, rewards = rollout_policy(model, policy, init, steps=3)
+        self.assertEqual(len(states), 3)
+        self.assertEqual(len(rewards), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- test CrossModalFusion forward pass and helper utilities
- cover training and rollout for multimodal world model
- cover training and rollout for world_model_rl bridge
- document new test coverage in Implementation.md

## Testing
- `pytest -q tests/test_cross_modal_fusion.py tests/test_multimodal_world_model.py tests/test_world_model_rl.py` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6862bf5c2af88331a073bfcb6c95f4a7