### PR TITLE
Add transformer circuits interpretability module

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -408,6 +408,13 @@ img = random_crop(Image.open(pairs[0][1]), (32, 32))
 txt = generate_transcript(pairs[0][2])
 ```
 
+## L-6 Mechanistic Interpretability Tools
+
+- `src/transformer_circuits.py` provides utilities to record attention weights
+  and ablate individual heads. `ActivationRecorder` registers hooks on named
+  modules, while `head_importance()` measures output differences when heads are
+  zeroed.
+
 ## Research workflow
 
 1. **Select an algorithm** from `docs/Plan.md` that remains unsolved.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -156,6 +156,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
   self-play and a sensor calibration routine.
 - `src/formal_verifier.py` checks model snapshots against custom invariants.
 - `src/eval_harness.py` aggregates metrics from all modules and prints a pass/fail scoreboard. The CLI now supports a `--concurrent` flag to run evaluations asynchronously via `evaluate_modules_async()`.
+- `src/transformer_circuits.py` records attention weights and lets researchers ablate individual heads for interpretability experiments.
 
 ### Recommended next steps
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -91,3 +91,11 @@ from .data_ingest import (
     add_gaussian_noise,
     text_dropout,
 )
+from .transformer_circuits import (
+    ActivationRecorder,
+    record_attention_weights,
+    zero_attention_head,
+    restore_attention_head,
+    patched_head,
+    head_importance,
+)

--- a/src/transformer_circuits.py
+++ b/src/transformer_circuits.py
@@ -1,0 +1,132 @@
+import contextlib
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+import torch
+import torch.nn as nn
+
+
+@dataclass
+class HeadPatch:
+    layer: str
+    head: int
+    orig_q: torch.Tensor
+    orig_k: torch.Tensor
+    orig_v: torch.Tensor
+
+
+class ActivationRecorder:
+    """Record activations from specified modules via forward hooks."""
+
+    def __init__(self, module: nn.Module, names: Iterable[str]) -> None:
+        self.module = module
+        self.names = list(names)
+        self.records: Dict[str, torch.Tensor] = {}
+        self.handles: list[torch.utils.hooks.RemovableHandle] = []
+        for name in self.names:
+            sub = dict(module.named_modules())[name]
+            handle = sub.register_forward_hook(self._make_hook(name))
+            self.handles.append(handle)
+
+    def _make_hook(self, name: str):
+        def hook(_mod: nn.Module, _inp: Tuple[torch.Tensor], out: torch.Tensor) -> None:
+            with torch.no_grad():
+                self.records[name] = out.detach()
+        return hook
+
+    def remove(self) -> None:
+        for h in self.handles:
+            h.remove()
+        self.handles.clear()
+
+
+def record_attention_weights(model: nn.Module, x: torch.Tensor) -> Dict[str, torch.Tensor]:
+    """Run ``model`` on ``x`` and return attention weights keyed by module name."""
+    weights: Dict[str, torch.Tensor] = {}
+    handles: list[torch.utils.hooks.RemovableHandle] = []
+    for name, mod in model.named_modules():
+        if isinstance(mod, nn.MultiheadAttention):
+            def hook(mod: nn.MultiheadAttention, inp, output, n=name):
+                # output is (attn, weights)
+                if isinstance(output, tuple) and len(output) == 2:
+                    weights[n] = output[1].detach()
+                else:
+                    weights[n] = mod.attn_output_weights.detach()
+            handles.append(mod.register_forward_hook(hook))
+    model(x)
+    for h in handles:
+        h.remove()
+    return weights
+
+
+def _get_mha(model: nn.Module, name: str) -> nn.MultiheadAttention:
+    mod = dict(model.named_modules()).get(name)
+    if not isinstance(mod, nn.MultiheadAttention):
+        raise ValueError(f"{name} is not MultiheadAttention")
+    return mod
+
+
+def zero_attention_head(model: nn.Module, name: str, head: int) -> HeadPatch:
+    """Zero the projection weights of one attention head and return the patch."""
+    attn = _get_mha(model, name)
+    hdim = attn.head_dim
+    start = head * hdim
+    end = start + hdim
+    patch = HeadPatch(
+        layer=name,
+        head=head,
+        orig_q=attn.in_proj_weight[start:end].detach().clone(),
+        orig_k=attn.in_proj_weight[attn.embed_dim + start : attn.embed_dim + end].detach().clone(),
+        orig_v=attn.in_proj_weight[2 * attn.embed_dim + start : 2 * attn.embed_dim + end].detach().clone(),
+    )
+    with torch.no_grad():
+        attn.in_proj_weight[start:end].zero_()
+        attn.in_proj_weight[attn.embed_dim + start : attn.embed_dim + end].zero_()
+        attn.in_proj_weight[2 * attn.embed_dim + start : 2 * attn.embed_dim + end].zero_()
+    return patch
+
+
+def restore_attention_head(model: nn.Module, patch: HeadPatch) -> None:
+    """Restore a head previously zeroed with :func:`zero_attention_head`."""
+    attn = _get_mha(model, patch.layer)
+    hdim = attn.head_dim
+    start = patch.head * hdim
+    end = start + hdim
+    with torch.no_grad():
+        attn.in_proj_weight[start:end].copy_(patch.orig_q)
+        attn.in_proj_weight[attn.embed_dim + start : attn.embed_dim + end].copy_(patch.orig_k)
+        attn.in_proj_weight[2 * attn.embed_dim + start : 2 * attn.embed_dim + end].copy_(patch.orig_v)
+
+
+@contextlib.contextmanager
+def patched_head(model: nn.Module, name: str, head: int):
+    """Context manager that zeros a head temporarily."""
+    patch = zero_attention_head(model, name, head)
+    try:
+        yield
+    finally:
+        restore_attention_head(model, patch)
+
+
+def head_importance(model: nn.Module, x: torch.Tensor, name: str) -> torch.Tensor:
+    """Return L2 output differences when ablating each head."""
+    attn = _get_mha(model, name)
+    num_heads = attn.num_heads
+    baseline = model(x).detach()
+    diffs = []
+    for h in range(num_heads):
+        with patched_head(model, name, h):
+            out = model(x).detach()
+        diffs.append(torch.norm(baseline - out).item())
+    return torch.tensor(diffs)
+
+
+__all__ = [
+    "ActivationRecorder",
+    "record_attention_weights",
+    "zero_attention_head",
+    "restore_attention_head",
+    "patched_head",
+    "head_importance",
+    "HeadPatch",
+]

--- a/tests/test_transformer_circuits.py
+++ b/tests/test_transformer_circuits.py
@@ -1,0 +1,28 @@
+import unittest
+import torch
+from asi.transformer_circuits import (
+    record_attention_weights,
+    head_importance,
+)
+
+
+class TestTransformerCircuits(unittest.TestCase):
+    def setUp(self):
+        layer = torch.nn.TransformerEncoderLayer(d_model=8, nhead=2)
+        self.model = torch.nn.TransformerEncoder(layer, num_layers=1)
+        self.input = torch.randn(4, 3, 8)  # seq, batch, dim
+
+    def test_record_attention_weights(self):
+        weights = record_attention_weights(self.model, self.input)
+        self.assertTrue(weights)
+        for w in weights.values():
+            self.assertEqual(w.shape[-2:], (self.input.size(0), self.input.size(0)))
+
+    def test_head_importance(self):
+        imps = head_importance(self.model, self.input, 'layers.0.self_attn')
+        self.assertEqual(imps.numel(), 2)
+        self.assertTrue(torch.all(imps >= 0))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a `transformer_circuits` helper with hooks and head ablations
- expose the new utilities from `asi.__init__`
- document the module in Plan and Implementation docs
- test attention recording and head importance

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6862e96ea86c83319968e7b952faf3d7