### PR TITLE
Add continuous evaluation automation

### DIFF
--- a/.github/workflows/continuous_eval.yml
+++ b/.github/workflows/continuous_eval.yml
@@ -1,0 +1,20 @@
+name: Continuous Eval
+
+on:
+  pull_request:
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run continuous evaluation
+        run: python scripts/continuous_eval.py

--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ code rather than enforcing a specific maximum line length.
 
 Automated tests run on GitHub Actions. The workflow installs the project in editable mode and executes `pytest`.
 See [.github/workflows/test.yml](.github/workflows/test.yml) for details.
+
+Continuous evaluation runs `scripts/continuous_eval.py` after each pull request.
+The script invokes `eval_harness` and `autobench` to track benchmark progress.
+See [.github/workflows/continuous_eval.yml](.github/workflows/continuous_eval.yml)
+for the GitHub Actions setup or schedule it locally with `cron`.

--- a/scripts/continuous_eval.py
+++ b/scripts/continuous_eval.py
@@ -1,0 +1,29 @@
+import argparse
+from asi.eval_harness import parse_modules, evaluate_modules, format_results
+from asi.autobench import run_autobench, summarize_results
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Run eval_harness and autobench for continuous evaluation"
+    )
+    parser.add_argument(
+        "--plan", default="docs/Plan.md", help="Path to Plan.md listing modules"
+    )
+    parser.add_argument(
+        "--test-dir", default="tests", help="Directory containing test files"
+    )
+    args = parser.parse_args(argv)
+
+    print("=== Eval Harness ===")
+    modules = parse_modules(args.plan)
+    results = evaluate_modules(modules)
+    print(format_results(results))
+
+    print("\n=== Autobench ===")
+    bench = run_autobench(args.test_dir)
+    print(summarize_results(bench))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- implement `scripts/continuous_eval.py` to run `eval_harness` and `autobench`
- run the script in a new GitHub Actions workflow
- document continuous evaluation workflow in the README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `python -m src.autobench`

------
https://chatgpt.com/codex/tasks/task_e_6863446a07508331b27b7ba9010cf8b1