### PR TITLE
Add self-play skill loop module

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -349,6 +349,8 @@ To reproduce the toy run step by step:
 
 - The orchestrator in `src/self_play_skill_loop.py` will alternate `self_play_env.rollout_env()` with `robot_skill_transfer.transfer_skills()`.
 - Each cycle logs rewards and fine-tunes policies on a small batch of real examples.
+- `run_loop()` returns the mean reward from each cycle and the final trained policy.
+- `main()` exposes a `self-play-loop` CLI entry that prints these rewards.
 
 ## A-9 Automated PR Conflict Checks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,5 @@ packages = ["asi"]
 
 [project.scripts]
 meta-rl-refactor = "asi.meta_rl_refactor:main"
+self-play-loop = "asi.self_play_skill_loop:main"
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -66,3 +66,4 @@ from .embodied_calibration import (
     calibrate,
 )
 from .lora_quant import LoRAQuantLinear, apply_quant_lora
+from .self_play_skill_loop import SelfPlaySkillLoopConfig, run_loop as run_self_play_skill_loop

--- a/src/self_play_skill_loop.py
+++ b/src/self_play_skill_loop.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence, Tuple, List
+
+import torch
+
+from .self_play_env import SimpleEnv, rollout_env
+from .robot_skill_transfer import (
+    SkillTransferConfig,
+    VideoPolicyDataset,
+    SkillTransferModel,
+    transfer_skills,
+)
+
+
+@dataclass
+class SelfPlaySkillLoopConfig:
+    """Configuration for the integrated self-play and skill transfer loop."""
+
+    env_state_dim: int = 4
+    img_channels: int = 3
+    action_dim: int = 2
+    hidden_dim: int = 128
+    lr: float = 1e-4
+    batch_size: int = 16
+    epochs: int = 1
+    steps: int = 20
+    cycles: int = 3
+
+
+def run_loop(
+    cfg: SelfPlaySkillLoopConfig,
+    policy: Callable[[torch.Tensor], torch.Tensor],
+    frames: Iterable[torch.Tensor],
+    actions: Iterable[int],
+) -> Tuple[List[float], SkillTransferModel]:
+    """Run integrated self-play and skill transfer cycles.
+
+    Returns the average reward per cycle and the final trained model.
+    """
+    env = SimpleEnv(cfg.env_state_dim)
+    dataset = VideoPolicyDataset(frames, actions)
+    transfer_cfg = SkillTransferConfig(
+        img_channels=cfg.img_channels,
+        action_dim=cfg.action_dim,
+        hidden_dim=cfg.hidden_dim,
+        lr=cfg.lr,
+        epochs=cfg.epochs,
+        batch_size=cfg.batch_size,
+    )
+    history: List[float] = []
+    current_policy = policy
+    model: SkillTransferModel | None = None
+    for _ in range(cfg.cycles):
+        _, rewards = rollout_env(env, current_policy, steps=cfg.steps)
+        history.append(sum(rewards) / len(rewards) if rewards else 0.0)
+        model = transfer_skills(transfer_cfg, dataset)
+
+        def new_policy(obs: torch.Tensor, m: SkillTransferModel = model) -> torch.Tensor:
+            with torch.no_grad():
+                logits = m(obs.unsqueeze(0))
+                return logits.argmax(dim=-1).squeeze(0)
+
+        current_policy = new_policy
+    assert model is not None
+    return history, model
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Command line interface for running a toy self-play skill loop."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run self-play skill loop")
+    parser.add_argument("--cycles", type=int, default=3)
+    parser.add_argument("--steps", type=int, default=20)
+    args = parser.parse_args(argv)
+
+    cfg = SelfPlaySkillLoopConfig(cycles=args.cycles, steps=args.steps)
+    policy = lambda obs: torch.zeros_like(obs)
+    frames = [torch.randn(cfg.img_channels, 8, 8) for _ in range(4)]
+    actions = [0 for _ in frames]
+    rewards, _ = run_loop(cfg, policy, frames, actions)
+    for i, r in enumerate(rewards):
+        print(f"Cycle {i}: mean reward {r:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_self_play_skill_loop.py
+++ b/tests/test_self_play_skill_loop.py
@@ -1,0 +1,41 @@
+import os
+import importlib.util
+import unittest
+from unittest.mock import patch
+import torch
+
+spec = importlib.util.spec_from_file_location("self_play_skill_loop", os.path.join(os.path.dirname(__file__), "..", "src", "self_play_skill_loop.py"))
+self_play_skill_loop = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(self_play_skill_loop)
+run_loop = self_play_skill_loop.run_loop
+SelfPlaySkillLoopConfig = self_play_skill_loop.SelfPlaySkillLoopConfig
+
+
+class TestSelfPlaySkillLoop(unittest.TestCase):
+    def test_run_loop_mocked(self):
+        cfg = SelfPlaySkillLoopConfig(cycles=2, steps=3, epochs=1)
+        frames = [torch.randn(cfg.img_channels, 4, 4) for _ in range(2)]
+        actions = [0, 1]
+
+        def fake_rollout(env, policy, steps=3):
+            obs = [torch.zeros(env.state.shape) for _ in range(steps)]
+            rewards = [1.0] * steps
+            return obs, rewards
+
+        class DummyModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.zeros(x.size(0), cfg.action_dim)
+
+        def fake_transfer(c, d):
+            return DummyModel()
+
+        policy = lambda obs: torch.zeros_like(obs)
+        with patch.object(self_play_skill_loop, "rollout_env", fake_rollout), patch.object(self_play_skill_loop, "transfer_skills", fake_transfer):
+            rewards, model = run_loop(cfg, policy, frames, actions)
+        self.assertEqual(len(rewards), 2)
+        self.assertIsInstance(model, DummyModel)
+        self.assertTrue(all(r == 1.0 for r in rewards))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `self_play_skill_loop` orchestrator
- expose `self-play-loop` CLI entry
- import new loop from package init
- test the loop with mocked environment
- document workflow in Implementation notes

## Testing
- `pip install -q numpy torch faiss-cpu aiohttp` *(fails: no output)*
- `pytest -q` *(fails: ModuleNotFoundError for numpy/torch)*

------
https://chatgpt.com/codex/tasks/task_e_6862bf4e7df883319cadbf22700bc22f