### PR TITLE
Add data ingestion pipeline

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -382,8 +382,10 @@ To reproduce the toy run step by step:
 
 ## M-4 Cross-Modal Data Ingestion Pipeline
 
-- `src/data_ingest.py` will align text, image and audio pairs from open datasets.
-- Augmentation helpers generate crops and transcripts for training the multi-modal world model.
+- `src/data_ingest.py` downloads open datasets and aligns text, image and audio files.
+- `load_pairs()` returns matching triples and `ingest_samples()` applies random
+  crops and optional audio transcription so the samples can feed
+  `cross_modal_fusion.py` and `multimodal_world_model.py`.
 
 ## Research workflow
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torch
 faiss-cpu
 # optional: flash-attn for FlashAttention-3 support
 aiohttp
+pillow

--- a/src/data_ingest.py
+++ b/src/data_ingest.py
@@ -1,0 +1,126 @@
+import os
+import random
+import tarfile
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import numpy as np
+import torch
+
+try:
+    from PIL import Image
+except Exception:  # pragma: no cover - optional dependency
+    Image = None  # type: ignore
+
+
+def download_dataset(url: str, dest: str | Path) -> Path:
+    """Download and extract an archive if ``dest`` doesn't already exist."""
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    filename = dest / Path(url).name
+    if not filename.exists():
+        urllib.request.urlretrieve(url, filename)
+    if filename.suffix in {".zip"}:
+        with zipfile.ZipFile(filename, "r") as zf:
+            zf.extractall(dest)
+    elif filename.suffix in {".tar", ".gz", ".tgz"}:
+        with tarfile.open(filename) as tf:
+            tf.extractall(dest)
+    return dest
+
+
+def _load_image(path: Path) -> torch.Tensor:
+    if Image is None:
+        raise ImportError("Pillow is required for image loading")
+    img = Image.open(path).convert("RGB")
+    arr = np.array(img, dtype=np.float32) / 255.0
+    return torch.from_numpy(arr).permute(2, 0, 1)
+
+
+def _load_audio(path: Path) -> torch.Tensor:
+    import wave
+
+    with wave.open(str(path), "rb") as wf:
+        frames = wf.readframes(wf.getnframes())
+        sampwidth = wf.getsampwidth()
+        dtype = {1: np.uint8, 2: np.int16, 4: np.int32}[sampwidth]
+        arr = np.frombuffer(frames, dtype=dtype).astype(np.float32)
+        arr = arr.reshape(-1, wf.getnchannels()).T
+        arr /= float(np.iinfo(dtype).max or 1)
+        return torch.from_numpy(arr)
+
+
+def transcribe_audio(path: str | Path) -> str:
+    """Return a transcript using ``speech_recognition`` if available."""
+    try:
+        import speech_recognition as sr  # pragma: no cover - heavy optional dep
+    except Exception:
+        return ""
+    recog = sr.Recognizer()
+    with sr.AudioFile(str(path)) as src:
+        audio = recog.record(src)
+    try:
+        return recog.recognize_google(audio)
+    except Exception:
+        return ""
+
+
+def random_crop(img: torch.Tensor, size: Tuple[int, int]) -> torch.Tensor:
+    """Randomly crop ``img`` (C, H, W) to ``size``."""
+    _, h, w = img.shape
+    th, tw = size
+    if h < th or w < tw:
+        raise ValueError("crop size larger than image")
+    i = random.randint(0, h - th)
+    j = random.randint(0, w - tw)
+    return img[:, i : i + th, j : j + tw]
+
+
+@dataclass
+class ModalSample:
+    text: str
+    image: torch.Tensor
+    audio: torch.Tensor
+
+
+def load_pairs(data_dir: str | Path, transcripts: bool = False) -> List[ModalSample]:
+    """Load and align ``text``/``image``/``audio`` files under ``data_dir``."""
+    base = Path(data_dir)
+    texts = {p.stem: p for p in (base / "texts").glob("*.txt")}
+    images = {p.stem: p for p in (base / "images").iterdir() if p.is_file()}
+    audios = {p.stem: p for p in (base / "audio").iterdir() if p.is_file()}
+    keys = texts.keys() & images.keys() & audios.keys()
+    items: List[ModalSample] = []
+    for k in sorted(keys):
+        text = texts[k].read_text().strip()
+        if transcripts:
+            text = f"{text} {transcribe_audio(audios[k])}".strip()
+        img = _load_image(images[k])
+        aud = _load_audio(audios[k])
+        items.append(ModalSample(text, img, aud))
+    return items
+
+
+def ingest_samples(
+    data_dir: str | Path,
+    crop_size: Tuple[int, int] | None = (224, 224),
+    transcripts: bool = True,
+) -> Iterable[Tuple[str, torch.Tensor, torch.Tensor]]:
+    """Yield augmented samples suitable for the fusion and world models."""
+    for sample in load_pairs(data_dir, transcripts=transcripts):
+        img = random_crop(sample.image, crop_size) if crop_size else sample.image
+        yield sample.text, img, sample.audio
+
+
+__all__ = [
+    "download_dataset",
+    "load_pairs",
+    "ingest_samples",
+    "transcribe_audio",
+    "random_crop",
+    "ModalSample",
+]
+

--- a/src/lora_quant.py
+++ b/src/lora_quant.py
@@ -90,10 +90,9 @@ def apply_quant_lora(model: nn.Module, target_modules: Sequence[str], r: int = 4
     for name, module in model.named_modules():
         for tgt in target_modules:
             if name.endswith(tgt) and isinstance(module, nn.Linear):
-                parent_name = name.rsplit(".", 1)[0]
+                parts = name.split(".")
                 parent = model
-                if parent_name:
-                    for attr in parent_name.split("."):
-                        parent = getattr(parent, attr)
-                setattr(parent, tgt, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
+                for attr in parts[:-1]:
+                    parent = getattr(parent, attr)
+                setattr(parent, parts[-1], LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
     return model


### PR DESCRIPTION
## Summary
- create `data_ingest.py` for aligned multi-modal datasets
- reference ingestion pipeline in implementation docs
- install Pillow for image support
- fix LoRA quantization helper to correctly replace modules

## Testing
- `pip install numpy torch faiss-cpu aiohttp >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c1ea24308331b6ceb94d642225f1