### PR TITLE
Extend task lists with data augmentation and continuous eval

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -453,5 +453,7 @@ txt = generate_transcript(pairs[0][2])
   saves interactive attention heatmaps for interpretability experiments.
 - Prototype a `GraphOfThoughtPlanner` that composes reasoning steps into a
   searchable graph for code refactoring decisions.
-- Add a `NeuroSymbolicExecutor` module that runs logical constraints alongside
-  neural world-model rollouts.
+- Add a `NeuroSymbolicExecutor` module that runs logical constraints alongside neural world-model rollouts.
+- Implement a `GenerativeDataAugmentor` that rolls out the world model to synthesize training triples and feeds them through `data_ingest`.
+- Add `continuous_eval.py` to schedule `eval_harness` and `autobench` after each pull request using GitHub Actions or a local cron job.
+- Combine `GraphOfThoughtPlanner` with `MetaRLRefactorAgent` in an `AdaptivePlanner` module that ranks and applies refactor suggestions automatically.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -204,6 +204,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     refactor quality gains over the baseline meta-RL agent.
 12. **Neuro-symbolic world model**: Integrate `NeuroSymbolicExecutor` with
     `world_model_rl.rollout_policy()` and log constraint violations.
+13. **Generative data augmentor**: Use `GenerativeDataAugmentor` to synthesize new training triples from world-model rollouts and expand the dataset.
+14. **Continuous evaluation**: Run `continuous_eval.py` after each pull request to track benchmark progress automatically.
+15. **Adaptive planning agent**: Merge `GraphOfThoughtPlanner` with `MetaRLRefactorAgent` to auto-rank refactor strategies.
 
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."


### PR DESCRIPTION
## Summary
- add new tasks around GenerativeDataAugmentor and continuous evaluation to Implementation.md
- expand Plan.md short-term research tasks to include generative augmentor, continuous eval and adaptive planning agent

## Testing
- `grep -n "\s$" -n docs/Implementation.md` *(no output)*
- `grep -n "\s$" -n docs/Plan.md` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_686318f90e048331b03eed6da480c907