### PR TITLE
Add memory profiler hooks

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -193,9 +193,13 @@ print(model.breakpoint, model.predict(params))
  they block with ``asyncio.run``. Inside a running loop they return an
  ``asyncio.Task`` so callers can ``await`` the scheduled operation. The
  explicit async variants (`aadd`, `adelete`, `asearch`, `save_async`,
- `load_async`) remain available for direct use.
- `HierarchicalMemory` defines `__len__` so `len(mem)` reports the number of
- stored vectors.
+`load_async`) remain available for direct use.
+`HierarchicalMemory` defines `__len__` so `len(mem)` reports the number of
+stored vectors.
+- `src/memory_profiler.py` hooks into `HierarchicalMemory` and records query
+  counts, hit/miss ratios and latency. Call `start_profiling()` on a memory
+  instance to begin collecting metrics and `report_stats()` to dump them as JSON
+  or CSV.
 
 ## C-4 MegaByte Patching
 

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -305,6 +305,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 49. **Dataset lineage manager**: Automatically track dataset versions and transformations, enabling reproducible training pipelines.
 50. **Multi-stage oversight**: Combine constitutional AI, deliberative alignment, and critic-in-the-loop RLHF with formal verification; success is <1% harmful output on the existing benchmarks.
 51. **Self-supervised sensorimotor pretraining**: Pretrain the embodied world model on large unlabelled multimodal logs; success is 20% fewer real-world samples to reach 90% task success.
+52. **Memory profiling**: Instrument `HierarchicalMemory` with a lightweight profiler that records query counts, hit/miss ratios and latency.
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."
 [3]: https://www.businessinsider.com/openai-orion-model-scaling-law-silicon-valley-chatgpt-2024-11?utm_source=chatgpt.com "OpenAI is reportedly struggling to improve its next big AI model. It's a warning for the entire AI industry."

--- a/src/memory_profiler.py
+++ b/src/memory_profiler.py
@@ -1,0 +1,92 @@
+"""Simple profiling hooks for HierarchicalMemory."""
+
+from __future__ import annotations
+
+import json
+import time
+from io import StringIO
+from typing import Any, Callable, Dict, Tuple
+
+import torch
+
+from .hierarchical_memory import HierarchicalMemory
+
+
+class MemoryProfiler:
+    """Record query statistics from a HierarchicalMemory instance."""
+
+    def __init__(self, memory: HierarchicalMemory) -> None:
+        self.memory = memory
+        self.reset()
+        self._orig_search: Callable[..., Tuple[torch.Tensor, list]] | None = None
+        self._orig_asearch: Callable[..., Any] | None = None
+
+    def reset(self) -> None:
+        """Reset all counters."""
+        self.query_count = 0
+        self.hit_count = 0
+        self.miss_count = 0
+        self.total_latency = 0.0
+
+    # --------------------------------------------------------------
+    def start_profiling(self) -> None:
+        """Patch the memory instance so searches update stats."""
+        if self._orig_search is not None:
+            return
+
+        self._orig_search = self.memory.search
+
+        def search_wrapper(query: torch.Tensor, k: int = 5):
+            start = time.perf_counter()
+            out, meta = self._orig_search(query, k)
+            elapsed = time.perf_counter() - start
+            self.query_count += 1
+            self.total_latency += elapsed
+            if meta:
+                self.hit_count += 1
+            else:
+                self.miss_count += 1
+            return out, meta
+
+        self.memory.search = search_wrapper  # type: ignore[assignment]
+
+        if hasattr(self.memory, "asearch"):
+            self._orig_asearch = self.memory.asearch
+
+            async def asearch_wrapper(query: torch.Tensor, k: int = 5):
+                start = time.perf_counter()
+                out, meta = await self._orig_asearch(query, k)
+                elapsed = time.perf_counter() - start
+                self.query_count += 1
+                self.total_latency += elapsed
+                if meta:
+                    self.hit_count += 1
+                else:
+                    self.miss_count += 1
+                return out, meta
+
+            self.memory.asearch = asearch_wrapper  # type: ignore[assignment]
+
+    # --------------------------------------------------------------
+    def report_stats(self, fmt: str = "json") -> str:
+        """Return collected metrics in ``json`` or ``csv`` format."""
+        avg_latency = self.total_latency / self.query_count if self.query_count else 0.0
+        stats: Dict[str, Any] = {
+            "queries": self.query_count,
+            "hits": self.hit_count,
+            "misses": self.miss_count,
+            "hit_rate": self.hit_count / self.query_count if self.query_count else 0.0,
+            "avg_latency": avg_latency,
+        }
+        if fmt.lower() == "csv":
+            buf = StringIO()
+            buf.write(",".join(["queries", "hits", "misses", "hit_rate", "avg_latency"]))
+            buf.write("\n")
+            buf.write(
+                f"{stats['queries']},{stats['hits']},{stats['misses']},{stats['hit_rate']},{stats['avg_latency']}"
+            )
+            return buf.getvalue()
+        return json.dumps(stats)
+
+
+__all__ = ["MemoryProfiler"]

--- a/tests/test_memory_profiler.py
+++ b/tests/test_memory_profiler.py
@@ -1,0 +1,51 @@
+import asyncio
+import json
+import unittest
+import torch
+
+from asi.hierarchical_memory import HierarchicalMemory
+from asi.memory_profiler import MemoryProfiler
+
+
+class TestMemoryProfiler(unittest.TestCase):
+    def test_stats_collection(self):
+        torch.manual_seed(0)
+        mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+        profiler = MemoryProfiler(mem)
+        profiler.start_profiling()
+
+        # miss before any vectors are added
+        mem.search(torch.randn(4), k=1)
+
+        data = torch.randn(1, 4)
+        mem.add(data, metadata=["x"])
+        mem.search(data[0], k=1)
+
+        stats = json.loads(profiler.report_stats())
+        self.assertEqual(stats["queries"], 2)
+        self.assertEqual(stats["hits"], 1)
+        self.assertEqual(stats["misses"], 1)
+        self.assertGreaterEqual(stats["avg_latency"], 0.0)
+
+    def test_async_stats(self):
+        torch.manual_seed(0)
+
+        async def run():
+            mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10, use_async=True)
+            profiler = MemoryProfiler(mem)
+            profiler.start_profiling()
+            await mem.asearch(torch.randn(4), k=1)  # miss
+            data = torch.randn(1, 4)
+            await mem.aadd(data, metadata=["y"])
+            await mem.asearch(data[0], k=1)  # hit
+            csv = profiler.report_stats(fmt="csv")
+            parts = csv.strip().split("\n")[1].split(",")
+            self.assertEqual(int(parts[0]), 2)
+            self.assertEqual(int(parts[1]), 1)
+            self.assertEqual(int(parts[2]), 1)
+
+        asyncio.run(run())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `MemoryProfiler` for HierarchicalMemory stats
- document profiling hooks
- add memory profiling task to project plan
- test profiling metrics

## Testing
- `PYTHONPATH=. pytest tests/test_memory_profiler.py -q`
- `pip install numpy torch faiss-cpu aiohttp grpcio grpcio-tools requests pillow` *(installation output truncated)*


------
https://chatgpt.com/codex/tasks/task_e_6865898c26d48331a5e633bda05bd85f