### PR TITLE
Add self-play skill loop orchestrator

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -347,8 +347,8 @@ To reproduce the toy run step by step:
 
 ## A-8 Integrated Self-Play & Skill Transfer
 
-- The orchestrator in `src/self_play_skill_loop.py` will alternate `self_play_env.rollout_env()` with `robot_skill_transfer.transfer_skills()`.
-- Each cycle logs rewards and fine-tunes policies on a small batch of real examples.
+- The orchestrator in `src/self_play_skill_loop.py` alternates `self_play_env.rollout_env()` with `robot_skill_transfer.transfer_skills()` and logs the reward trajectory for each cycle.
+- Each cycle fine-tunes policies on a small batch of real examples.
 
 ## A-9 Automated PR Conflict Checks
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -39,6 +39,7 @@ from .robot_skill_transfer import (
     transfer_skills,
 )
 from .self_play_env import EnvStep, SimpleEnv, rollout_env
+from .self_play_skill_loop import self_play_skill_loop
 from .formal_verifier import (
     VerificationResult,
     check_grad_norm,

--- a/src/self_play_skill_loop.py
+++ b/src/self_play_skill_loop.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+import torch
+
+from .self_play_env import SimpleEnv, rollout_env
+from .robot_skill_transfer import (
+    SkillTransferConfig,
+    VideoPolicyDataset,
+    transfer_skills,
+)
+
+
+
+def self_play_skill_loop(
+    env: SimpleEnv,
+    policy: Callable[[torch.Tensor], torch.Tensor],
+    skill_cfg: SkillTransferConfig,
+    real_dataset: VideoPolicyDataset,
+    cycles: int = 3,
+    steps: int = 20,
+) -> list[list[float]]:
+    """Run alternating self-play and skill transfer cycles.
+
+    Each cycle runs ``rollout_env`` to generate a reward trajectory then
+    fine-tunes the policy using ``transfer_skills`` on ``real_dataset``.
+    The reward trajectory for each cycle is logged and returned.
+    """
+
+    reward_logs: list[list[float]] = []
+    for i in range(cycles):
+        _, rewards = rollout_env(env, policy, steps=steps)
+        logging.info("cycle %d rewards: %s", i, rewards)
+        reward_logs.append(rewards)
+        transfer_skills(skill_cfg, real_dataset)
+    return reward_logs
+
+
+__all__ = ["self_play_skill_loop"]

--- a/tests/test_self_play_skill_loop.py
+++ b/tests/test_self_play_skill_loop.py
@@ -1,0 +1,27 @@
+import unittest
+import torch
+
+from asi.self_play_skill_loop import self_play_skill_loop
+from asi.self_play_env import SimpleEnv
+from asi.robot_skill_transfer import SkillTransferConfig, VideoPolicyDataset
+
+
+class TestSelfPlaySkillLoop(unittest.TestCase):
+    def test_one_cycle(self):
+        env = SimpleEnv(state_dim=2)
+
+        def policy(obs: torch.Tensor) -> torch.Tensor:
+            return torch.ones_like(obs) * 0.05
+
+        cfg = SkillTransferConfig(img_channels=1, action_dim=2, epochs=1, batch_size=2)
+        frames = [torch.randn(1, 4, 4) for _ in range(4)]
+        actions = [0, 1, 0, 1]
+        dataset = VideoPolicyDataset(frames, actions)
+
+        rewards = self_play_skill_loop(env, policy, cfg, dataset, cycles=1, steps=5)
+        self.assertEqual(len(rewards), 1)
+        self.assertGreater(len(rewards[0]), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `self_play_skill_loop` alternating rollouts and fine-tuning
- expose it in the package and document its workflow
- test one integrated training cycle

## Testing
- `pytest tests/test_self_play_skill_loop.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6862bf0d6c3883319130586d030238d0