### PR TITLE
Add hybrid retention module and async data download

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -431,14 +431,18 @@ txt = generate_transcript(pairs[0][2])
 
 - Create a `HybridRetention` module that combines the linear update from
   `MambaBlock` with the decay kernel in `RetNetRetention`.
+- Implemented in `src/hybrid_retention.py` with a unit test under
+  `tests/test_hybrid_retention.py`.
 - Extend `HierarchicalMemory` so `cross_modal_fusion.encode_all()` can store and
   retrieve multimodal embeddings.
 - Add a `log_memory_usage()` helper to `eval_harness.py` and print GPU memory
   usage alongside accuracy metrics.
+- Added and hooked into both synchronous and async evaluators.
 - Integrate `QAEHyperparamSearch` into `MetaRLRefactorAgent` to tune the
   exploration rate during refactoring.
 - Rewrite `download_triples()` with asyncio to fetch dataset files
   concurrently.
+- Introduced `download_triples_async()` and updated the sync wrapper.
 - Add streaming RPCs to `MemoryServer` so batches of vectors can be pushed and
   queried in one call. Update `memory.proto` and the `RemoteMemory` client.
 - Implement optional gradient checkpointing in `multimodal_world_model.py` via a

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -116,6 +116,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
   that returns a dataclass `BreakpointModel` with piecewise slopes.
 - `src/retnet_retention.py` implements a RetNet-style retention kernel for **C-1**.
 - `src/mamba_block.py` provides a simplified Mamba state-space block for **C-2**.
+- `src/hybrid_retention.py` merges the Mamba update with RetNet-style decay.
 - `src/hyena_filter.py` implements the implicit-FFT filter for **C-3**.
 - `src/streaming_compression.py` maintains a reservoir buffer with a small
   autoencoder for **streaming compression**.
@@ -156,7 +157,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 - `src/self_play_env.py` and `src/embodied_calibration.py` offer a sandbox for
   self-play and a sensor calibration routine.
 - `src/formal_verifier.py` checks model snapshots against custom invariants.
-- `src/eval_harness.py` aggregates metrics from all modules and prints a pass/fail scoreboard. The CLI now supports a `--concurrent` flag to run evaluations asynchronously via `evaluate_modules_async()`.
+- `src/eval_harness.py` aggregates metrics from all modules and prints a pass/fail scoreboard. The CLI now supports a `--concurrent` flag to run evaluations asynchronously via `evaluate_modules_async()` and reports GPU memory with `log_memory_usage()`.
 - `src/transformer_circuits.py` records attention weights and lets researchers ablate individual heads for interpretability experiments.
 
 ### Recommended next steps
@@ -186,8 +187,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
    with half the memory use.
 4. **QAE-guided refactoring**: Employ `QAEHyperparamSearch` to tune exploration
    parameters in `MetaRLRefactorAgent` and track benchmark uplift.
-5. **Scalability metrics**: Update `eval_harness.py` to record GPU memory usage
-   alongside pass/fail results.
+5. **Scalability metrics**: `eval_harness.py` now records GPU memory usage
+   alongside pass/fail results via `log_memory_usage()`.
 6. **Distributed memory benchmark**: Run `DistributedMemory` with four
    `MemoryServer` nodes using `distributed_memory_benchmark.py` and measure
    query latency and throughput versus the single-node baseline.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -99,3 +99,6 @@ from .transformer_circuits import (
     patched_head,
     head_importance,
 )
+from .mamba_block import MambaBlock
+from .retnet_retention import RetNetRetention
+from .hybrid_retention import HybridRetention

--- a/src/hybrid_retention.py
+++ b/src/hybrid_retention.py
@@ -1,0 +1,58 @@
+import torch
+from torch import nn
+
+class HybridRetention(nn.Module):
+    """Combine Mamba-style linear updates with RetNet decay."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 1,
+        decay: float | list[float] = 0.9,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        self.num_heads = num_heads
+        if isinstance(decay, float):
+            decay = [decay] * num_heads
+        if len(decay) != num_heads:
+            raise ValueError("decay must match num_heads")
+        self.register_buffer("decay", torch.tensor(decay).view(1, num_heads, 1))
+        self.A = nn.Parameter(torch.randn(dim, dim) * 0.1)
+        self.B = nn.Parameter(torch.randn(dim, dim) * 0.1)
+        self.gate = nn.Linear(dim, dim)
+        self.out_proj = nn.Linear(dim, dim)
+        self.drop = nn.Dropout(dropout)
+
+    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        """Return sequence processed by hybrid retention."""
+        batch, seq, dim = q.shape
+        if dim != self.dim or dim % self.num_heads != 0:
+            raise ValueError("dimension mismatch")
+        head_dim = dim // self.num_heads
+
+        q = q.view(batch, seq, self.num_heads, head_dim)
+        k = k.view(batch, seq, self.num_heads, head_dim)
+        v = v.view(batch, seq, self.num_heads, head_dim)
+
+        r = torch.zeros(batch, self.num_heads, head_dim, device=q.device, dtype=q.dtype)
+        state = torch.zeros(batch, self.num_heads, head_dim, device=q.device, dtype=q.dtype)
+        outputs = []
+        for t in range(seq):
+            r = self.decay * r + k[:, t] * v[:, t]
+            inp = q[:, t]
+            gate = torch.sigmoid(self.gate(inp.view(batch, -1))).view(batch, self.num_heads, head_dim)
+            blended = gate * state + (1 - gate) * inp
+            s = torch.tanh(
+                blended.view(batch, dim) @ self.A.t()
+                + r.view(batch, dim) @ self.B.t()
+            )
+            s = self.drop(s).view(batch, self.num_heads, head_dim)
+            state = s
+            out = self.out_proj(state.view(batch, dim)).view(batch, self.num_heads, head_dim)
+            outputs.append(out)
+        out = torch.stack(outputs, dim=1)
+        return out.view(batch, seq, dim)
+
+__all__ = ["HybridRetention"]

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,7 +1,12 @@
 import unittest
 import asyncio
 
-from asi.eval_harness import parse_modules, evaluate_modules, evaluate_modules_async
+from asi.eval_harness import (
+    parse_modules,
+    evaluate_modules,
+    evaluate_modules_async,
+    log_memory_usage,
+)
 
 
 class TestEvalHarness(unittest.TestCase):
@@ -16,6 +21,7 @@ class TestEvalHarness(unittest.TestCase):
         for name in subset:
             self.assertIn(name, results)
             self.assertTrue(results[name][0], name)
+            self.assertIn("gpu=", results[name][1])
 
     def test_evaluate_subset_async(self):
         subset = ["moe_router", "flash_attention3"]
@@ -23,6 +29,11 @@ class TestEvalHarness(unittest.TestCase):
         for name in subset:
             self.assertIn(name, results)
             self.assertTrue(results[name][0], name)
+            self.assertIn("gpu=", results[name][1])
+
+    def test_log_memory_usage(self):
+        mem = log_memory_usage()
+        self.assertIsInstance(mem, float)
 
 
 if __name__ == "__main__":

--- a/tests/test_hybrid_retention.py
+++ b/tests/test_hybrid_retention.py
@@ -1,0 +1,16 @@
+import unittest
+import torch
+
+from asi.hybrid_retention import HybridRetention
+
+class TestHybridRetention(unittest.TestCase):
+    def test_forward_shapes(self):
+        module = HybridRetention(dim=4, num_heads=2)
+        q = torch.randn(2, 5, 4)
+        k = torch.randn(2, 5, 4)
+        v = torch.randn(2, 5, 4)
+        out = module(q, k, v)
+        self.assertEqual(out.shape, q.shape)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `HybridRetention` combining Mamba and RetNet mechanisms
- add async `download_triples_async` and wrapper in `data_ingest`
- extend `eval_harness` with `log_memory_usage` and report GPU usage
- update documentation for new utilities
- add tests for hybrid retention and updated eval harness

## Testing
- `python -m pytest tests/test_hybrid_retention.py tests/test_eval_harness.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6863251179d083319cee33398eb03b9e