### PR TITLE
Implement prioritized sampling in skill loop

### DIFF
--- a/src/self_play_skill_loop.py
+++ b/src/self_play_skill_loop.py
@@ -14,7 +14,6 @@ from .robot_skill_transfer import (
 )
 
 
-
 @dataclass
 class SelfPlaySkillLoopConfig:
     """Configuration for :func:`run_loop`."""
@@ -61,11 +60,13 @@ def run_loop(
         for o, a, r in zip(obs_list, acts, rewards):
             buffer.add(o, a, r)
         history.append(sum(rewards) / len(rewards) if rewards else 0.0)
-        sample_frames, sample_actions = buffer.sample(cfg.batch_size)
+        sample_frames, sample_actions = buffer.sample_by_priority(cfg.batch_size)
         dataset = VideoPolicyDataset(sample_frames, sample_actions)
         model = transfer_skills(transfer_cfg, dataset)
 
-        def new_policy(obs: torch.Tensor, m: SkillTransferModel = model) -> torch.Tensor:
+        def new_policy(
+            obs: torch.Tensor, m: SkillTransferModel = model
+        ) -> torch.Tensor:
             with torch.no_grad():
                 logits = m(obs.unsqueeze(0))
                 return logits.argmax(dim=-1).squeeze(0)

--- a/tests/test_self_play_skill_loop.py
+++ b/tests/test_self_play_skill_loop.py
@@ -7,22 +7,28 @@ import importlib.util
 import types
 import sys
 
-pkg = types.ModuleType('asi')
-sys.modules['asi'] = pkg
-loader_env = importlib.machinery.SourceFileLoader('asi.self_play_env', 'src/self_play_env.py')
+pkg = types.ModuleType("asi")
+sys.modules["asi"] = pkg
+loader_env = importlib.machinery.SourceFileLoader(
+    "asi.self_play_env", "src/self_play_env.py"
+)
 spec_env = importlib.util.spec_from_loader(loader_env.name, loader_env)
 self_play_env = importlib.util.module_from_spec(spec_env)
-sys.modules['asi.self_play_env'] = self_play_env
+sys.modules["asi.self_play_env"] = self_play_env
 loader_env.exec_module(self_play_env)
-loader_rst = importlib.machinery.SourceFileLoader('asi.robot_skill_transfer', 'src/robot_skill_transfer.py')
+loader_rst = importlib.machinery.SourceFileLoader(
+    "asi.robot_skill_transfer", "src/robot_skill_transfer.py"
+)
 spec_rst = importlib.util.spec_from_loader(loader_rst.name, loader_rst)
 robot_skill_transfer = importlib.util.module_from_spec(spec_rst)
-sys.modules['asi.robot_skill_transfer'] = robot_skill_transfer
+sys.modules["asi.robot_skill_transfer"] = robot_skill_transfer
 loader_rst.exec_module(robot_skill_transfer)
-loader = importlib.machinery.SourceFileLoader('asi.self_play_skill_loop', 'src/self_play_skill_loop.py')
+loader = importlib.machinery.SourceFileLoader(
+    "asi.self_play_skill_loop", "src/self_play_skill_loop.py"
+)
 spec = importlib.util.spec_from_loader(loader.name, loader)
 self_play_skill_loop = importlib.util.module_from_spec(spec)
-sys.modules['asi.self_play_skill_loop'] = self_play_skill_loop
+sys.modules["asi.self_play_skill_loop"] = self_play_skill_loop
 loader.exec_module(self_play_skill_loop)
 run_loop = self_play_skill_loop.run_loop
 SelfPlaySkillLoopConfig = self_play_skill_loop.SelfPlaySkillLoopConfig
@@ -50,12 +56,65 @@ class TestSelfPlaySkillLoop(unittest.TestCase):
             return DummyModel()
 
         policy = lambda obs: torch.zeros_like(obs)
-        with patch.object(self_play_skill_loop, "rollout_env", fake_rollout), patch.object(self_play_skill_loop, "transfer_skills", fake_transfer):
+        with (
+            patch.object(self_play_skill_loop, "rollout_env", fake_rollout),
+            patch.object(self_play_skill_loop, "transfer_skills", fake_transfer),
+        ):
             rewards, model = run_loop(cfg, policy, frames, actions)
         self.assertEqual(len(rewards), 2)
         self.assertIsInstance(model, DummyModel)
         self.assertTrue(all(r == 1.0 for r in rewards))
 
+    def test_run_loop_prioritized_sampling(self):
+        cfg = SelfPlaySkillLoopConfig(cycles=1, steps=1, epochs=1, batch_size=1)
+        frames = [torch.zeros(cfg.img_channels, 4, 4)]
+        actions = [0]
 
-if __name__ == '__main__':
+        def fake_rollout(env, policy, steps=1, return_actions=False):
+            obs = [torch.zeros(env.state.shape) for _ in range(steps)]
+            rewards = [1.0] * steps
+            acts = [0 for _ in range(steps)]
+            if return_actions:
+                return obs, rewards, acts
+            return obs, rewards
+
+        class DummyModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.zeros(x.size(0), cfg.action_dim)
+
+        def fake_transfer(c, d):
+            return DummyModel()
+
+        buffer_instance = None
+
+        class DummyBuffer:
+            def __init__(self, capacity):
+                self.sample_called = False
+
+            def add(self, *args, **kwargs):
+                pass
+
+            def sample_by_priority(self, batch_size):
+                self.sample_called = True
+                return frames, actions
+
+        def buffer_factory(capacity):
+            nonlocal buffer_instance
+            buffer_instance = DummyBuffer(capacity)
+            return buffer_instance
+
+        policy = lambda obs: torch.zeros_like(obs)
+
+        with (
+            patch.object(self_play_skill_loop, "rollout_env", fake_rollout),
+            patch.object(self_play_skill_loop, "transfer_skills", fake_transfer),
+            patch.object(
+                self_play_skill_loop, "PrioritizedReplayBuffer", buffer_factory
+            ),
+        ):
+            run_loop(cfg, policy, frames, actions)
+        self.assertTrue(buffer_instance.sample_called)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add prioritized replay buffer with explicit priority sampling API
- update self-play skill loop to draw training data by priority
- test that run_loop calls prioritized sampling

## Testing
- `pytest tests/test_prioritized_replay_buffer.py tests/test_self_play_skill_loop.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68634459b4608331acf816be7d1a19eb