### PR TITLE
Update fusion training lr and fix LoRA patch

### DIFF
--- a/src/cross_modal_fusion.py
+++ b/src/cross_modal_fusion.py
@@ -95,6 +95,7 @@ class CrossModalFusion(nn.Module):
 
     def __init__(self, cfg: CrossModalFusionConfig) -> None:
         super().__init__()
+        self.cfg = cfg
         self.text_enc = TextEncoder(cfg.vocab_size, cfg.text_dim)
         self.img_enc = ImageEncoder(cfg.img_channels, cfg.text_dim)
         self.audio_enc = AudioEncoder(cfg.audio_channels, cfg.text_dim)
@@ -139,7 +140,7 @@ def train_fusion_model(
 ) -> None:
     """Train model using CLIP-style contrastive loss."""
     loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
-    opt = torch.optim.Adam(model.parameters(), lr=model.temperature)
+    opt = torch.optim.Adam(model.parameters(), lr=model.cfg.lr)
     device = next(model.parameters()).device
     model.train()
     for _ in range(epochs):

--- a/src/lora_quant.py
+++ b/src/lora_quant.py
@@ -90,10 +90,13 @@ def apply_quant_lora(model: nn.Module, target_modules: Sequence[str], r: int = 4
     for name, module in model.named_modules():
         for tgt in target_modules:
             if name.endswith(tgt) and isinstance(module, nn.Linear):
-                parent_name = name.rsplit(".", 1)[0]
+                if "." in name:
+                    parent_name, attr = name.rsplit(".", 1)
+                else:
+                    parent_name, attr = "", name
                 parent = model
                 if parent_name:
-                    for attr in parent_name.split("."):
-                        parent = getattr(parent, attr)
-                setattr(parent, tgt, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
+                    for part in parent_name.split("."):
+                        parent = getattr(parent, part)
+                setattr(parent, attr, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
     return model

--- a/tests/test_cross_modal_fusion.py
+++ b/tests/test_cross_modal_fusion.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch
+import torch
+
+from asi.cross_modal_fusion import (
+    CrossModalFusionConfig,
+    CrossModalFusion,
+    MultiModalDataset,
+    train_fusion_model,
+)
+
+
+class TestCrossModalFusion(unittest.TestCase):
+    def test_train_uses_cfg_lr(self):
+        cfg = CrossModalFusionConfig(
+            vocab_size=10,
+            text_dim=8,
+            img_channels=1,
+            audio_channels=1,
+            latent_dim=2,
+            lr=0.123,
+        )
+        model = CrossModalFusion(cfg)
+
+        def tokenizer(x):
+            return [0, 1]
+
+        dataset = MultiModalDataset(
+            [("a", torch.zeros(1, 32, 32), torch.zeros(1, 16))], tokenizer
+        )
+
+        with patch("torch.optim.Adam") as AdamMock:
+            opt = AdamMock.return_value
+            train_fusion_model(model, dataset, epochs=1, batch_size=1)
+            self.assertEqual(AdamMock.call_args.kwargs["lr"], cfg.lr)
+            assert opt.step.called
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- store training config inside `CrossModalFusion`
- use `model.cfg.lr` when constructing the optimizer
- fix `apply_quant_lora` to properly replace top-level modules
- add a regression test for the fusion trainer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862bf1368b8833185b00d484897f213