### PR TITLE
Update cross modal memory storage

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -469,10 +469,12 @@ triples = offline_synthesizer(wm, tokenizer, "hello", np.zeros((1, 4, 4)), polic
 ### Upcoming Implementation Tasks
 
 - Create a `HybridRetention` module that combines the linear update from
-  `MambaBlock` with the decay kernel in `RetNetRetention`. **Implemented** in
+- `MambaBlock` with the decay kernel in `RetNetRetention`. **Implemented** in
   `src/hybrid_retention.py` with a unit test.
 - Extend `HierarchicalMemory` so `cross_modal_fusion.encode_all()` can store and
-  retrieve averaged multimodal embeddings via `add_multimodal`.
+  retrieve averaged multimodal embeddings via `add_multimodal`. **Implemented**:
+  `encode_all()` now calls `memory.add_multimodal()` when a memory instance is
+  passed, enabling lookup on the fused embedding.
 - Rewrite `download_triples()` with asyncio as `download_triples_async` for faster
   dataset fetching.
 - Add a `log_memory_usage()` helper to `eval_harness.py` and print GPU memory

--- a/src/cross_modal_fusion.py
+++ b/src/cross_modal_fusion.py
@@ -178,7 +178,7 @@ def encode_all(
             if memory is not None:
                 start = idx * batch_size
                 metas = [start + i for i in range(tokens.size(0))]
-                memory.add_modalities(t_emb.cpu(), i_emb.cpu(), a_emb.cpu(), metas)
+                memory.add_multimodal(t_emb.cpu(), i_emb.cpu(), a_emb.cpu(), metas)
     all_t = torch.cat(text_vecs, dim=0)
     all_i = torch.cat(img_vecs, dim=0)
     all_a = torch.cat(aud_vecs, dim=0)

--- a/tests/test_cross_modal_fusion.py
+++ b/tests/test_cross_modal_fusion.py
@@ -56,12 +56,12 @@ class TestCrossModalFusion(unittest.TestCase):
         ]
         ds = MultiModalDataset(triples, simple_tokenizer)
         mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
-        vecs = encode_all(self.model, ds, batch_size=1, memory=mem)
-        self.assertEqual(vecs[0].shape[0], len(ds))
-        q = vecs[0][0]
-        out, meta = mem.search_by_modality(q, k=1, modality="text")
+        t, i, a = encode_all(self.model, ds, batch_size=1, memory=mem)
+        self.assertEqual(t.shape[0], len(ds))
+        q = (t[0] + i[0] + a[0]) / 3.0
+        out, meta = mem.search(q, k=1)
         self.assertEqual(out.shape, (1, 4))
-        self.assertEqual(meta[0]["modality"], "text")
+        self.assertEqual(meta[0], 0)
 
     def test_mixed_modality_retrieval(self):
         triples = [
@@ -72,13 +72,13 @@ class TestCrossModalFusion(unittest.TestCase):
         mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
         t, i, a = encode_all(self.model, ds, batch_size=1, memory=mem)
 
-        out, meta = mem.search_by_modality(a[0], k=1, modality="image")
-        self.assertEqual(meta[0]["id"], 0)
-        self.assertEqual(meta[0]["modality"], "image")
+        q0 = (t[0] + i[0] + a[0]) / 3.0
+        out, meta = mem.search(q0, k=1)
+        self.assertEqual(meta[0], 0)
 
-        out, meta = mem.search_by_modality(t[1], k=1, modality="audio")
-        self.assertEqual(meta[0]["id"], 1)
-        self.assertEqual(meta[0]["modality"], "audio")
+        q1 = (t[1] + i[1] + a[1]) / 3.0
+        out, meta = mem.search(q1, k=1)
+        self.assertEqual(meta[0], 1)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- use `add_multimodal` when encoding with a memory
- test retrieval of averaged vectors
- document new `encode_all` behaviour

## Testing
- `pytest -q tests/test_cross_modal_fusion.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686486854cc48331aa29a05441d3fffe