### PR TITLE
Add PR conflict checker with tests

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -66,3 +66,4 @@ from .embodied_calibration import (
     calibrate,
 )
 from .lora_quant import LoRAQuantLinear, apply_quant_lora
+from .pr_conflict_checker import check_pr_conflicts

--- a/src/lora_quant.py
+++ b/src/lora_quant.py
@@ -90,10 +90,14 @@ def apply_quant_lora(model: nn.Module, target_modules: Sequence[str], r: int = 4
     for name, module in model.named_modules():
         for tgt in target_modules:
             if name.endswith(tgt) and isinstance(module, nn.Linear):
-                parent_name = name.rsplit(".", 1)[0]
+                parts = name.split(".")
                 parent = model
-                if parent_name:
-                    for attr in parent_name.split("."):
-                        parent = getattr(parent, attr)
-                setattr(parent, tgt, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
+                for attr in parts[:-1]:
+                    parent = getattr(parent, attr)
+                attr_name = parts[-1]
+                setattr(
+                    parent,
+                    attr_name,
+                    LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout),
+                )
     return model

--- a/src/pr_conflict_checker.py
+++ b/src/pr_conflict_checker.py
@@ -1,0 +1,78 @@
+import subprocess
+from typing import Dict
+from pathlib import Path
+
+from .pull_request_monitor import list_open_prs
+from .autobench import BenchResult, summarize_results
+
+
+def _run_git(args: list[str], cwd: Path) -> str:
+    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    proc.check_returncode()
+    return proc.stdout.strip()
+
+
+def _check_branch_conflict(base: str, branch: str, cwd: Path) -> tuple[bool, str]:
+    base_rev = _run_git(["merge-base", base, branch], cwd)
+    proc = subprocess.run(
+        ["git", "merge-tree", base_rev, base, branch],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    output = proc.stdout
+    return ("<<<<<<<" in output), output
+
+
+def check_pr_conflicts(
+    repo: str,
+    token: str | None = None,
+    base: str = "main",
+    remote: str = "origin",
+    repo_path: str | Path = ".",
+) -> Dict[str, BenchResult]:
+    """Fetch open PRs and check if they merge cleanly with ``base``."""
+    cwd = Path(repo_path)
+    prs = list_open_prs(repo, token)
+    results: Dict[str, BenchResult] = {}
+    for pr in prs:
+        branch_name = f"pr_{pr['number']}"
+        subprocess.run(
+            ["git", "fetch", remote, f"refs/pull/{pr['number']}/head:{branch_name}"],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        conflict, out = _check_branch_conflict(base, branch_name, cwd)
+        results[f"PR {pr['number']}"] = BenchResult(not conflict, out)
+    return results
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Check merge conflicts for open PRs")
+    parser.add_argument("repo", help="<owner>/<repo> to query")
+    parser.add_argument("--token", default=None, help="GitHub token")
+    parser.add_argument("--base", default="main", help="Base branch to merge into")
+    parser.add_argument("--remote", default="origin", help="Remote name")
+    parser.add_argument(
+        "--repo-path",
+        default=".",
+        help="Path to the local clone of the repository",
+    )
+    args = parser.parse_args()
+
+    results = check_pr_conflicts(
+        args.repo,
+        token=args.token,
+        base=args.base,
+        remote=args.remote,
+        repo_path=args.repo_path,
+    )
+    print(summarize_results(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pr_conflict_checker.py
+++ b/tests/test_pr_conflict_checker.py
@@ -1,0 +1,69 @@
+import os
+import tempfile
+import unittest
+import subprocess
+import sys
+from unittest.mock import patch
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+from asi.pr_conflict_checker import check_pr_conflicts
+from autobench import summarize_results
+
+
+def git(cmd, cwd):
+    subprocess.run(cmd, cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+class TestPRConflictChecker(unittest.TestCase):
+    def setUp(self):
+        self.remote = tempfile.mkdtemp()
+        git(['git', 'init', '--bare', self.remote], cwd=self.remote)
+        self.repo = tempfile.mkdtemp()
+        git(['git', 'init'], cwd=self.repo)
+        git(['git', 'config', 'user.email', 'a@b.c'], cwd=self.repo)
+        git(['git', 'config', 'user.name', 'test'], cwd=self.repo)
+        git(['git', 'remote', 'add', 'origin', self.remote], cwd=self.repo)
+        with open(os.path.join(self.repo, 'file.txt'), 'w') as f:
+            f.write('base\n')
+        git(['git', 'add', 'file.txt'], cwd=self.repo)
+        git(['git', 'commit', '-m', 'init'], cwd=self.repo)
+        git(['git', 'branch', '-M', 'main'], cwd=self.repo)
+        git(['git', 'push', 'origin', 'main'], cwd=self.repo)
+        self.first_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=self.repo).decode().strip()
+        git(['git', 'checkout', '-b', 'feature_no_conflict'], cwd=self.repo)
+        with open(os.path.join(self.repo, 'another.txt'), 'w') as f:
+            f.write('hi\n')
+        git(['git', 'add', 'another.txt'], cwd=self.repo)
+        git(['git', 'commit', '-m', 'feature_no_conflict'], cwd=self.repo)
+        git(['git', 'push', 'origin', 'feature_no_conflict:refs/pull/1/head'], cwd=self.repo)
+        git(['git', 'checkout', 'main'], cwd=self.repo)
+        with open(os.path.join(self.repo, 'file.txt'), 'w') as f:
+            f.write('mainline\n')
+        git(['git', 'add', 'file.txt'], cwd=self.repo)
+        git(['git', 'commit', '-m', 'main_change'], cwd=self.repo)
+        git(['git', 'push', 'origin', 'main'], cwd=self.repo)
+        git(['git', 'checkout', self.first_commit, '-b', 'feature_conflict'], cwd=self.repo)
+        with open(os.path.join(self.repo, 'file.txt'), 'w') as f:
+            f.write('pr_branch\n')
+        git(['git', 'add', 'file.txt'], cwd=self.repo)
+        git(['git', 'commit', '-m', 'feature_conflict'], cwd=self.repo)
+        git(['git', 'push', 'origin', 'feature_conflict:refs/pull/2/head'], cwd=self.repo)
+
+    def tearDown(self):
+        subprocess.run(['rm', '-rf', self.repo, self.remote])
+
+    def test_check_pr_conflicts(self):
+        prs = [{'number': 1, 'title': 'clean'}, {'number': 2, 'title': 'conflict'}]
+        with patch('asi.pr_conflict_checker.list_open_prs', return_value=prs):
+            results = check_pr_conflicts('dummy/repo', repo_path=self.repo)
+        self.assertTrue(results['PR 1'].passed)
+        self.assertFalse(results['PR 2'].passed)
+        summary = summarize_results(results)
+        self.assertIn('Passed 1/2 modules', summary)
+        self.assertIn('PR 1: PASS', summary)
+        self.assertIn('PR 2: FAIL', summary)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `pr_conflict_checker` to test merging PR branches
- export `check_pr_conflicts` in the package
- fix `apply_quant_lora` to correctly replace modules
- test conflict detection using temporary repos

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862bf0f44208331be977a106a0cf636