### PR TITLE
Fix scheduler reference

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -520,7 +520,7 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   in `src/distributed_trainer.py` with tests.
 - Build an `EdgeMemoryClient` to stream context vectors to `RemoteMemory`
   so edge devices can handle large-context inference. **Implemented**
-- Create an `AdaptiveCurriculumScheduler` that blends curated data with
+- Create an `AdaptiveCurriculum` that blends curated data with
   self-play logs using reinforcement learning.
 - Extend `QAEHyperparamSearch` to explore novel transformer components during
   architecture search.


### PR DESCRIPTION
## Summary
- update docs to reference AdaptiveCurriculum rather than the outdated AdaptiveCurriculumScheduler

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68648da791a083318764732a511d4f00