### PR TITLE
Add automated PR conflict checker

### DIFF
--- a/docs/merge_conflict.md
+++ b/docs/merge_conflict.md
@@ -54,6 +54,19 @@ git diff upstream/main..FETCH_HEAD
 
 This shows any changes not yet in `upstream/main`. After merging the branch
 locally, run `git merge-base` or `git status` to detect conflicts.
+
+## 4. Run the Automated Checker
+
+The repository provides a small helper script that summarizes conflict status
+for every open pull request. It fetches each PR branch, runs `git merge-base`
+and `git merge-tree`, then prints an AutoBench-style table.
+
+```bash
+python -m src.pr_conflict_checker letapicode/ASI
+```
+
+Set `--token` to a GitHub token for higher API limits and `--remote` if your
+PRs live on a remote other than `origin`.
 ---
 
 ## Handling Giant PR and Individual Task PRs

--- a/src/pr_conflict_checker.py
+++ b/src/pr_conflict_checker.py
@@ -1,0 +1,65 @@
+import subprocess
+from typing import Dict, List
+
+from pull_request_monitor import list_open_prs
+
+
+def fetch_pr(remote: str, pr_number: int) -> None:
+    """Fetch the pull request head locally."""
+    subprocess.run(
+        ["git", "fetch", remote, f"pull/{pr_number}/head:pr/{pr_number}"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def pr_has_conflict(pr_number: int, remote: str = "origin") -> bool:
+    """Return True if merging the PR into main would conflict."""
+    fetch_pr(remote, pr_number)
+    merge_base = (
+        subprocess.check_output(["git", "merge-base", "main", f"pr/{pr_number}"])
+        .decode()
+        .strip()
+    )
+    proc = subprocess.run(
+        ["git", "merge-tree", merge_base, "main", f"pr/{pr_number}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return "<<<<<<<" in proc.stdout or ">>>>>>>" in proc.stdout
+
+
+def check_all_prs(repo: str, token: str | None = None, remote: str = "origin") -> Dict[int, bool]:
+    """Return a mapping of PR number to conflict status."""
+    prs = list_open_prs(repo, token)
+    return {pr["number"]: pr_has_conflict(pr["number"], remote) for pr in prs}
+
+
+def summarize_conflicts(prs: List[Dict[str, str]], conflicts: Dict[int, bool]) -> str:
+    """Return formatted scoreboard of conflict status."""
+    total = len(prs)
+    conflict_count = sum(1 for c in conflicts.values() if c)
+    lines = [f"Conflicts in {conflict_count}/{total} PRs"]
+    for pr in prs:
+        status = "CONFLICT" if conflicts[pr["number"]] else "NO CONFLICT"
+        lines.append(f"#{pr['number']} {pr['title']}: {status}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Check open PRs for merge conflicts")
+    parser.add_argument("repo", help="<owner>/<repo> to query")
+    parser.add_argument("--token", default=None, help="GitHub token")
+    parser.add_argument("--remote", default="origin", help="Git remote to fetch PRs from")
+    args = parser.parse_args()
+
+    prs = list_open_prs(args.repo, args.token)
+    conflicts = {pr["number"]: pr_has_conflict(pr["number"], args.remote) for pr in prs}
+    print(summarize_conflicts(prs, conflicts))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pr_conflict_checker.py
+++ b/tests/test_pr_conflict_checker.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import patch
+import importlib.util
+import os
+
+spec = importlib.util.spec_from_file_location(
+    'pr_conflict_checker', os.path.join(os.path.dirname(__file__), '..', 'src', 'pr_conflict_checker.py')
+)
+prcc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(prcc)
+
+list_open_prs = prcc.list_open_prs
+pr_has_conflict = prcc.pr_has_conflict
+summarize_conflicts = prcc.summarize_conflicts
+
+
+class TestPRConflictChecker(unittest.TestCase):
+    def test_summarize_conflicts(self):
+        prs = [
+            {'number': 1, 'title': 'Fix bug'},
+            {'number': 2, 'title': 'Add feature'},
+        ]
+        conflicts = {1: True, 2: False}
+        summary = summarize_conflicts(prs, conflicts)
+        self.assertIn('Conflicts in 1/2 PRs', summary)
+        self.assertIn('#1 Fix bug: CONFLICT', summary)
+        self.assertIn('#2 Add feature: NO CONFLICT', summary)
+
+    def test_check_all_prs(self):
+        prs = [
+            {'number': 1, 'title': 'Fix bug'},
+            {'number': 2, 'title': 'Add feature'},
+        ]
+        with patch.object(prcc, 'list_open_prs', return_value=prs), \
+             patch.object(prcc, 'fetch_pr'), \
+             patch.object(prcc.subprocess, 'check_output', return_value=b'base'), \
+             patch.object(prcc.subprocess, 'run') as mock_run:
+            mock_run.return_value.stdout = '<<<<<\n'
+            conflicts = prcc.check_all_prs('owner/repo')
+        self.assertEqual(conflicts[1], True)
+        self.assertEqual(conflicts[2], True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `src/pr_conflict_checker.py` for detecting merge conflicts
- document usage in `docs/merge_conflict.md`
- add unit tests for the conflict checker

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asi')*

------
https://chatgpt.com/codex/tasks/task_e_6862c1e776e8833191f78b45dae45b5d