### PR TITLE
Implement self-play skill loop orchestrator

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -347,8 +347,8 @@ To reproduce the toy run step by step:
 
 ## A-8 Integrated Self-Play & Skill Transfer
 
-- The orchestrator in `src/self_play_skill_loop.py` will alternate `self_play_env.rollout_env()` with `robot_skill_transfer.transfer_skills()`.
-- Each cycle logs rewards and fine-tunes policies on a small batch of real examples.
+- `src/self_play_skill_loop.py` provides `run_loop()` which alternates `self_play_env.rollout_env()` with `robot_skill_transfer.transfer_skills()`.
+- Episode rewards and training accuracy are printed each cycle and the helper can be run via `python -m src.self_play_skill_loop`.
 
 ## A-9 Automated PR Conflict Checks
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -39,6 +39,7 @@ from .robot_skill_transfer import (
     transfer_skills,
 )
 from .self_play_env import EnvStep, SimpleEnv, rollout_env
+from .self_play_skill_loop import run_loop as run_self_play_skill_loop
 from .formal_verifier import (
     VerificationResult,
     check_grad_norm,

--- a/src/lora_quant.py
+++ b/src/lora_quant.py
@@ -88,12 +88,12 @@ def apply_quant_lora(model: nn.Module, target_modules: Sequence[str], r: int = 4
         Optional dropout probability for the injected adapters.
     """
     for name, module in model.named_modules():
-        for tgt in target_modules:
-            if name.endswith(tgt) and isinstance(module, nn.Linear):
-                parent_name = name.rsplit(".", 1)[0]
-                parent = model
-                if parent_name:
-                    for attr in parent_name.split("."):
-                        parent = getattr(parent, attr)
-                setattr(parent, tgt, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
+        if any(name.endswith(tgt) and isinstance(module, nn.Linear) for tgt in target_modules):
+            parent = model
+            attr = name
+            if "." in name:
+                parent_name, attr = name.rsplit(".", 1)
+                for part in parent_name.split("."):
+                    parent = getattr(parent, part)
+            setattr(parent, attr, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
     return model

--- a/src/self_play_skill_loop.py
+++ b/src/self_play_skill_loop.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+from typing import Callable
+
+import torch
+
+from .self_play_env import SimpleEnv, rollout_env
+from .robot_skill_transfer import (
+    SkillTransferConfig,
+    VideoPolicyDataset,
+    transfer_skills,
+)
+
+
+def run_loop(
+    cycles: int,
+    env: SimpleEnv,
+    policy: Callable[[torch.Tensor], torch.Tensor],
+    dataset: VideoPolicyDataset,
+    cfg: SkillTransferConfig,
+) -> None:
+    """Alternate self-play rollouts with skill transfer fine-tuning."""
+    for i in range(cycles):
+        _, rewards = rollout_env(env, policy)
+        avg_reward = sum(rewards) / len(rewards)
+        model = transfer_skills(cfg, dataset)
+        with torch.no_grad():
+            frames = torch.stack([f for f, _ in dataset])
+            actions = torch.tensor([a for _, a in dataset])
+            preds = model(frames).argmax(dim=1)
+            accuracy = (preds == actions).float().mean().item()
+        print(f"Cycle {i+1}: reward {avg_reward:.3f}, skill acc {accuracy:.3f}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run self-play skill loop")
+    parser.add_argument("--cycles", type=int, default=3)
+    args = parser.parse_args(argv)
+
+    env = SimpleEnv(state_dim=4)
+
+    def policy(obs: torch.Tensor) -> torch.Tensor:
+        return torch.randn_like(obs) * 0.1
+
+    frames = torch.randn(8, 3, 32, 32)
+    actions = torch.randint(0, 5, (8,))
+    dataset = VideoPolicyDataset(frames, actions)
+    cfg = SkillTransferConfig(img_channels=3, action_dim=5, epochs=1)
+    run_loop(args.cycles, env, policy, dataset, cfg)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `self_play_skill_loop.py` with `run_loop()` entry point
- expose loop via package `run_self_play_skill_loop`
- fix `apply_quant_lora()` replacement logic
- document self-play & skill transfer workflow

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c1e64a688331b7754548540d11e7