### PR TITLE
Add self-healing trainer module

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -24,6 +24,7 @@ from .async_vector_store import AsyncFaissVectorStore
 from .iter_align import IterativeAligner
 from .critic_rlhf import CriticScorer, CriticRLHFTrainer
 from .chunkwise_retrainer import ChunkWiseRetrainer
+from .self_healing_trainer import SelfHealingTrainer
 from .scaling_law import BreakpointScalingLaw
 from .link_slot_attention import LinkSlotAttention
 from .mamba_block import MambaBlock

--- a/src/self_healing_trainer.py
+++ b/src/self_healing_trainer.py
@@ -1,0 +1,64 @@
+"""Simple trainer that restarts failed distributed workers."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from typing import Callable, Any
+
+
+class SelfHealingTrainer:
+    """Run a distributed training function with automatic restarts."""
+
+    def __init__(
+        self,
+        worker_fn: Callable[[int, int, Any], None],
+        world_size: int,
+        max_restarts: int = 1,
+        **worker_kwargs: Any,
+    ) -> None:
+        self.worker_fn = worker_fn
+        self.world_size = world_size
+        self.max_restarts = max_restarts
+        self.worker_kwargs = worker_kwargs
+        self._restarts = [0] * world_size
+        self._procs: list[mp.Process | None] = [None] * world_size
+
+    def _worker_wrapper(self, rank: int, queue: mp.Queue) -> None:
+        try:
+            self.worker_fn(rank, self.world_size, **self.worker_kwargs)
+            queue.put((rank, 0))
+        except Exception:  # pragma: no cover - runtime failure path
+            queue.put((rank, 1))
+
+    def _start_worker(self, rank: int, queue: mp.Queue) -> None:
+        proc = mp.Process(target=self._worker_wrapper, args=(rank, queue))
+        proc.start()
+        self._procs[rank] = proc
+
+    def run(self) -> None:
+        """Launch workers and restart them if they fail."""
+        queue: mp.Queue = mp.Queue()
+        for r in range(self.world_size):
+            self._start_worker(r, queue)
+        finished = 0
+        while finished < self.world_size:
+            rank, status = queue.get()
+            proc = self._procs[rank]
+            if proc is not None:
+                proc.join()
+            if status != 0 and self._restarts[rank] < self.max_restarts:
+                self._restarts[rank] += 1
+                self._start_worker(rank, queue)
+                continue
+            if status != 0:
+                for p in self._procs:
+                    if p is not None and p.is_alive():
+                        p.terminate()
+                raise RuntimeError(f"worker {rank} failed")
+            finished += 1
+        for p in self._procs:
+            if p is not None:
+                p.join()
+
+
+__all__ = ["SelfHealingTrainer"]

--- a/tests/test_self_healing_trainer.py
+++ b/tests/test_self_healing_trainer.py
@@ -1,0 +1,44 @@
+import unittest
+import multiprocessing as mp
+import torch
+
+from asi.self_healing_trainer import SelfHealingTrainer
+from asi.distributed_memory import DistributedMemory
+from asi.hierarchical_memory import HierarchicalMemory
+from asi.memory_service import serve
+
+
+class TestSelfHealingTrainer(unittest.TestCase):
+    def test_restart_failed_worker(self):
+        try:
+            import grpc  # noqa: F401
+        except Exception:
+            self.skipTest("grpcio not available")
+
+        remote = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+        server = serve(remote, "localhost:50110")
+        manager = mp.Manager()
+        flags = manager.dict(fail=True)
+
+        def worker(rank: int, world_size: int, addr: str, flags_dict):
+            mem = DistributedMemory(dim=4, compressed_dim=2, capacity=10, remotes=[addr])
+            if rank == 0 and flags_dict.get("fail", False):
+                flags_dict["fail"] = False
+                raise RuntimeError("boom")
+            x = torch.randn(1, 4)
+            mem.add(x, metadata=[f"r{rank}"])
+
+        trainer = SelfHealingTrainer(
+            worker_fn=worker,
+            world_size=2,
+            max_restarts=1,
+            addr="localhost:50110",
+            flags_dict=flags,
+        )
+        trainer.run()
+        server.stop(0)
+        self.assertEqual(len(remote), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `SelfHealingTrainer` to restart failed distributed workers
- expose trainer in the package init
- add unit test covering worker failure recovery

## Testing
- `pytest tests/test_self_healing_trainer.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6863446f15a48331993c5ac9d543d269