### PR TITLE
Add offline world model data synthesizer

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -408,6 +408,27 @@ img = random_crop(Image.open(pairs[0][1]), (32, 32))
 txt = generate_transcript(pairs[0][2])
 ```
 
+`offline_synthesizer()` rolls out the multimodal world model to generate
+simplified synthetic triples offline:
+
+```python
+from asi.multimodal_world_model import MultiModalWorldModel, MultiModalWorldModelConfig
+from asi.data_ingest import offline_synthesizer
+import torch
+import numpy as np
+
+cfg = MultiModalWorldModelConfig(vocab_size=10, img_channels=1, action_dim=2)
+wm = MultiModalWorldModel(cfg)
+
+def policy(state):
+    return torch.zeros((), dtype=torch.long)
+
+def tokenizer(t: str):
+    return [ord(c) % cfg.vocab_size for c in t]
+
+triples = offline_synthesizer(wm, tokenizer, "hello", np.zeros((1, 4, 4)), policy, steps=2)
+```
+
 ## L-6 Mechanistic Interpretability Tools
 
 - `src/transformer_circuits.py` provides utilities to record attention weights

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -92,6 +92,7 @@ from .data_ingest import (
     random_crop_image,
     add_gaussian_noise,
     text_dropout,
+    offline_synthesizer,
 )
 from .transformer_circuits import (
     ActivationRecorder,

--- a/src/multimodal_world_model.py
+++ b/src/multimodal_world_model.py
@@ -53,8 +53,8 @@ class DynamicsModel(nn.Module):
         self.reward_head = nn.Linear(embed_dim, 1)
 
     def forward(self, state: torch.Tensor, action: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        a = self.action_emb(action).unsqueeze(1)
-        h = self.dec(tgt=a, memory=state.unsqueeze(1)).squeeze(1)
+        a = self.action_emb(action).unsqueeze(0)  # (1, embed_dim)
+        h = self.dec(tgt=a.unsqueeze(0), memory=state.unsqueeze(0)).squeeze(0)
         next_state = self.state_proj(h)
         reward = self.reward_head(h).squeeze(-1)
         return next_state, reward

--- a/tests/test_data_ingest.py
+++ b/tests/test_data_ingest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import importlib.machinery
 import importlib.util
 import sys
+import torch
 
 loader = importlib.machinery.SourceFileLoader('di', 'src/data_ingest.py')
 spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -17,7 +18,18 @@ pair_modalities = di.pair_modalities
 random_crop_image = di.random_crop_image
 add_gaussian_noise = di.add_gaussian_noise
 text_dropout = di.text_dropout
+offline_synthesizer = di.offline_synthesizer
 import numpy as np
+
+loader_mm = importlib.machinery.SourceFileLoader('mm', 'src/multimodal_world_model.py')
+spec_mm = importlib.util.spec_from_loader(loader_mm.name, loader_mm)
+mm = importlib.util.module_from_spec(spec_mm)
+sys.modules['multimodal_world_model'] = mm
+sys.modules['asi.multimodal_world_model'] = mm
+sys.modules['mm'] = mm
+loader_mm.exec_module(mm)
+MultiModalWorldModel = mm.MultiModalWorldModel
+MultiModalWorldModelConfig = mm.MultiModalWorldModelConfig
 
 
 class TestDataIngest(unittest.TestCase):
@@ -45,6 +57,25 @@ class TestDataIngest(unittest.TestCase):
 
         out = text_dropout('the quick brown fox', p=1.0)
         self.assertTrue(out)
+
+    def test_offline_synthesizer(self):
+        cfg = MultiModalWorldModelConfig(vocab_size=10, img_channels=1, action_dim=2, embed_dim=8)
+        wm = MultiModalWorldModel(cfg)
+
+        def policy(state):
+            return torch.zeros((), dtype=torch.long)
+
+        def tokenizer(t: str):
+            return [ord(c) % cfg.vocab_size for c in t]
+
+        img = np.zeros((1, 4, 4), dtype=np.float32)
+        triples = offline_synthesizer(wm, tokenizer, "hi", img, policy, steps=2)
+
+        self.assertEqual(len(triples), 2)
+        t, i, a = triples[0]
+        self.assertIsInstance(t, str)
+        self.assertIsInstance(i, np.ndarray)
+        self.assertIsInstance(a, np.ndarray)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add `offline_synthesizer` helper for generating multimodal triples
- export the new helper in the package
- fix world model dynamics dimension handling
- document synthesizer usage in the implementation guide
- test synthesizer generation

## Testing
- `pip install -e .` *(fails: see logs)*
- `pytest tests/test_data_ingest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6863446fef948331949bb78b43dc2ee8