### PR TITLE
Integrate gRPC memory server and metric harness

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -327,12 +327,7 @@ To reproduce the toy run step by step:
 
 ## C-8 Distributed Hierarchical Memory Backend
 
-- `src/hierarchical_memory.py` now includes optional gRPC support. `MemoryServer`
-  wraps a `HierarchicalMemory` instance and serves ``Push`` and ``Query`` RPCs.
-- Helper functions `push_remote()` and `query_remote()` send vectors to the
-  server and retrieve nearest neighbours over the network.
-- The server constructor accepts an ``address`` and ``max_workers`` to control
-  the bind host and connection pool size.
+- `src/hierarchical_memory.py` now exposes `start_server()` to share a FAISS index across nodes via gRPC. Clients use `push_remote()` and `query_remote()` to send compressed vectors and fetch nearest neighbours from the shared store.
 
 ## A-5 Multi-Modal World Model
 

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -123,7 +123,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 - `src/hierarchical_memory.py` ties compression and retrieval together for
   hierarchical context. With a database path it hooks into FAISS so far-past
   tokens reload from disk automatically. Search results remain on the
-  same device as the query.
+  same device as the query. The module now exposes `start_server()` so nodes can
+  share a vector store over gRPC with `push_remote()` and `query_remote()`.
 - `src/link_slot_attention.py` implements retrieval-augmented attention that
   fetches top-k vectors from the hierarchical memory for each token.
 - `src/megabyte_patching.py` adds a hierarchical byte patcher for **C-4**.

--- a/proto/memory.proto
+++ b/proto/memory.proto
@@ -7,8 +7,9 @@ service MemoryService {
 }
 
 message PushRequest {
-  repeated float vector = 1;
-  string metadata = 2;
+  repeated float vectors = 1;
+  repeated string metadata = 2;
+  int32 dim = 3;
 }
 
 message PushReply {
@@ -16,11 +17,13 @@ message PushReply {
 }
 
 message QueryRequest {
-  repeated float vector = 1;
+  repeated float query = 1;
   int32 k = 2;
+  int32 dim = 3;
 }
 
 message QueryReply {
   repeated float vectors = 1;
   repeated string metadata = 2;
+  int32 dim = 3;
 }

--- a/src/memory_pb2.py
+++ b/src/memory_pb2.py
@@ -15,7 +15,7 @@ _runtime_version.ValidateProtobufRuntimeVersion(
     31,
     0,
     '',
-    'memory.proto'
+    'memory.proto',
 )
 # @@protoc_insertion_point(imports)
 
@@ -24,21 +24,21 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cmemory.proto\x12\x03\x61si\"/\n\x0bPushRequest\x12\x0e\n\x06vector\x18\x01 \x03(\x02\x12\x10\n\x08metadata\x18\x02 \x01(\t\"\x17\n\tPushReply\x12\n\n\x02ok\x18\x01 \x01(\x08\")\n\x0cQueryRequest\x12\x0e\n\x06vector\x18\x01 \x03(\x02\x12\t\n\x01k\x18\x02 \x01(\x05\"/\n\nQueryReply\x12\x0f\n\x07vectors\x18\x01 \x03(\x02\x12\x10\n\x08metadata\x18\x02 \x03(\t2f\n\rMemoryService\x12(\n\x04Push\x12\x10.asi.PushRequest\x1a\x0e.asi.PushReply\x12+\n\x05Query\x12\x11.asi.QueryRequest\x1a\x0f.asi.QueryReplyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cmemory.proto\x12\x03asi\"=\n\x0bPushRequest\x12\x0f\n\x07vectors\x18\x01 \x03(\x02\x12\x10\n\x08metadata\x18\x02 \x03(\t\x12\x0b\n\x03dim\x18\x03 \x01(\x05\"\x17\n\tPushReply\x12\n\n\x02ok\x18\x01 \x01(\x08\"5\n\x0cQueryRequest\x12\r\n\x05query\x18\x01 \x03(\x02\x12\t\n\x01k\x18\x02 \x01(\x05\x12\x0b\n\x03dim\x18\x03 \x01(\x05\"<\n\nQueryReply\x12\x0f\n\x07vectors\x18\x01 \x03(\x02\x12\x10\n\x08metadata\x18\x02 \x03(\t\x12\x0b\n\x03dim\x18\x03 \x01(\x05\x32f\n\rMemoryService\x12(\n\x04Push\x12\x10.asi.PushRequest\x1a\x0e.asi.PushReply\x12+\n\x05Query\x12\x11.asi.QueryRequest\x1a\x0f.asi.QueryReplyb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'memory_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_PUSHREQUEST']._serialized_start=21
-  _globals['_PUSHREQUEST']._serialized_end=68
-  _globals['_PUSHREPLY']._serialized_start=70
-  _globals['_PUSHREPLY']._serialized_end=93
-  _globals['_QUERYREQUEST']._serialized_start=95
-  _globals['_QUERYREQUEST']._serialized_end=136
-  _globals['_QUERYREPLY']._serialized_start=138
-  _globals['_QUERYREPLY']._serialized_end=185
-  _globals['_MEMORYSERVICE']._serialized_start=187
-  _globals['_MEMORYSERVICE']._serialized_end=289
+  _globals['_PUSHREQUEST']._serialized_start=26
+  _globals['_PUSHREQUEST']._serialized_end=87
+  _globals['_PUSHREPLY']._serialized_start=89
+  _globals['_PUSHREPLY']._serialized_end=112
+  _globals['_QUERYREQUEST']._serialized_start=114
+  _globals['_QUERYREQUEST']._serialized_end=167
+  _globals['_QUERYREPLY']._serialized_start=169
+  _globals['_QUERYREPLY']._serialized_end=229
+  _globals['_MEMORYSERVICE']._serialized_start=231
+  _globals['_MEMORYSERVICE']._serialized_end=333
 # @@protoc_insertion_point(module_scope)

--- a/src/memory_pb2_grpc.py
+++ b/src/memory_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-import memory_pb2 as memory__pb2
+from . import memory_pb2 as memory__pb2
 
 GRPC_GENERATED_VERSION = '1.73.1'
 GRPC_VERSION = grpc.__version__


### PR DESCRIPTION
## Summary
- extend `hierarchical_memory` with gRPC server helpers and remote APIs
- refine 4-bit LoRA injection logic
- rewrite `eval_harness` to collect metric table
- expose CLI runner in `self_play_skill_loop`
- update protobuf schema for multi-vector RPCs
- document distributed memory improvements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6862c7815cfc8331bf3d0bd1d5fc2423