### PR TITLE
Consolidate features from conflicting PRs

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -333,6 +333,8 @@ To reproduce the toy run step by step:
   server and retrieve nearest neighbours over the network. Asynchronous variants `push_remote_async()` and `query_remote_async()` allow non-blocking interaction when using ``grpc.aio``.
 - The server constructor accepts an ``address`` and ``max_workers`` to control
   the bind host and connection pool size.
+- `src/remote_memory.py` provides a small :class:`RemoteMemory` client that wraps
+  these RPCs in a convenient Python interface.
 
 ## A-5 Multi-Modal World Model
 

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -29,7 +29,7 @@ Citations point to the most recent public work so you can drill straight into th
 | **C-5** | **Top-k Sparse Attention for inference**        | Select k≈64 most-relevant keys each step                           | 20 %b/word latency cut at 1 M tokens; accuracy drop <0.5 pp ([arxiv.org][11])                                                |
 | **C-6** | **RWKV infinite-context training loop**         | Constant-memory recurrence with token-shift trick                  | Train 7 B RWKV on 4 M-token samples, VRAM ≤80 GB; effective context ≥2 M at inference ([wiki.rwkv.com][12], [arxiv.org][13]) |
 | **C-7** | **Hierarchical Retrieval Memory**         | Cache long-tail tokens in a disk-backed vector DB                     | Retrieval hit rate ≥85 % at 1 M tokens |
-| **C-8** | **Distributed Hierarchical Memory Backend** | Share the vector store across nodes via a gRPC service (see `MemoryServer`) | Throughput scales to 4+ nodes with <1.2× single-node latency |
+| **C-8** | **Distributed Hierarchical Memory Backend** | Share the vector store across nodes via a gRPC service (see `MemoryServer`, `RemoteMemory`) | Throughput scales to 4+ nodes with <1.2× single-node latency |
 
 **Path to “trillion-token” context:** combine *C-1/2/3* for linear-or-sub-linear scaling, add **hierarchical retrieval** (store distant tokens in an external vector DB and re-inject on-demand).  Recurrence handles the whole stream; retrieval gives random access—context length becomes limited only by storage, not RAM.
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -20,6 +20,7 @@ from .hierarchical_memory import (
 )
 from .distributed_memory import DistributedMemory
 from .memory_service import serve
+from .remote_memory import RemoteMemory
 from .vector_store import VectorStore, FaissVectorStore
 from .async_vector_store import AsyncFaissVectorStore
 from .iter_align import IterativeAligner

--- a/src/remote_memory.py
+++ b/src/remote_memory.py
@@ -1,0 +1,42 @@
+import torch
+from typing import Iterable, Tuple, List, Any
+
+try:
+    import grpc  # type: ignore
+    from . import memory_pb2, memory_pb2_grpc
+    _HAS_GRPC = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAS_GRPC = False
+
+
+class RemoteMemory:
+    """Thin gRPC client for :class:`~asi.hierarchical_memory.MemoryServer`."""
+
+    def __init__(self, address: str) -> None:
+        if not _HAS_GRPC:
+            raise ImportError("grpcio is required for RemoteMemory")
+        self.address = address
+        self.channel = grpc.insecure_channel(address)
+        self.stub = memory_pb2_grpc.MemoryServiceStub(self.channel)
+
+    def add(self, x: torch.Tensor, metadata: Iterable[Any] | None = None) -> None:
+        """Send vectors and optional metadata to the remote store."""
+        if x.ndim == 1:
+            x = x.unsqueeze(0)
+        metas = list(metadata) if metadata is not None else [None] * len(x)
+        for vec, meta in zip(x, metas):
+            req = memory_pb2.PushRequest(
+                vector=vec.detach().cpu().view(-1).tolist(),
+                metadata="" if meta is None else str(meta),
+            )
+            self.stub.Push(req)
+
+    def search(self, query: torch.Tensor, k: int = 5) -> Tuple[torch.Tensor, List[str]]:
+        """Query nearest vectors from the remote store."""
+        req = memory_pb2.QueryRequest(vector=query.detach().cpu().view(-1).tolist(), k=k)
+        reply = self.stub.Query(req)
+        vec = torch.tensor(reply.vectors).reshape(-1, query.size(-1))
+        return vec, list(reply.metadata)
+
+
+__all__ = ["RemoteMemory"]

--- a/tests/test_remote_memory.py
+++ b/tests/test_remote_memory.py
@@ -1,0 +1,29 @@
+import unittest
+import torch
+
+from asi.hierarchical_memory import HierarchicalMemory
+from asi.memory_service import serve
+from asi.remote_memory import RemoteMemory
+
+
+class TestRemoteMemory(unittest.TestCase):
+    def test_add_and_search(self):
+        try:
+            import grpc  # noqa: F401
+        except Exception:
+            self.skipTest("grpcio not available")
+
+        mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+        server = serve(mem, "localhost:50200")
+
+        client = RemoteMemory("localhost:50200")
+        data = torch.randn(1, 4)
+        client.add(data[0], metadata=["x"])
+        out, meta = client.search(data[0], k=1)
+        self.assertEqual(out.shape, (1, 4))
+        self.assertEqual(meta[0], "x")
+        server.stop(0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `RemoteMemory` client for gRPC memory server
- document the client in Implementation guide and Plan
- export `RemoteMemory` from `asi` package
- cover new functionality with a unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6862e326dcb0833182e813aa1e78f116