### PR TITLE
Add roadmap items for memory and distillation

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -553,3 +553,10 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Implement a `MultiAgentCoordinator` that synchronizes multiple `MetaRLRefactorAgent` instances and schedules cooperative refactoring tasks across repositories.
 - Implement a `PQVectorStore` using FAISS `IndexIVFPQ` for compressed vector storage and integrate it with `HierarchicalMemory`. Benchmark retrieval accuracy against `FaissVectorStore`.
 - Add a `DuplicateDetector` that uses CLIP embeddings with locality-sensitive hashing to drop near-duplicate samples during ingestion and connect it to `AutoDatasetFilter`.
+- Implement a `TemporalVectorCompressor` in `streaming_compression.py` with a
+  decay factor so `HierarchicalMemory` can prioritize recent context. Benchmark
+  retrieval accuracy against the existing compressor.
+- Add a `CrossLingualTranslator` helper in `data_ingest.py` to translate text
+  into multiple languages during ingestion and store the augmented triples.
+- Create a `WorldModelDistiller` module and a `scripts/distill_world_model.py`
+  utility to train smaller student models from the large world model.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -282,6 +282,17 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 37. **Duplicate data filter**: Use CLIP embeddings with locality-sensitive
     hashing to drop near-duplicate samples during ingestion and connect it to
     `AutoDatasetFilter`.
+38. **Temporal decay memory**: Add a `TemporalVectorCompressor` that weights
+    embeddings by recency. Evaluate retrieval accuracy drop <3% compared with
+    the existing `StreamingCompressor` on 1&nbsp;M-token streams.
+39. **Cross-lingual data ingestion**: Integrate a `CrossLingualTranslator`
+    into `data_ingest` so text is stored in multiple languages. Measure BLEU
+    >30 on public benchmarks and track retrieval gains from the augmented
+    triples.
+40. **World-model distillation**: Implement a `WorldModelDistiller` that
+    compresses the large world model into a smaller student network. Target
+    <5% reward loss on the embodied RL benchmarks while reducing model size by
+    ≥4×.
 
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."


### PR DESCRIPTION
## Summary
- propose temporal decay memory, cross-lingual ingestion, and distillation in docs/Plan.md
- append implementation notes for new compression, translation, and distillation modules

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6865765ae39c8331a36a48556f0269bb