### PR TITLE
Implement edge memory streaming client

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -461,7 +461,7 @@ txt = generate_transcript(pairs[0][2])
 - Implement a `DistributedTrainer` that automatically restarts failed
   processes and coordinates checkpoints with `DistributedMemory`.
 - Build an `EdgeMemoryClient` to stream context vectors to `RemoteMemory`
-  so edge devices can handle large-context inference.
+  so edge devices can handle large-context inference. **Implemented**
 - Create an `AdaptiveCurriculumScheduler` that blends curated data with
   self-play logs using reinforcement learning.
 - Extend `QAEHyperparamSearch` to explore novel transformer components during

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -209,7 +209,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     in a `DistributedTrainer` that automatically resumes from failures.
 14. **Edge-memory virtualization**: Stream context from `HierarchicalMemory`
     through `RemoteMemory` so low-memory devices can handle large-context
-    inference.
+    inference. *Implemented in `src/edge_memory_client.py` with tests.*
 15. **Adaptive curriculum scheduler**: Mix curated datasets with self-play logs
     via reinforcement learning to accelerate skill acquisition.
 16. **Quantum architecture search**: Extend `QAEHyperparamSearch` to explore

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -19,6 +19,7 @@ from .hierarchical_memory import (
 )
 from .distributed_memory import DistributedMemory
 from .remote_memory import RemoteMemory
+from .edge_memory_client import EdgeMemoryClient
 from .vector_store import VectorStore, FaissVectorStore
 from .async_vector_store import AsyncFaissVectorStore
 from .iter_align import IterativeAligner

--- a/src/edge_memory_client.py
+++ b/src/edge_memory_client.py
@@ -1,0 +1,60 @@
+import torch
+from typing import Iterable, Any, Tuple, List
+
+from .remote_memory import RemoteMemory
+
+try:
+    import grpc  # type: ignore
+    _HAS_GRPC = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAS_GRPC = False
+
+
+class EdgeMemoryClient:
+    """Buffering client that streams vectors to :class:`RemoteMemory`."""
+
+    def __init__(self, address: str, buffer_size: int = 32) -> None:
+        if not _HAS_GRPC:
+            raise ImportError("grpcio is required for EdgeMemoryClient")
+        self.remote = RemoteMemory(address)
+        self.buffer_size = buffer_size
+        self._vec_buf: List[torch.Tensor] = []
+        self._meta_buf: List[Any] = []
+
+    def add(self, x: torch.Tensor, metadata: Iterable[Any] | None = None) -> None:
+        """Add vectors to the send buffer and flush when full."""
+        if x.ndim == 1:
+            x = x.unsqueeze(0)
+        metas = list(metadata) if metadata is not None else [None] * len(x)
+        for vec, meta in zip(x, metas):
+            self._vec_buf.append(vec)
+            self._meta_buf.append(meta)
+            if len(self._vec_buf) >= self.buffer_size:
+                self.flush()
+
+    def flush(self) -> None:
+        """Send buffered vectors to the remote store."""
+        if not self._vec_buf:
+            return
+        batch = torch.stack(self._vec_buf)
+        self.remote.add(batch, self._meta_buf)
+        self._vec_buf.clear()
+        self._meta_buf.clear()
+
+    def search(self, query: torch.Tensor, k: int = 5) -> Tuple[torch.Tensor, List[str]]:
+        """Flush pending vectors and query the remote store."""
+        self.flush()
+        return self.remote.search(query, k)
+
+    def close(self) -> None:
+        """Flush remaining vectors."""
+        self.flush()
+
+    def __enter__(self) -> "EdgeMemoryClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+__all__ = ["EdgeMemoryClient"]

--- a/tests/test_edge_memory_client.py
+++ b/tests/test_edge_memory_client.py
@@ -1,0 +1,35 @@
+import unittest
+import torch
+
+from asi.hierarchical_memory import HierarchicalMemory
+from asi.memory_service import serve
+from asi.edge_memory_client import EdgeMemoryClient
+
+
+class TestEdgeMemoryClient(unittest.TestCase):
+    def test_stream_add_and_query(self):
+        try:
+            import grpc  # noqa: F401
+        except Exception:
+            self.skipTest("grpcio not available")
+
+        mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+        server = serve(mem, "localhost:50210")
+
+        client = EdgeMemoryClient("localhost:50210", buffer_size=2)
+        data = torch.randn(3, 4)
+        metas = ["a", "b", "c"]
+
+        for vec, m in zip(data, metas):
+            client.add(vec, metadata=[m])
+
+        out, meta = client.search(data[0], k=1)
+        self.assertEqual(out.shape, (1, 4))
+        self.assertIn(meta[0], metas)
+
+        client.close()
+        server.stop(0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `EdgeMemoryClient` to buffer vectors and forward them to `RemoteMemory`
- expose `EdgeMemoryClient` in the package
- document completion of edge-memory virtualization
- test edge memory streaming behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest tests/test_edge_memory_client.py tests/test_remote_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68634460bb4c83319de17abb9a96ffbd