### PR TITLE
Implement SSDCache layer in hierarchical memory

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -469,7 +469,8 @@ txt = generate_transcript(pairs[0][2])
 - Implement an `ElasticMoERouter` that scales the number of active experts
   according to real-time GPU utilization.
 - Extend `HierarchicalMemory` with an `SSDCache` that prefetches high-frequency
-  vectors for faster retrieval.
+  vectors for faster retrieval. *Implemented with a disk-backed cache and
+  persistence helpers in `src/hierarchical_memory.py`.*
 - Build an `AutoDatasetFilter` using generative noise detection to discard
   low-quality training samples before ingestion.
 - Implement a `GenerativeDataAugmentor` that rolls out the world model to

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -217,7 +217,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 17. **Elastic mixture-of-experts routing**: Implement `ElasticMoERouter` to vary
     expert counts with GPU load and compare load balance with the static router.
 18. **Hierarchical SSD caching**: Add an `SSDCache` layer in `HierarchicalMemory`
-    that prefetches frequently accessed vectors for low-latency retrieval.
+    that prefetches frequently accessed vectors for low-latency retrieval. *Implemented
+    in `src/hierarchical_memory.py` with persistence utilities and unit tests.*
 19. **Generative noise filtering**: Use `AutoDatasetFilter` during data ingest to
     prune low-quality samples and track the effect on training stability.
 20. **Generative data augmentor**: Use `GenerativeDataAugmentor` to synthesize

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12,6 +12,7 @@ from .deliberative_alignment import DeliberativeAligner
 from .streaming_compression import ReservoirBuffer, StreamingCompressor
 from .hierarchical_memory import (
     HierarchicalMemory,
+    SSDCache,
     push_remote,
     query_remote,
     push_remote_async,


### PR DESCRIPTION
## Summary
- add a persistent `SSDCache` class for prefetched vectors
- use the cache in `HierarchicalMemory` with save/load support
- export `SSDCache` from the package
- document the new cache in the Plan and Implementation docs
- add unit tests covering cache persistence

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686344660a388331bb40be1704595fa3