### PR TITLE
Consolidate PR features with async memory RPC

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -330,7 +330,7 @@ To reproduce the toy run step by step:
 - `src/hierarchical_memory.py` now includes optional gRPC support. `MemoryServer`
   wraps a `HierarchicalMemory` instance and serves ``Push`` and ``Query`` RPCs.
 - Helper functions `push_remote()` and `query_remote()` send vectors to the
-  server and retrieve nearest neighbours over the network.
+  server and retrieve nearest neighbours over the network. Asynchronous variants `push_remote_async()` and `query_remote_async()` allow non-blocking interaction when using ``grpc.aio``.
 - The server constructor accepts an ``address`` and ``max_workers`` to control
   the bind host and connection pool size.
 

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -155,7 +155,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 - `src/self_play_env.py` and `src/embodied_calibration.py` offer a sandbox for
   self-play and a sensor calibration routine.
 - `src/formal_verifier.py` checks model snapshots against custom invariants.
-- `src/eval_harness.py` aggregates metrics from all modules and prints a pass/fail scoreboard.
+- `src/eval_harness.py` aggregates metrics from all modules and prints a pass/fail scoreboard. The CLI now supports a `--concurrent` flag to run evaluations asynchronously via `evaluate_modules_async()`.
 
 ### Recommended next steps
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,7 +10,14 @@ from .quantum_hpo import (
 from .collective_constitution import CollectiveConstitution
 from .deliberative_alignment import DeliberativeAligner
 from .streaming_compression import ReservoirBuffer, StreamingCompressor
-from .hierarchical_memory import HierarchicalMemory
+from .hierarchical_memory import (
+    HierarchicalMemory,
+    MemoryServer,
+    push_remote,
+    query_remote,
+    push_remote_async,
+    query_remote_async,
+)
 from .vector_store import VectorStore, FaissVectorStore
 from .async_vector_store import AsyncFaissVectorStore
 from .iter_align import IterativeAligner

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,6 +1,7 @@
 import unittest
+import asyncio
 
-from asi.eval_harness import parse_modules, evaluate_modules
+from asi.eval_harness import parse_modules, evaluate_modules, evaluate_modules_async
 
 
 class TestEvalHarness(unittest.TestCase):
@@ -12,6 +13,13 @@ class TestEvalHarness(unittest.TestCase):
     def test_evaluate_subset(self):
         subset = ["moe_router", "flash_attention3", "scaling_law"]
         results = evaluate_modules(subset)
+        for name in subset:
+            self.assertIn(name, results)
+            self.assertTrue(results[name][0], name)
+
+    def test_evaluate_subset_async(self):
+        subset = ["moe_router", "flash_attention3"]
+        results = asyncio.run(evaluate_modules_async(subset))
         for name in subset:
             self.assertIn(name, results)
             self.assertTrue(results[name][0], name)

--- a/tests/test_hierarchical_memory.py
+++ b/tests/test_hierarchical_memory.py
@@ -3,9 +3,16 @@ import unittest
 import asyncio
 import torch
 
-from asi.hierarchical_memory import HierarchicalMemory
+from asi.hierarchical_memory import (
+    HierarchicalMemory,
+    MemoryServer,
+    push_remote,
+    query_remote,
+    push_remote_async,
+    query_remote_async,
+)
 try:
-    from asi.hierarchical_memory import MemoryServer, push_remote, query_remote
+    import grpc  # noqa: F401
     _HAS_GRPC = True
 except Exception:
     _HAS_GRPC = False
@@ -143,6 +150,26 @@ class TestHierarchicalMemory(unittest.TestCase):
         self.assertEqual(vec.shape, (1, 4))
         self.assertEqual(meta[0], "r")
         server.stop(0)
+
+    def test_grpc_server_async(self):
+        if not _HAS_GRPC:
+            self.skipTest("grpcio not available")
+
+        torch.manual_seed(0)
+
+        async def run() -> None:
+            mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+            server = MemoryServer(mem, address="localhost:50071", max_workers=1)
+            server.start()
+            data = torch.randn(1, 4)
+            ok = await push_remote_async("localhost:50071", data[0], metadata="r")
+            self.assertTrue(ok)
+            vec, meta = await query_remote_async("localhost:50071", data[0], k=1)
+            self.assertEqual(vec.shape, (1, 4))
+            self.assertEqual(meta[0], "r")
+            server.stop(0)
+
+        asyncio.run(run())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add async `push_remote_async` and `query_remote_async` helpers
- allow concurrent evaluation via `evaluate_modules_async`
- expose new helpers in `asi` package
- extend hierarchical memory and eval harness tests
- document new capabilities in Plan and Implementation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6862ccecfe4c8331a54a155e2819712c