### PR TITLE
Add AttentionVisualizer and tests

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -454,6 +454,7 @@ txt = generate_transcript(pairs[0][2])
   processes or hosts and aggregate the results.
 - Extend `transformer_circuits.py` with an `AttentionVisualizer` class that
   saves interactive attention heatmaps for interpretability experiments.
+  **Implemented** in `src/transformer_circuits.py` with unit tests.
 - Prototype a `GraphOfThoughtPlanner` that composes reasoning steps into a
   searchable graph for code refactoring decisions.
 - Add a `NeuroSymbolicExecutor` module that runs logical constraints alongside

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -199,7 +199,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 9. **Self-play dataset fusion**: Feed trajectories from
    `self_play_skill_loop` into `multimodal_world_model.train_world_model()`
    to test world-model learning from mixed-modality self-play data.
-10. **Attention trace analysis**: Use the upcoming `AttentionVisualizer` to
+10. **Attention trace analysis**: Use the new `AttentionVisualizer` to
    inspect long-context retrieval patterns on ≥1&nbsp;M-token evaluations.
 11. **Graph-of-thought planning**: Prototype `GraphOfThoughtPlanner` and measure
     refactor quality gains over the baseline meta-RL agent.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -100,4 +100,5 @@ from .transformer_circuits import (
     restore_attention_head,
     patched_head,
     head_importance,
+    AttentionVisualizer,
 )


### PR DESCRIPTION
## Summary
- extend `transformer_circuits` with `AttentionVisualizer` to save attention heatmaps
- export new class from the package
- document completion in `Implementation.md`
- update plan to reference new visualizer
- test attention visualizer functionality

## Testing
- `pytest tests/test_transformer_circuits.py::TestTransformerCircuits::test_attention_visualizer -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6863445be6a48331836cc758d550500e