### PR TITLE
Add generative data augmentor

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -473,7 +473,8 @@ txt = generate_transcript(pairs[0][2])
 - Build an `AutoDatasetFilter` using generative noise detection to discard
   low-quality training samples before ingestion.
 - Implement a `GenerativeDataAugmentor` that rolls out the world model to
-  synthesize training triples and feeds them through `data_ingest`.
+  synthesize training triples and feeds them through `data_ingest`. **Implemented**
+  in `src/generative_data_augmentor.py`.
 - Add `continuous_eval.py` to schedule `eval_harness` and `autobench` after each
   pull request using GitHub Actions or a local cron job.
 - Combine `GraphOfThoughtPlanner` with `MetaRLRefactorAgent` in an `AdaptivePlanner`

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -221,7 +221,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 19. **Generative noise filtering**: Use `AutoDatasetFilter` during data ingest to
     prune low-quality samples and track the effect on training stability.
 20. **Generative data augmentor**: Use `GenerativeDataAugmentor` to synthesize
-    new training triples from world-model rollouts and expand the dataset.
+    new training triples from world-model rollouts and expand the dataset. The
+    module integrates with `data_ingest` for easy ingestion.
 21. **Continuous evaluation**: Run `continuous_eval.py` after each pull request
     to track benchmark progress automatically.
 22. **Adaptive planning agent**: Merge `GraphOfThoughtPlanner` with

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -92,7 +92,9 @@ from .data_ingest import (
     random_crop_image,
     add_gaussian_noise,
     text_dropout,
+    synthesize_from_world_model,
 )
+from .generative_data_augmentor import GenerativeDataAugmentor
 from .transformer_circuits import (
     ActivationRecorder,
     record_attention_weights,

--- a/src/generative_data_augmentor.py
+++ b/src/generative_data_augmentor.py
@@ -1,0 +1,42 @@
+import numpy as np
+import torch
+from typing import Callable, List, Tuple
+
+try:  # pragma: no cover - load from sys.path
+    from multimodal_world_model import MultiModalWorldModel, rollout
+except Exception:  # pragma: no cover - package relative import
+    from .multimodal_world_model import MultiModalWorldModel, rollout  # type: ignore
+
+
+class GenerativeDataAugmentor:
+    """Synthesize multimodal triples from world-model rollouts."""
+
+    def __init__(self, world_model: MultiModalWorldModel) -> None:
+        self.world_model = world_model
+
+    def _tokenize(self, text: str) -> torch.Tensor:
+        tokens = [ord(c) % self.world_model.cfg.vocab_size for c in text]
+        return torch.tensor(tokens, dtype=torch.long).unsqueeze(0)
+
+    def synthesize(
+        self,
+        start_text: str,
+        start_image: np.ndarray,
+        policy_fn: Callable[[torch.Tensor], torch.Tensor],
+        steps: int = 5,
+    ) -> List[Tuple[str, np.ndarray, np.ndarray]]:
+        """Roll out ``world_model`` and return text-image-audio triples."""
+        t = self._tokenize(start_text)
+        img = torch.tensor(start_image, dtype=torch.float32).unsqueeze(0)
+        states, rewards = rollout(self.world_model, t, img, policy_fn, steps=steps)
+        triples: List[Tuple[str, np.ndarray, np.ndarray]] = []
+        for s, r in zip(states, rewards):
+            val = float(s.mean().item())
+            text = f"latent:{val:.2f}"
+            image = np.full_like(start_image, val, dtype=np.float32)
+            audio = np.full(16, r, dtype=np.float32)
+            triples.append((text, image, audio))
+        return triples
+
+
+__all__ = ["GenerativeDataAugmentor"]

--- a/tests/test_cross_modal_fusion.py
+++ b/tests/test_cross_modal_fusion.py
@@ -23,6 +23,7 @@ def simple_tokenizer(text: str):
 
 class TestCrossModalFusion(unittest.TestCase):
     def setUp(self):
+        torch.manual_seed(0)
         cfg = CrossModalFusionConfig(
             vocab_size=50,
             text_dim=8,

--- a/tests/test_generative_data_augmentor.py
+++ b/tests/test_generative_data_augmentor.py
@@ -1,0 +1,56 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import sys
+import numpy as np
+import torch
+
+loader = importlib.machinery.SourceFileLoader('mmw', 'src/multimodal_world_model.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mmw = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mmw
+sys.modules['asi.multimodal_world_model'] = mmw
+sys.modules['multimodal_world_model'] = mmw
+loader.exec_module(mmw)
+MultiModalWorldModelConfig = mmw.MultiModalWorldModelConfig
+MultiModalWorldModel = mmw.MultiModalWorldModel
+
+loader = importlib.machinery.SourceFileLoader('gda', 'src/generative_data_augmentor.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+gda = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = gda
+sys.modules['asi.generative_data_augmentor'] = gda
+sys.modules['generative_data_augmentor'] = gda
+loader.exec_module(gda)
+GenerativeDataAugmentor = gda.GenerativeDataAugmentor
+
+loader = importlib.machinery.SourceFileLoader('di', 'src/data_ingest.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+di = importlib.util.module_from_spec(spec)
+sys.modules['asi.data_ingest'] = di
+loader.exec_module(di)
+synthesize_from_world_model = di.synthesize_from_world_model
+
+
+class TestGenerativeDataAugmentor(unittest.TestCase):
+    def setUp(self):
+        cfg = MultiModalWorldModelConfig(vocab_size=10, img_channels=3, action_dim=2)
+        self.world_model = MultiModalWorldModel(cfg)
+        self.augmentor = GenerativeDataAugmentor(self.world_model)
+
+    def test_synthesize(self):
+        policy = lambda s: torch.zeros(1, dtype=torch.long)
+        img = np.zeros((3, 4, 4), dtype=np.float32)
+        triples = self.augmentor.synthesize('hi', img, policy, steps=2)
+        self.assertEqual(len(triples), 2)
+        self.assertEqual(triples[0][1].shape, img.shape)
+
+    def test_pipeline(self):
+        policy = lambda s: torch.zeros(1, dtype=torch.long)
+        img = np.zeros((3, 4, 4), dtype=np.float32)
+        out = synthesize_from_world_model(self.augmentor, [('hello', img)], policy, steps=1)
+        self.assertEqual(len(out), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `GenerativeDataAugmentor` for world-model rollouts
- expose integration helper in `data_ingest`
- wire new augmentor through package exports
- document the new module in Implementation and Plan docs
- add tests covering the augmentor and stabilize fusion tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68634468faa4833189c2126e7cea9051