### PR TITLE
Add PR conflict checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ This repository experiments with algorithms needed for self-improving AI. The bi
 - `scripts/moe_vs_dense.py` benchmarks dense versus Mixture-of-Experts feed-forward layers.
 - `python -m src.paper_to_code` transpiles LaTeX pseudo-code to Python.
 - `python -m src.autobench` runs each test file in isolation and reports a summary.
+- `python -m src.pr_conflict_checker <owner>/<repo>` shows merge conflicts for open PRs.
 - `meta-rl-refactor` parses action/reward logs and suggests the next refactoring step.
 
 Example:
 
 ```bash
 meta-rl-refactor sample_log.csv
+python -m src.pr_conflict_checker owner/repo
 ```
 
 ## Setup

--- a/src/pr_conflict_checker.py
+++ b/src/pr_conflict_checker.py
@@ -1,0 +1,52 @@
+import subprocess
+from typing import Dict
+
+from .autobench import BenchResult, summarize_results
+from .pull_request_monitor import list_open_prs
+
+
+def check_pr_conflicts(repo: str, token: str | None = None, remote: str = "origin") -> Dict[str, BenchResult]:
+    """Return merge-conflict status for all open PRs."""
+    results: Dict[str, BenchResult] = {}
+    prs = list_open_prs(repo, token)
+    for pr in prs:
+        pr_ref = f"refs/pull/{pr['number']}/head"
+        local_ref = f"pr/{pr['number']}"
+        fetch = subprocess.run(
+            ["git", "fetch", remote, f"{pr_ref}:{local_ref}"],
+            capture_output=True,
+            text=True,
+        )
+        key = f"#{pr['number']} {pr['title']}"
+        if fetch.returncode != 0:
+            results[key] = BenchResult(False, fetch.stdout + fetch.stderr)
+            continue
+        base = subprocess.check_output(
+            ["git", "merge-base", f"{remote}/main", local_ref],
+            text=True,
+        ).strip()
+        merge = subprocess.run(
+            ["git", "merge-tree", base, f"{remote}/main", local_ref],
+            capture_output=True,
+            text=True,
+        )
+        conflict = "<<<<<<<" in merge.stdout
+        results[key] = BenchResult(not conflict, merge.stdout + merge.stderr)
+    return results
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Check merge conflicts for open PRs")
+    parser.add_argument("repo", help="<owner>/<repo>")
+    parser.add_argument("--token", default=None, help="GitHub token")
+    parser.add_argument("--remote", default="origin", help="Git remote to use")
+    args = parser.parse_args()
+
+    results = check_pr_conflicts(args.repo, args.token, args.remote)
+    print(summarize_results(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pr_conflict_checker.py
+++ b/tests/test_pr_conflict_checker.py
@@ -1,0 +1,71 @@
+import unittest
+import importlib.util
+import importlib.machinery
+import types
+from unittest.mock import patch
+import io
+import sys
+
+pkg = types.ModuleType('asi')
+pkg.__path__ = ['src']
+sys.modules.setdefault('asi', pkg)
+spec = importlib.util.spec_from_file_location('asi.pr_conflict_checker', 'src/pr_conflict_checker.py')
+pr_check = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pr_check)
+
+BenchResult = pr_check.BenchResult
+check_pr_conflicts = pr_check.check_pr_conflicts
+
+
+def fake_list_open_prs(repo, token=None):
+    return [
+        {"number": 1, "title": "Bug"},
+        {"number": 2, "title": "Feature"},
+    ]
+
+
+def fake_run(cmd, capture_output=True, text=True):
+    class Res:
+        def __init__(self, code=0, out="", err=""):
+            self.returncode = code
+            self.stdout = out
+            self.stderr = err
+    if cmd[1] == "fetch":
+        return Res()
+    if cmd[1] == "merge-tree":
+        if cmd[-1] == "pr/1":
+            return Res(0, "<<<<<<< HEAD\nconflict\n=======\n>>>>>>\n")
+        return Res()
+    return Res()
+
+
+def fake_check_output(cmd, text=True):
+    return "base\n"
+
+
+class TestPRConflictChecker(unittest.TestCase):
+    def test_check_pr_conflicts(self):
+        with patch.object(pr_check, 'list_open_prs', fake_list_open_prs), \
+             patch.object(pr_check.subprocess, 'run', fake_run), \
+             patch.object(pr_check.subprocess, 'check_output', fake_check_output):
+            results = check_pr_conflicts('owner/repo')
+        self.assertIn('#1 Bug', results)
+        self.assertFalse(results['#1 Bug'].passed)
+        self.assertIn('#2 Feature', results)
+        self.assertTrue(results['#2 Feature'].passed)
+
+    def test_main_outputs_summary(self):
+        with patch.object(pr_check, 'list_open_prs', fake_list_open_prs), \
+             patch.object(pr_check.subprocess, 'run', fake_run), \
+             patch.object(pr_check.subprocess, 'check_output', fake_check_output):
+            buf = io.StringIO()
+            with patch.object(sys, 'stdout', buf), \
+                 patch.object(sys, 'argv', ['pr_conflict_checker', 'owner/repo']):
+                pr_check.main()
+            out = buf.getvalue()
+        self.assertIn('Passed 1/2 modules', out)
+        self.assertIn('#1 Bug', out)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add pr_conflict_checker module for detecting merge conflicts
- integrate with AutoBench summary format
- test merge conflict detection
- document pr_conflict_checker usage

## Testing
- `pytest tests/test_autobench.py tests/test_pull_request_monitor.py tests/test_pr_conflict_checker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862bf52b60c8331ad5b856168e8ca06