### PR TITLE
Mark tasks 21-25 as implemented

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -529,12 +529,12 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Implement a `GenerativeDataAugmentor` that rolls out the world model to
   synthesize training triples and feeds them through `data_ingest`. **Implemented**
   in `src/generative_data_augmentor.py`.
-- Add `continuous_eval.py` to schedule `eval_harness` and `autobench` after each pull request using GitHub Actions or a local cron job. **Implemented**
+- Add `continuous_eval.py` to schedule `eval_harness` and `autobench` after each pull request using GitHub Actions or a local cron job. **Implemented in `scripts/continuous_eval.py`.**
 - Combine `GraphOfThoughtPlanner` with `MetaRLRefactorAgent` in an `AdaptivePlanner`
-  module that ranks and applies refactor suggestions automatically.
+  module that ranks and applies refactor suggestions automatically. **Implemented in `src/adaptive_planner.py`.**
 - `src/neural_arch_search.py` implements distributed architecture search and is
-  integrated with `eval_harness.py` to score candidate models automatically.
+  integrated with `eval_harness.py` to score candidate models automatically. **Implemented in `src/neural_arch_search.py`.**
 - Implement a `SelfHealingTrainer` that monitors distributed jobs and restarts
-  failed runs to maintain full compute utilization.
+  failed runs to maintain full compute utilization. **Implemented in `src/self_healing_trainer.py`.**
 - Extend `data_ingest.py` with an `offline_synthesizer` that uses the world
-  model to generate synthetic multimodal triples for training.
+  model to generate synthetic multimodal triples for training. **Implemented as `data_ingest.offline_synthesizer`.**

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -236,15 +236,20 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     new training triples from world-model rollouts and expand the dataset. The
     module integrates with `data_ingest` for easy ingestion.
 21. **Continuous evaluation**: Run `continuous_eval.py` after each pull request
-    to track benchmark progress automatically.
+    to track benchmark progress automatically. *Implemented in
+    `scripts/continuous_eval.py`.*
 22. **Adaptive planning agent**: Merge `GraphOfThoughtPlanner` with
-    `MetaRLRefactorAgent` to auto-rank refactor strategies.
+    `MetaRLRefactorAgent` to auto-rank refactor strategies. *Implemented in
+    `src/adaptive_planner.py`.*
 23. **Neural architecture search**: Evaluate `src/neural_arch_search.py` across
     candidate module configurations and report accuracy vs. compute costs.
+    *Implemented in `src/neural_arch_search.py`.*
 24. **Self-healing distributed training**: Deploy `SelfHealingTrainer` to
     restart failed jobs automatically and track overall utilization.
+    *Implemented in `src/self_healing_trainer.py`.*
 25. **World-model data synthesis**: Use the `offline_synthesizer` to generate
-    synthetic multimodal triples and measure retrieval improvements.
+    synthetic multimodal triples and measure retrieval improvements. *Implemented
+    in `data_ingest.offline_synthesizer`.*
 
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."


### PR DESCRIPTION
## Summary
- note implementations for Plan tasks 21–25
- record implemented modules in Implementation.md

## Testing
- `grep -n "scripts/continuous_eval.py" -n docs/Implementation.md`


------
https://chatgpt.com/codex/tasks/task_e_68649853f4308331b6f0632f56606ad8