### PR TITLE
Add AdaptivePlanner for refactor strategy ranking

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -29,6 +29,7 @@ from .link_slot_attention import LinkSlotAttention
 from .mamba_block import MambaBlock
 from .retnet_retention import RetNetRetention
 from .hybrid_retention import HybridRetention
+from .adaptive_planner import GraphOfThoughtPlanner, AdaptivePlanner
 
 from .pull_request_monitor import (
     list_open_prs,

--- a/src/adaptive_planner.py
+++ b/src/adaptive_planner.py
@@ -1,0 +1,58 @@
+"""Graph-of-thought planning combined with meta-RL refactoring."""
+
+from typing import Callable, Iterable, List, Tuple, Any
+
+try:  # Allow execution as script without package context
+    from .meta_rl_refactor import MetaRLRefactorAgent
+except Exception:  # pragma: no cover - fallback for direct module load
+    import importlib.util as _ilu
+    from pathlib import Path as _Path
+
+    _path = _Path(__file__).resolve().parent / "meta_rl_refactor.py"
+    spec = _ilu.spec_from_file_location("meta_rl_refactor", _path)
+    module = _ilu.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    MetaRLRefactorAgent = module.MetaRLRefactorAgent
+
+
+class GraphOfThoughtPlanner:
+    """Rank strategies using a scoring function."""
+
+    def __init__(self, scorer: Callable[[str], float]) -> None:
+        self.scorer = scorer
+
+    def rank(self, strategies: Iterable[str]) -> List[Tuple[str, float]]:
+        ranked = [(s, float(self.scorer(s))) for s in strategies]
+        ranked.sort(key=lambda x: x[1], reverse=True)
+        return ranked
+
+
+class AdaptivePlanner:
+    """Combine :class:`GraphOfThoughtPlanner` with :class:`MetaRLRefactorAgent`."""
+
+    def __init__(
+        self,
+        scorer: Callable[[str], float],
+        actions: Iterable[str] = ("replace", "refactor", "rollback"),
+        epsilon: float = 0.1,
+    ) -> None:
+        self.planner = GraphOfThoughtPlanner(scorer)
+        self.agent = MetaRLRefactorAgent(actions=actions, epsilon=epsilon)
+        self.state = 0
+
+    def rank_strategies(self, strategies: Iterable[str]) -> List[Tuple[str, float]]:
+        ranked = self.planner.rank(strategies)
+        next_state = self.state
+        for strategy, score in ranked:
+            action = strategy.split()[0]
+            self.agent.update(self.state, action, score, next_state)
+        return ranked
+
+    def best_strategy(self, strategies: Iterable[str]) -> str:
+        ranked = self.rank_strategies(strategies)
+        action = self.agent.select_action(self.state)
+        for strat, _ in ranked:
+            if strat.startswith(action):
+                return strat
+        return ranked[0][0]

--- a/tests/test_adaptive_planner.py
+++ b/tests/test_adaptive_planner.py
@@ -1,0 +1,46 @@
+import unittest
+import importlib.machinery
+import importlib.util
+
+loader = importlib.machinery.SourceFileLoader('adaptive_planner', 'src/adaptive_planner.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+adaptive_planner = importlib.util.module_from_spec(spec)
+loader.exec_module(adaptive_planner)
+AdaptivePlanner = adaptive_planner.AdaptivePlanner
+
+
+def quality_score(strategy: str) -> float:
+    strategy = strategy.lower()
+    if 'refactor' in strategy:
+        return 2.0
+    if 'replace' in strategy:
+        return 1.0
+    return 0.0
+
+
+class TestAdaptivePlanner(unittest.TestCase):
+    def test_ranking(self):
+        planner = AdaptivePlanner(quality_score, epsilon=0.0)
+        strategies = ['rollback', 'replace var', 'refactor loops']
+        ranked = planner.rank_strategies(strategies)
+        self.assertEqual(ranked[0][0], 'refactor loops')
+        self.assertGreater(ranked[0][1], ranked[-1][1])
+
+    def test_learning_improves_quality(self):
+        import random
+
+        random.seed(1)
+        planner = AdaptivePlanner(quality_score, epsilon=1.0)
+        strategies = ['replace foo', 'rollback', 'refactor bar']
+
+        action0 = planner.agent.select_action(0)
+        first = next(s for s in strategies if s.startswith(action0))
+
+        planner.rank_strategies(strategies)
+        planner.agent.epsilon = 0.0
+        second = planner.best_strategy(strategies)
+        self.assertLess(quality_score(first), quality_score(second))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `adaptive_planner` combining `GraphOfThoughtPlanner` with `MetaRLRefactorAgent`
- expose `AdaptivePlanner` from the package
- test ranking and RL-driven quality improvement

## Testing
- `python -m unittest tests.test_adaptive_planner -v`
- ❌ `pytest -q` *(fails: ModuleNotFoundError for torch and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6863446d43648331827918d321cf1ad2