### PR TITLE
Add unit tests for new modules

### DIFF
--- a/tests/test_cross_modal_fusion.py
+++ b/tests/test_cross_modal_fusion.py
@@ -1,0 +1,62 @@
+import unittest
+import torch
+
+from asi.cross_modal_fusion import (
+    CrossModalFusionConfig,
+    CrossModalFusion,
+    MultiModalDataset,
+    train_fusion_model,
+    encode_all,
+)
+
+
+def simple_tokenizer(text: str):
+    return [ord(c) % 50 for c in text]
+
+
+class TestCrossModalFusion(unittest.TestCase):
+    def setUp(self):
+        cfg = CrossModalFusionConfig(
+            vocab_size=50,
+            text_dim=16,
+            img_channels=3,
+            audio_channels=1,
+            latent_dim=8,
+            temperature=0.1,
+        )
+        self.model = CrossModalFusion(cfg)
+        img = torch.randn(3, 8, 8)
+        aud = torch.randn(1, 16)
+        self.dataset = MultiModalDataset(
+            [
+                ("a", img, aud),
+                ("b", img.clone(), aud.clone()),
+            ],
+            simple_tokenizer,
+        )
+
+    def test_forward_shapes(self):
+        tokens, img, aud = self.dataset[0]
+        tokens = tokens.unsqueeze(0)
+        img = img.unsqueeze(0)
+        aud = aud.unsqueeze(0)
+        t, i, a = self.model(tokens, img, aud)
+        self.assertEqual(t.shape, (1, 8))
+        self.assertEqual(i.shape, (1, 8))
+        self.assertEqual(a.shape, (1, 8))
+
+    def test_encode_all(self):
+        t_vecs, i_vecs, a_vecs = encode_all(self.model, self.dataset, batch_size=1)
+        self.assertEqual(t_vecs.shape, (2, 8))
+        self.assertEqual(i_vecs.shape, (2, 8))
+        self.assertEqual(a_vecs.shape, (2, 8))
+
+    def test_train_updates_params(self):
+        before = self.model.text_proj.fc.weight.clone()
+        train_fusion_model(self.model, self.dataset, epochs=1, batch_size=1)
+        after = self.model.text_proj.fc.weight
+        self.assertFalse(torch.allclose(before, after))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formal_verifier.py
+++ b/tests/test_formal_verifier.py
@@ -1,0 +1,38 @@
+import unittest
+import torch
+
+from asi.formal_verifier import (
+    check_grad_norm,
+    check_output_bounds,
+    verify_model,
+    VerificationResult,
+)
+
+
+class TestFormalVerifier(unittest.TestCase):
+    def test_check_grad_norm(self):
+        model = torch.nn.Linear(2, 1)
+        x = torch.ones(1, 2)
+        model(x).sum().backward()
+        ok, _ = check_grad_norm(model, max_norm=100.0)
+        self.assertTrue(ok)
+        ok, _ = check_grad_norm(model, max_norm=0.0)
+        self.assertFalse(ok)
+
+    def test_check_output_bounds(self):
+        output = torch.tensor([0.5, -0.2])
+        self.assertTrue(check_output_bounds(output, 1.0)[0])
+        self.assertFalse(check_output_bounds(output, 0.3)[0])
+
+    def test_verify_model(self):
+        checks = [lambda: (True, "ok1"), lambda: (True, "ok2")]
+        res = verify_model(torch.nn.Linear(1, 1), checks)
+        self.assertIsInstance(res, VerificationResult)
+        self.assertTrue(res.passed)
+        res_fail = verify_model(torch.nn.Linear(1, 1), [lambda: (False, "bad")])
+        self.assertFalse(res_fail.passed)
+        self.assertEqual(res_fail.messages[0], "bad")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multimodal_world_model.py
+++ b/tests/test_multimodal_world_model.py
@@ -1,0 +1,50 @@
+import unittest
+import torch
+
+from asi.multimodal_world_model import (
+    MultiModalWorldModelConfig,
+    MultiModalWorldModel,
+    TrajectoryDataset,
+    train_world_model,
+    rollout,
+)
+
+
+def simple_tokenizer(text: str):
+    return [ord(c) % 50 for c in text]
+
+
+class TestMultiModalWorldModel(unittest.TestCase):
+    def setUp(self):
+        cfg = MultiModalWorldModelConfig(vocab_size=50, img_channels=3, action_dim=5, embed_dim=8)
+        self.model = MultiModalWorldModel(cfg)
+        img = torch.randn(3, 8, 8)
+        entry = ("a", img, torch.tensor(0), "b", img.clone(), 0.0)
+        self.dataset = TrajectoryDataset([entry], simple_tokenizer)
+
+    def test_forward_shapes(self):
+        t, img, a, _, _, _ = self.dataset[0]
+        t = t.unsqueeze(0)
+        img = img.unsqueeze(0)
+        a = a.unsqueeze(0)
+        state, reward = self.model(t, img, a)
+        self.assertEqual(state.shape, (1, 8))
+        self.assertEqual(reward.shape, (1,))
+
+    def test_rollout(self):
+        start_t, start_img, _, _, _, _ = self.dataset[0]
+        policy = lambda s: torch.tensor(0, dtype=torch.long, device=s.device)
+        states, rewards = rollout(self.model, start_t, start_img, policy, steps=3)
+        self.assertEqual(len(states), 3)
+        self.assertEqual(len(rewards), 3)
+        self.assertEqual(states[0].shape, (8,))
+
+    def test_train_world_model(self):
+        before = self.model.dyn.reward_head.weight.clone()
+        train_world_model(self.model, self.dataset, epochs=1, batch_size=1)
+        after = self.model.dyn.reward_head.weight
+        self.assertFalse(torch.allclose(before, after))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_play_env.py
+++ b/tests/test_self_play_env.py
@@ -1,0 +1,26 @@
+import unittest
+import torch
+
+from asi.self_play_env import SimpleEnv, rollout_env
+
+
+class TestSelfPlayEnv(unittest.TestCase):
+    def test_step_and_reset(self):
+        env = SimpleEnv(state_dim=3)
+        obs = env.reset()
+        self.assertTrue(torch.allclose(obs, torch.zeros(3)))
+        step = env.step(torch.ones(3))
+        self.assertEqual(step.observation.shape, (3,))
+        self.assertIsInstance(step.reward, float)
+
+    def test_rollout_env(self):
+        env = SimpleEnv(state_dim=2)
+        policy = lambda obs: torch.zeros_like(obs)
+        obs_list, rewards = rollout_env(env, policy, steps=5)
+        self.assertEqual(len(obs_list), 1)
+        self.assertEqual(len(rewards), 1)
+        self.assertTrue(env.state.norm() < 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- test CrossModalFusion forward and training utility
- test MultiModalWorldModel forward, rollout, and training
- test SimpleEnv rollout helper
- test formal verifier helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6862bf56861c83318ddb7c843f6708fe