### PR TITLE
Add hybrid retention and logging utilities

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -177,17 +177,20 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 ### Short-Term Research Tasks
 
 1. **Hybrid retention backbone**: Fuse `RetNetRetention` with `MambaBlock` and
-   measure throughput and memory compared with the individual kernels.
+   measure throughput and memory compared with the individual kernels. The new
+   module `src/hybrid_retention.py` implements this combination.
 2. **Cross-modal retrieval memory**: Store embeddings from
    `cross_modal_fusion.encode_all()` inside `HierarchicalMemory` and evaluate
-   retrieval accuracy on 1&nbsp;M-token streams.
+   retrieval accuracy on 1&nbsp;M-token streams. The helper
+   `HierarchicalMemory.add_multimodal()` handles averaged text, image and audio
+   vectors.
 3. **LoRA-quantized world model**: Apply `apply_quant_lora()` to the
    multimodal world model and confirm the RL bridge still meets reward targets
    with half the memory use.
 4. **QAE-guided refactoring**: Employ `QAEHyperparamSearch` to tune exploration
    parameters in `MetaRLRefactorAgent` and track benchmark uplift.
 5. **Scalability metrics**: Update `eval_harness.py` to record GPU memory usage
-   alongside pass/fail results.
+   alongside pass/fail results using `log_memory_usage()`.
 6. **Distributed memory benchmark**: Run `DistributedMemory` with four
    `MemoryServer` nodes using `distributed_memory_benchmark.py` and measure
    query latency and throughput versus the single-node baseline.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -28,6 +28,9 @@ from .critic_rlhf import CriticScorer, CriticRLHFTrainer
 from .chunkwise_retrainer import ChunkWiseRetrainer
 from .scaling_law import BreakpointScalingLaw
 from .link_slot_attention import LinkSlotAttention
+from .retnet_retention import RetNetRetention
+from .mamba_block import MambaBlock
+from .hybrid_retention import HybridRetention
 
 from .pull_request_monitor import (
     list_open_prs,
@@ -83,6 +86,7 @@ from .embodied_calibration import (
 from .lora_quant import LoRAQuantLinear, apply_quant_lora
 from .data_ingest import (
     download_triples,
+    adownload_triples,
     align_triples,
     random_crop,
     generate_transcript,

--- a/src/data_ingest.py
+++ b/src/data_ingest.py
@@ -2,20 +2,21 @@ from __future__ import annotations
 
 import random
 import wave
+import asyncio
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
 import numpy as np
-import requests
+import aiohttp
 from PIL import Image
 
 
-def download_file(url: str, dest: Path) -> None:
-    """Download ``url`` into ``dest``."""
+async def _download_file(session: aiohttp.ClientSession, url: str, dest: Path) -> None:
+    """Asynchronously download ``url`` into ``dest``."""
     dest.parent.mkdir(parents=True, exist_ok=True)
-    r = requests.get(url, timeout=30)
-    r.raise_for_status()
-    dest.write_bytes(r.content)
+    async with session.get(url, timeout=30) as resp:
+        resp.raise_for_status()
+        dest.write_bytes(await resp.read())
 
 
 def download_triples(
@@ -24,17 +25,40 @@ def download_triples(
     audio_urls: Iterable[str],
     out_dir: str,
 ) -> List[Tuple[Path, Path, Path]]:
-    """Download text, image and audio triples into ``out_dir``."""
+    """Download text, image and audio triples into ``out_dir`` concurrently."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(adownload_triples(text_urls, img_urls, audio_urls, out_dir))
+    else:
+        return loop.create_task(adownload_triples(text_urls, img_urls, audio_urls, out_dir))
+
+
+async def adownload_triples(
+    text_urls: Iterable[str],
+    img_urls: Iterable[str],
+    audio_urls: Iterable[str],
+    out_dir: str,
+) -> List[Tuple[Path, Path, Path]]:
+    """Asynchronously download triples into ``out_dir``."""
     triples: List[Tuple[Path, Path, Path]] = []
     out = Path(out_dir)
-    for i, (t, iurl, a) in enumerate(zip(text_urls, img_urls, audio_urls)):
-        t_path = out / "text" / f"{i}.txt"
-        i_path = out / "images" / f"{i}.png"
-        a_path = out / "audio" / f"{i}.wav"
-        download_file(t, t_path)
-        download_file(iurl, i_path)
-        download_file(a, a_path)
-        triples.append((t_path, i_path, a_path))
+    async with aiohttp.ClientSession() as session:
+        tasks = []
+        for i, (t, iurl, a) in enumerate(zip(text_urls, img_urls, audio_urls)):
+            t_path = out / "text" / f"{i}.txt"
+            i_path = out / "images" / f"{i}.png"
+            a_path = out / "audio" / f"{i}.wav"
+            tasks.extend(
+                [
+                    _download_file(session, t, t_path),
+                    _download_file(session, iurl, i_path),
+                    _download_file(session, a, a_path),
+                ]
+            )
+            triples.append((t_path, i_path, a_path))
+        if tasks:
+            await asyncio.gather(*tasks)
     return triples
 
 
@@ -118,6 +142,7 @@ def text_dropout(text: str, p: float = 0.1) -> str:
 
 __all__ = [
     "download_triples",
+    "adownload_triples",
     "align_triples",
     "random_crop",
     "generate_transcript",

--- a/src/eval_harness.py
+++ b/src/eval_harness.py
@@ -13,6 +13,16 @@ import numpy as np
 import torch
 
 
+def log_memory_usage() -> float:
+    """Return peak GPU memory usage in MB, resetting the counter."""
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        mem = torch.cuda.max_memory_allocated() / (1024 ** 2)
+        torch.cuda.reset_peak_memory_stats()
+        return float(mem)
+    return 0.0
+
+
 # ---------------------------------------------------------------------------
 # Module discovery
 # ---------------------------------------------------------------------------
@@ -250,6 +260,8 @@ def format_results(results: Dict[str, Tuple[bool, str]]) -> str:
     for mod, (ok, info) in sorted(results.items()):
         status = "PASS" if ok else "FAIL"
         lines.append(f"{mod}: {status} - {info}")
+    mem = log_memory_usage()
+    lines.append(f"GPU memory used: {mem:.1f} MB")
     return "\n".join(lines)
 
 

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -57,6 +57,17 @@ class HierarchicalMemory:
             comp = self.compressor.encoder(x).detach().cpu().numpy()
             self.store.add(comp, metadata)
 
+    def add_multimodal(
+        self,
+        text: torch.Tensor,
+        images: torch.Tensor,
+        audio: torch.Tensor,
+        metadata: Iterable[Any] | None = None,
+    ) -> None:
+        """Store averaged multimodal embeddings."""
+        vecs = (text + images + audio) / 3.0
+        self.add(vecs, metadata)
+
     def delete(self, index: int | Iterable[int] | None = None, tag: Any | None = None) -> None:
         """Remove vectors from the store by index or metadata tag."""
         if isinstance(self.store, AsyncFaissVectorStore):
@@ -79,6 +90,17 @@ class HierarchicalMemory:
             await self.store.aadd(comp, metadata)
         else:
             self.store.add(comp, metadata)
+
+    async def aadd_multimodal(
+        self,
+        text: torch.Tensor,
+        images: torch.Tensor,
+        audio: torch.Tensor,
+        metadata: Iterable[Any] | None = None,
+    ) -> None:
+        """Asynchronously store averaged multimodal embeddings."""
+        vecs = (text + images + audio) / 3.0
+        await self.aadd(vecs, metadata)
 
     async def adelete(self, index: int | Iterable[int] | None = None, tag: Any | None = None) -> None:
         """Asynchronously delete vectors from the store."""

--- a/src/hybrid_retention.py
+++ b/src/hybrid_retention.py
@@ -1,0 +1,23 @@
+import torch
+from torch import nn
+
+from .retnet_retention import RetNetRetention
+from .mamba_block import MambaBlock
+
+
+class HybridRetention(nn.Module):
+    """Fuse MambaBlock updates with RetNet-style retention."""
+
+    def __init__(self, dim: int, num_heads: int = 1, decay: float | list[float] = 0.9, dropout: float = 0.0) -> None:
+        super().__init__()
+        self.mamba = MambaBlock(dim=dim, dropout=dropout, residual=False)
+        self.retention = RetNetRetention(num_heads=num_heads, decay=decay)
+
+    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        """Return combined Mamba and RetNet outputs."""
+        m_out = self.mamba(q)
+        r_out = self.retention(q, k, v)
+        return m_out + r_out
+
+
+__all__ = ["HybridRetention"]

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,7 +1,12 @@
 import unittest
 import asyncio
 
-from asi.eval_harness import parse_modules, evaluate_modules, evaluate_modules_async
+from asi.eval_harness import (
+    parse_modules,
+    evaluate_modules,
+    evaluate_modules_async,
+    log_memory_usage,
+)
 
 
 class TestEvalHarness(unittest.TestCase):
@@ -23,6 +28,11 @@ class TestEvalHarness(unittest.TestCase):
         for name in subset:
             self.assertIn(name, results)
             self.assertTrue(results[name][0], name)
+
+    def test_log_memory_usage(self):
+        mem = log_memory_usage()
+        self.assertIsInstance(mem, float)
+        self.assertGreaterEqual(mem, 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_hierarchical_memory.py
+++ b/tests/test_hierarchical_memory.py
@@ -100,6 +100,17 @@ class TestHierarchicalMemory(unittest.TestCase):
             mem2 = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10, db_path=tmpdir)
             self.assertEqual(len(mem2), 2)
 
+    def test_add_multimodal(self):
+        torch.manual_seed(0)
+        mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+        t = torch.randn(2, 4)
+        i = torch.randn(2, 4)
+        a = torch.randn(2, 4)
+        mem.add_multimodal(t, i, a, metadata=["m1", "m2"])
+        out, meta = mem.search(t[0], k=1)
+        self.assertEqual(len(meta), 1)
+        self.assertIn(meta[0], ["m1", "m2"])
+
     def test_sync_methods_inside_event_loop(self):
         torch.manual_seed(0)
 


### PR DESCRIPTION
## Summary
- implement `HybridRetention` combining MambaBlock and RetNetRetention
- track GPU memory usage in `eval_harness`
- allow asynchronous dataset downloads in `data_ingest`
- add multimodal helpers to `HierarchicalMemory`
- update docs and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6863251179d083319cee33398eb03b9e