### PR TITLE
Add GraphOfThought reasoning graph

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -454,8 +454,9 @@ txt = generate_transcript(pairs[0][2])
   processes or hosts and aggregate the results.
 - Extend `transformer_circuits.py` with an `AttentionVisualizer` class that
   saves interactive attention heatmaps for interpretability experiments.
-- Prototype a `GraphOfThoughtPlanner` that composes reasoning steps into a
-  searchable graph for code refactoring decisions.
+- **Implemented** a `GraphOfThoughtPlanner` via `GraphOfThought` (see
+  `src/graph_of_thought.py`) that composes reasoning steps into a searchable
+  graph for code refactoring decisions.
 - Add a `NeuroSymbolicExecutor` module that runs logical constraints alongside
   neural world-model rollouts.
 - Implement a `DistributedTrainer` that automatically restarts failed

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -201,8 +201,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
    to test world-model learning from mixed-modality self-play data.
 10. **Attention trace analysis**: Use the upcoming `AttentionVisualizer` to
    inspect long-context retrieval patterns on ≥1&nbsp;M-token evaluations.
-11. **Graph-of-thought planning**: Prototype `GraphOfThoughtPlanner` and measure
-    refactor quality gains over the baseline meta-RL agent.
+11. **Graph-of-thought planning**: Implement `GraphOfThought` (see
+    `src/graph_of_thought.py`) and measure refactor quality gains over the
+    baseline meta-RL agent.
 12. **Neuro-symbolic world model**: Integrate `NeuroSymbolicExecutor` with
     `world_model_rl.rollout_policy()` and log constraint violations.
 13. **Self-healing distributed trainer**: Wrap `world_model_rl.train_world_model()`

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -101,3 +101,4 @@ from .transformer_circuits import (
     patched_head,
     head_importance,
 )
+from .graph_of_thought import GraphOfThought

--- a/src/graph_of_thought.py
+++ b/src/graph_of_thought.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Sequence
+import json
+
+
+@dataclass
+class ThoughtNode:
+    """Node representing a reasoning step."""
+
+    id: int
+    text: str
+    metadata: Dict[str, Any] | None = None
+
+
+class GraphOfThought:
+    """Simple searchable reasoning graph."""
+
+    def __init__(self) -> None:
+        self.nodes: Dict[int, ThoughtNode] = {}
+        self.edges: Dict[int, List[int]] = {}
+
+    def add_step(
+        self, text: str, metadata: Dict[str, Any] | None = None, node_id: int | None = None
+    ) -> int:
+        """Add a reasoning step and return its node id."""
+        if node_id is None:
+            node_id = max(self.nodes.keys(), default=-1) + 1
+        self.nodes[node_id] = ThoughtNode(node_id, text, metadata or {})
+        self.edges.setdefault(node_id, [])
+        return node_id
+
+    def connect(self, src: int, dst: int) -> None:
+        """Create a directed edge from ``src`` to ``dst``."""
+        if src not in self.nodes or dst not in self.nodes:
+            raise KeyError("unknown node id")
+        self.edges.setdefault(src, []).append(dst)
+
+    def search(self, start: int, goal_pred: Callable[[ThoughtNode], bool]) -> List[int]:
+        """Return path of node ids from ``start`` until ``goal_pred`` is satisfied."""
+        if start not in self.nodes:
+            raise KeyError("unknown start node")
+        visited = {start}
+        queue: deque[tuple[int, List[int]]] = deque([(start, [start])])
+        while queue:
+            node_id, path = queue.popleft()
+            node = self.nodes[node_id]
+            if goal_pred(node):
+                return path
+            for nxt in self.edges.get(node_id, []):
+                if nxt not in visited:
+                    visited.add(nxt)
+                    queue.append((nxt, path + [nxt]))
+        return []
+
+    def plan_refactor(self, start: int, keyword: str = "refactor") -> List[int]:
+        """Search for a node containing ``keyword`` in its text."""
+        key = keyword.lower()
+        return self.search(start, lambda node: key in node.text.lower())
+
+    @classmethod
+    def from_json(cls, path: str) -> "GraphOfThought":
+        """Load graph from a JSON file."""
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        graph = cls()
+        for node in data.get("nodes", []):
+            graph.add_step(
+                node.get("text", ""),
+                metadata=node.get("metadata"),
+                node_id=int(node["id"]),
+            )
+        for src, dst in data.get("edges", []):
+            graph.connect(int(src), int(dst))
+        return graph
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """CLI entry point for planning code refactors."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Search reasoning graph for refactor plan")
+    parser.add_argument("graph", help="Path to graph JSON file")
+    parser.add_argument("start", type=int, help="Start node id")
+    parser.add_argument("--goal", default="refactor", help="Goal keyword")
+    args = parser.parse_args(argv)
+
+    graph = GraphOfThought.from_json(args.graph)
+    path = graph.plan_refactor(args.start, args.goal)
+    if path:
+        print(" -> ".join(str(n) for n in path))
+    else:
+        print("No plan found")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    main()

--- a/tests/test_graph_of_thought.py
+++ b/tests/test_graph_of_thought.py
@@ -1,0 +1,65 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+import os
+import importlib.machinery
+import importlib.util
+
+loader = importlib.machinery.SourceFileLoader(
+    'graph_of_thought', 'src/graph_of_thought.py'
+)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+graph_mod = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = graph_mod
+loader.exec_module(graph_mod)
+GraphOfThought = graph_mod.GraphOfThought
+
+
+class TestGraphOfThought(unittest.TestCase):
+    def test_add_and_search(self):
+        g = GraphOfThought()
+        a = g.add_step("start")
+        b = g.add_step("analyze")
+        c = g.add_step("apply refactor")
+        g.connect(a, b)
+        g.connect(b, c)
+        path = g.plan_refactor(a, keyword="refactor")
+        self.assertEqual(path, [a, b, c])
+
+    def test_unreachable(self):
+        g = GraphOfThought()
+        a = g.add_step("start")
+        b = g.add_step("middle")
+        g.connect(a, b)
+        path = g.plan_refactor(a, keyword="refactor")
+        self.assertEqual(path, [])
+
+
+class TestGraphOfThoughtCLI(unittest.TestCase):
+    def test_cli_runs(self):
+        data = {
+            "nodes": [
+                {"id": 0, "text": "start"},
+                {"id": 1, "text": "apply refactor"},
+            ],
+            "edges": [[0, 1]],
+        }
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            json.dump(data, f)
+            fname = f.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, "src/graph_of_thought.py", fname, "0"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0)
+            self.assertIn("0 -> 1", proc.stdout)
+        finally:
+            os.unlink(fname)
+
+
+if __name__ == "__main__":  # pragma: no cover - test helper
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `GraphOfThought` for reasoning graphs with search and CLI
- expose `GraphOfThought` in the package init
- document graph-of-thought planning in Plan.md and Implementation.md
- add tests for the new module

## Testing
- `python -m unittest tests.test_graph_of_thought -v`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6863445d1800833191b86334d597be7d