### PR TITLE
Implement hybrid retention module

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -178,7 +178,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 
 1. **Hybrid retention backbone**: Fuse `RetNetRetention` with `MambaBlock` and
    measure throughput and memory compared with the individual kernels.
-   *Implemented in `src/hybrid_retention.py`.*
+   *Implemented in `src/hybrid_retention.py` with unit tests.*
 2. **Cross-modal retrieval memory**: Store embeddings from
    `cross_modal_fusion.encode_all()` inside `HierarchicalMemory` and evaluate
    retrieval accuracy on 1&nbsp;M-token streams.

--- a/src/hybrid_retention.py
+++ b/src/hybrid_retention.py
@@ -1,28 +1,65 @@
 import torch
 from torch import nn
 
-from .mamba_block import MambaBlock
-from .retnet_retention import RetNetRetention
-
-
 class HybridRetention(nn.Module):
-    """Fuse RetNet-style retention with a Mamba linear update."""
+    """RetNet decay kernel followed by a Mamba-style linear update."""
 
     def __init__(
         self,
+        num_heads: int,
         dim: int,
-        num_heads: int = 1,
         decay: float | list[float] = 0.9,
         dropout: float = 0.0,
+        residual: bool = False,
     ) -> None:
         super().__init__()
-        self.retention = RetNetRetention(num_heads=num_heads, decay=decay)
-        self.mamba = MambaBlock(dim=dim, dropout=dropout, residual=True)
+        self.num_heads = num_heads
+        self.dim = dim
+        if isinstance(decay, float):
+            decay = [decay] * num_heads
+        if len(decay) != num_heads:
+            raise ValueError("decay must have length equal to num_heads")
+        self.register_buffer("decay", torch.tensor(decay).view(1, num_heads, 1))
+
+        # linear update parameters from MambaBlock
+        self.in_proj = nn.Linear(dim, dim)
+        self.out_proj = nn.Linear(dim, dim)
+        self.gate = nn.Linear(dim, dim)
+        self.A = nn.Parameter(torch.randn(dim, dim) * 0.1)
+        self.B = nn.Parameter(torch.randn(dim, dim) * 0.1)
+        self.drop = nn.Dropout(dropout)
+        self.use_residual = residual
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
-        """Apply retention then a gated linear recurrence."""
-        retained = self.retention(q, k, v)
-        return self.mamba(retained)
+        """Apply retention then gated linear recurrence."""
+        batch, seq, dim = q.shape
+        if dim != self.dim:
+            raise ValueError("dim mismatch")
+        if dim % self.num_heads != 0:
+            raise ValueError("dim must be divisible by num_heads")
+        head_dim = dim // self.num_heads
+
+        q = q.view(batch, seq, self.num_heads, head_dim)
+        k = k.view(batch, seq, self.num_heads, head_dim)
+        v = v.view(batch, seq, self.num_heads, head_dim)
+
+        r = torch.zeros(batch, self.num_heads, head_dim, device=q.device, dtype=q.dtype)
+        state = torch.zeros(batch, dim, device=q.device, dtype=q.dtype)
+        outputs = []
+        for t in range(seq):
+            r = self.decay * r + k[:, t] * v[:, t]
+            retained = (q[:, t] * r).view(batch, dim)
+
+            inp = self.in_proj(retained)
+            gate = torch.sigmoid(self.gate(inp))
+            blended = gate * state + (1 - gate) * inp
+            state = torch.tanh(blended @ self.A.t() + inp @ self.B.t())
+            state = self.drop(state)
+            out = self.out_proj(state)
+            if self.use_residual:
+                out = out + retained
+            outputs.append(out)
+        return torch.stack(outputs, dim=1)
 
 
 __all__ = ["HybridRetention"]

--- a/tests/test_hybrid_retention.py
+++ b/tests/test_hybrid_retention.py
@@ -6,10 +6,18 @@ from asi.hybrid_retention import HybridRetention
 
 class TestHybridRetention(unittest.TestCase):
     def test_forward_shape(self):
-        module = HybridRetention(dim=8, num_heads=2)
-        q = torch.randn(2, 4, 8)
-        k = torch.randn(2, 4, 8)
-        v = torch.randn(2, 4, 8)
+        module = HybridRetention(num_heads=1, dim=4)
+        q = torch.randn(2, 5, 4)
+        k = torch.randn(2, 5, 4)
+        v = torch.randn(2, 5, 4)
+        out = module(q, k, v)
+        self.assertEqual(out.shape, q.shape)
+
+    def test_multihead_shapes(self):
+        module = HybridRetention(num_heads=2, dim=8, decay=[0.9, 0.8])
+        q = torch.randn(3, 4, 8)
+        k = torch.randn(3, 4, 8)
+        v = torch.randn(3, 4, 8)
         out = module(q, k, v)
         self.assertEqual(out.shape, q.shape)
 


### PR DESCRIPTION
## Summary
- combine decay kernel from `RetNetRetention` with the linear Mamba update
- expose `HybridRetention(num_heads, dim, decay, dropout)`
- test multi-head behavior in `tests/test_hybrid_retention.py`
- mention unit tests in `docs/Plan.md`

## Testing
- `pytest tests/test_hybrid_retention.py tests/test_retnet_retention.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68633a0b3fc48331ac1dacc7cdb323cb