### PR TITLE
Add hybrid retention and multimodal memory

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -28,6 +28,7 @@ from .critic_rlhf import CriticScorer, CriticRLHFTrainer
 from .chunkwise_retrainer import ChunkWiseRetrainer
 from .scaling_law import BreakpointScalingLaw
 from .link_slot_attention import LinkSlotAttention
+from .hybrid_retention import HybridRetention
 
 from .pull_request_monitor import (
     list_open_prs,

--- a/src/hybrid_retention.py
+++ b/src/hybrid_retention.py
@@ -1,0 +1,28 @@
+import torch
+from torch import nn
+
+from .mamba_block import MambaBlock
+from .retnet_retention import RetNetRetention
+
+
+class HybridRetention(nn.Module):
+    """Fuse RetNet-style retention with a Mamba linear update."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 1,
+        decay: float | list[float] = 0.9,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.retention = RetNetRetention(num_heads=num_heads, decay=decay)
+        self.mamba = MambaBlock(dim=dim, dropout=dropout, residual=True)
+
+    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        """Apply retention then a gated linear recurrence."""
+        retained = self.retention(q, k, v)
+        return self.mamba(retained)
+
+
+__all__ = ["HybridRetention"]

--- a/tests/test_hierarchical_memory.py
+++ b/tests/test_hierarchical_memory.py
@@ -100,6 +100,17 @@ class TestHierarchicalMemory(unittest.TestCase):
             mem2 = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10, db_path=tmpdir)
             self.assertEqual(len(mem2), 2)
 
+    def test_modalities(self):
+        torch.manual_seed(0)
+        mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+        text = torch.randn(2, 4)
+        images = torch.randn(2, 4)
+        mem.add_modalities(text, images, metadata=["a", "b"])
+        q = text[0]
+        out, meta = mem.search_by_modality(q, k=1, modality="text")
+        self.assertEqual(out.shape, (1, 4))
+        self.assertEqual(meta[0]["modality"], "text")
+
     def test_sync_methods_inside_event_loop(self):
         torch.manual_seed(0)
 

--- a/tests/test_hybrid_retention.py
+++ b/tests/test_hybrid_retention.py
@@ -1,0 +1,18 @@
+import unittest
+import torch
+
+from asi.hybrid_retention import HybridRetention
+
+
+class TestHybridRetention(unittest.TestCase):
+    def test_forward_shape(self):
+        module = HybridRetention(dim=8, num_heads=2)
+        q = torch.randn(2, 4, 8)
+        k = torch.randn(2, 4, 8)
+        v = torch.randn(2, 4, 8)
+        out = module(q, k, v)
+        self.assertEqual(out.shape, q.shape)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_meta_rl_refactor.py
+++ b/tests/test_meta_rl_refactor.py
@@ -13,6 +13,7 @@ spec = importlib.util.spec_from_loader(loader.name, loader)
 meta_rl_refactor = importlib.util.module_from_spec(spec)
 loader.exec_module(meta_rl_refactor)
 MetaRLRefactorAgent = meta_rl_refactor.MetaRLRefactorAgent
+QAEHyperparamSearch = meta_rl_refactor.QAEHyperparamSearch
 
 
 
@@ -26,6 +27,19 @@ class TestMetaRLRefactorAgent(unittest.TestCase):
         self.assertGreater(agent.q[(s1, "replace")], 0.0)
         action = agent.select_action(s1)
         self.assertEqual(action, "replace")
+
+    def test_tune_epsilon(self):
+        calls = []
+
+        def eval_func(eps: float) -> bool:
+            calls.append(eps)
+            return eps > 0.2
+
+        agent = MetaRLRefactorAgent(epsilon=0.5)
+        best, prob = agent.tune_epsilon([0.1, 0.3, 0.5], eval_func, shots=5)
+        self.assertIn(best, [0.3, 0.5])
+        self.assertGreaterEqual(prob, 0.0)
+        self.assertEqual(agent.epsilon, best)
 
 
 class TestMetaRLRefactorCLI(unittest.TestCase):


### PR DESCRIPTION
## Summary
- implement `HybridRetention` combining RetNet retention with Mamba block
- extend `HierarchicalMemory` with `add_modalities` and `search_by_modality`
- store embeddings in `cross_modal_fusion.encode_all`
- integrate `QAEHyperparamSearch` with `MetaRLRefactorAgent`
- add relevant unit tests

## Testing
- `pytest tests/test_hybrid_retention.py tests/test_cross_modal_fusion.py tests/test_hierarchical_memory.py tests/test_meta_rl_refactor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686326bdd9888331b539a4db835ac6fa