### PR TITLE
Consolidate self-play loop and LoRA helper

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -351,8 +351,7 @@ To reproduce the toy run step by step:
 
 ## A-8 Integrated Self-Play & Skill Transfer
 
-- The orchestrator in `src/self_play_skill_loop.py` alternates `self_play_env.rollout_env()` with `robot_skill_transfer.transfer_skills()` and logs the reward trajectory for each cycle.
-- Each cycle fine-tunes policies on a small batch of real examples.
+ - The orchestrator in `src/self_play_skill_loop.py` exposes `run_loop()` which alternates `self_play_env.rollout_env()` with `robot_skill_transfer.transfer_skills()`. Each cycle prints the average reward and skill accuracy. Running `python -m src.self_play_skill_loop` executes a demo loop.
 
 ## A-9 Automated PR Conflict Checks
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -39,7 +39,7 @@ from .robot_skill_transfer import (
     transfer_skills,
 )
 from .self_play_env import EnvStep, SimpleEnv, rollout_env
-from .self_play_skill_loop import self_play_skill_loop
+from .self_play_skill_loop import run_loop as run_self_play_skill_loop, self_play_skill_loop
 from .formal_verifier import (
     VerificationResult,
     check_grad_norm,

--- a/src/lora_quant.py
+++ b/src/lora_quant.py
@@ -87,16 +87,12 @@ def apply_quant_lora(model: nn.Module, target_modules: Sequence[str], r: int = 4
     dropout:
         Optional dropout probability for the injected adapters.
     """
-    for name, module in model.named_modules():
+    modules = list(model.named_modules())
+    for name, module in modules:
         for tgt in target_modules:
-            if name.endswith(tgt) and isinstance(module, nn.Linear):
-                if "." in name:
-                    parent_name, child = name.rsplit(".", 1)
-                else:
-                    parent_name, child = "", name
+            if name.split(".")[-1] == tgt and isinstance(module, nn.Linear):
                 parent = model
-                if parent_name:
-                    for attr in parent_name.split("."):
-                        parent = getattr(parent, attr)
-                setattr(parent, child, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
+                for attr in name.split(".")[:-1]:
+                    parent = getattr(parent, attr)
+                setattr(parent, tgt, LoRAQuantLinear(module, r=r, alpha=alpha, dropout=dropout))
     return model


### PR DESCRIPTION
## Summary
- export `run_self_play_skill_loop` in `asi` package
- refine `apply_quant_lora` to safely replace modules
- rework `self_play_skill_loop` into `run_loop` with CLI
- note the new loop helper in the Implementation guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6862c7815cfc8331bf3d0bd1d5fc2423