### PR TITLE
Add self-play world model training helper

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -398,6 +398,10 @@ python scripts/distributed_memory_benchmark.py --servers 4 --vectors 100
 
 - `src/world_model_rl.py` learns a generative world model from logged trajectories and runs model-based RL for rapid policy updates.
 - The prototype interfaces with ``gym``-like data and provides ``rollout_policy()`` for offline rollout generation.
+- `train_with_self_play()` runs ``self_play_skill_loop.run_loop`` to collect
+  transitions, converts them into ``TrajectoryDataset`` entries and calls
+  ``train_world_model``.
+
 
 ## M-3 Self-Calibration for Embodied Agents
 

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -200,9 +200,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 8. **Checkpointed world model**: *(done)* the multimodal world model now
    supports a `checkpoint_blocks` flag which reduces memory usage during
    training.
-9. **Self-play dataset fusion**: Feed trajectories from
-   `self_play_skill_loop` into `multimodal_world_model.train_world_model()`
-   to test world-model learning from mixed-modality self-play data.
+9. **Self-play dataset fusion**: *(implemented)* `train_with_self_play` records
+   trajectories from `self_play_skill_loop.run_loop` and feeds them into
+   `train_world_model` for mixed-modality experiments.
 10. **Attention trace analysis**: Use the new `AttentionVisualizer` to
    inspect long-context retrieval patterns on ≥1&nbsp;M-token evaluations.
 11. **Graph-of-thought planning**: Implement `GraphOfThought` (see

--- a/scripts/self_play_world_model.py
+++ b/scripts/self_play_world_model.py
@@ -1,0 +1,24 @@
+import torch
+from asi.self_play_skill_loop import SelfPlaySkillLoopConfig
+from asi.world_model_rl import RLBridgeConfig, train_with_self_play
+
+
+def main() -> None:
+    sp_cfg = SelfPlaySkillLoopConfig(cycles=2, steps=5)
+    rl_cfg = RLBridgeConfig(
+        state_dim=sp_cfg.env_state_dim,
+        action_dim=sp_cfg.action_dim,
+        epochs=1,
+        batch_size=4,
+    )
+    frames = [torch.randn(sp_cfg.img_channels, 8, 8) for _ in range(4)]
+    actions = [0 for _ in frames]
+    policy = lambda obs: torch.zeros((), dtype=torch.long)
+
+    wm, skill_model = train_with_self_play(rl_cfg, sp_cfg, policy, frames, actions)
+    print("world model trained", isinstance(wm, torch.nn.Module))
+    print("skill model", type(skill_model).__name__)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -81,8 +81,10 @@ from .cross_modal_fusion import (
 from .world_model_rl import (
     RLBridgeConfig,
     TransitionDataset,
+    TrajectoryDataset,
     WorldModel as RLWorldModel,
     train_world_model as train_rl_world_model,
+    train_with_self_play,
     rollout_policy,
 )
 from .embodied_calibration import (


### PR DESCRIPTION
## Summary
- integrate self-play skill loop with world-model RL
- export `train_with_self_play` and dataset alias
- add simple demonstration script
- document the new workflow
- mark self-play dataset fusion as implemented

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864868829948331b5f80d7a82db5518