### PR TITLE
Add ONNX export helper and script

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -395,6 +395,7 @@ python scripts/distributed_memory_benchmark.py --servers 4 --vectors 100
 
 - `src/cross_modal_fusion.py` embeds text, images and audio in one latent space.
 - `train_fusion_model()` fine-tunes a shared encoder-decoder using CLIP- and Whisper-style objectives and `encode_all()` returns embeddings for retrieval.
+- Run `scripts/export_onnx.py` to export the fusion and world models as ONNX graphs.
 
 ## M-2 World-Model RL Bridge
 
@@ -570,3 +571,4 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Implement a `ContextWindowProfiler` that measures memory footprint and wall-clock time at various sequence lengths. Integrate it with `eval_harness` to track the cost of long-context runs.
 - Extend `HierarchicalMemory` with an adaptive eviction policy that prunes rarely used vectors and emit statistics on hit/miss ratios.
 - Add an optional `SafetyPolicyMonitor` hook in `self_play_skill_loop` that runs `deliberative_alignment` each cycle and logs policy violations.
+- Add `export_to_onnx()` in `src/onnx_utils.py` and `scripts/export_onnx.py` to save ONNX graphs for `MultiModalWorldModel` and `CrossModalFusion`. Run `python scripts/export_onnx.py --out-dir models` to generate them.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -305,6 +305,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 49. **Dataset lineage manager**: Automatically track dataset versions and transformations, enabling reproducible training pipelines.
 50. **Multi-stage oversight**: Combine constitutional AI, deliberative alignment, and critic-in-the-loop RLHF with formal verification; success is <1% harmful output on the existing benchmarks.
 51. **Self-supervised sensorimotor pretraining**: Pretrain the embodied world model on large unlabelled multimodal logs; success is 20% fewer real-world samples to reach 90% task success.
+52. **ONNX export**: Provide `export_to_onnx()` and a script to save `MultiModalWorldModel` and `CrossModalFusion` as ONNX graphs.
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."
 [3]: https://www.businessinsider.com/openai-orion-model-scaling-law-silicon-valley-chatgpt-2024-11?utm_source=chatgpt.com "OpenAI is reportedly struggling to improve its next big AI model. It's a warning for the entire AI industry."

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -1,0 +1,31 @@
+import argparse
+import os
+
+from src.multimodal_world_model import MultiModalWorldModel, MultiModalWorldModelConfig
+from src.cross_modal_fusion import CrossModalFusion, CrossModalFusionConfig
+from src.onnx_utils import export_to_onnx
+
+
+def main(out_dir: str) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+
+    wm_cfg = MultiModalWorldModelConfig(vocab_size=10, img_channels=3, action_dim=2, embed_dim=8)
+    wm = MultiModalWorldModel(wm_cfg)
+    export_to_onnx(wm, os.path.join(out_dir, "multimodal_world_model.onnx"))
+
+    fusion_cfg = CrossModalFusionConfig(
+        vocab_size=10,
+        text_dim=8,
+        img_channels=3,
+        audio_channels=1,
+        latent_dim=4,
+    )
+    fusion = CrossModalFusion(fusion_cfg)
+    export_to_onnx(fusion, os.path.join(out_dir, "cross_modal_fusion.onnx"))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Export models to ONNX format")
+    parser.add_argument("--out-dir", default=".", help="Output directory")
+    args = parser.parse_args()
+    main(args.out_dir)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -119,5 +119,6 @@ from .transformer_circuits import (
     AttentionVisualizer,
 )
 from .neural_arch_search import DistributedArchSearch
+from .onnx_utils import export_to_onnx
 from .graph_of_thought import GraphOfThought
 

--- a/src/onnx_utils.py
+++ b/src/onnx_utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from .multimodal_world_model import MultiModalWorldModel
+from .cross_modal_fusion import CrossModalFusion
+
+
+def export_to_onnx(model: nn.Module, path: str) -> None:
+    """Export supported models to ONNX format."""
+    model.eval()
+    with torch.no_grad():
+        if isinstance(model, MultiModalWorldModel):
+            cfg = model.cfg
+            example = (
+                torch.randint(0, cfg.vocab_size, (1, 4)),
+                torch.randn(1, cfg.img_channels, 8, 8),
+                torch.randint(0, cfg.action_dim, (1,)),
+            )
+            input_names = ["text", "image", "action"]
+            output_names = ["state", "reward"]
+        elif isinstance(model, CrossModalFusion):
+            cfg = model.cfg
+            example = (
+                torch.randint(0, cfg.vocab_size, (1, 5)),
+                torch.randn(1, cfg.img_channels, 16, 16),
+                torch.randn(1, cfg.audio_channels, 32),
+            )
+            input_names = ["text", "images", "audio"]
+            output_names = ["text_feat", "img_feat", "audio_feat"]
+        else:
+            raise TypeError("Unsupported model type for ONNX export")
+
+        torch.onnx.export(
+            model,
+            example,
+            path,
+            input_names=input_names,
+            output_names=output_names,
+            opset_version=11,
+        )
+
+
+__all__ = ["export_to_onnx"]

--- a/tests/test_onnx_utils.py
+++ b/tests/test_onnx_utils.py
@@ -1,0 +1,73 @@
+import unittest
+import tempfile
+import importlib.machinery
+import importlib.util
+import sys
+import numpy as np
+import onnxruntime as ort
+
+# preload dependencies for relative imports
+loader = importlib.machinery.SourceFileLoader('asi.lora_quant', 'src/lora_quant.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod_lora = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mod_lora
+loader.exec_module(mod_lora)
+
+loader = importlib.machinery.SourceFileLoader('asi.multimodal_world_model', 'src/multimodal_world_model.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mmwm = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mmwm
+loader.exec_module(mmwm)
+MultiModalWorldModelConfig = mmwm.MultiModalWorldModelConfig
+MultiModalWorldModel = mmwm.MultiModalWorldModel
+
+loader = importlib.machinery.SourceFileLoader('asi.cross_modal_fusion', 'src/cross_modal_fusion.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+cmf = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = cmf
+loader.exec_module(cmf)
+CrossModalFusionConfig = cmf.CrossModalFusionConfig
+CrossModalFusion = cmf.CrossModalFusion
+
+loader = importlib.machinery.SourceFileLoader('asi.onnx_utils', 'src/onnx_utils.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+onnx_utils = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = onnx_utils
+loader.exec_module(onnx_utils)
+export_to_onnx = onnx_utils.export_to_onnx
+
+
+class TestONNXUtils(unittest.TestCase):
+    def test_world_model_export(self):
+        cfg = MultiModalWorldModelConfig(vocab_size=10, img_channels=3, action_dim=2, embed_dim=8)
+        model = MultiModalWorldModel(cfg)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = tmpdir + '/wm.onnx'
+            export_to_onnx(model, path)
+            sess = ort.InferenceSession(path)
+            inputs = {
+                'text': np.random.randint(0, cfg.vocab_size, (1, 4), dtype=np.int64),
+                'image': np.random.randn(1, cfg.img_channels, 8, 8).astype(np.float32),
+                'action': np.random.randint(0, cfg.action_dim, (1,), dtype=np.int64),
+            }
+            out = sess.run(None, inputs)
+            self.assertEqual(len(out), 2)
+
+    def test_fusion_export(self):
+        cfg = CrossModalFusionConfig(vocab_size=10, text_dim=8, img_channels=3, audio_channels=1, latent_dim=4)
+        model = CrossModalFusion(cfg)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = tmpdir + '/fusion.onnx'
+            export_to_onnx(model, path)
+            sess = ort.InferenceSession(path)
+            inputs = {
+                'text': np.random.randint(0, cfg.vocab_size, (1, 5), dtype=np.int64),
+                'images': np.random.randn(1, cfg.img_channels, 16, 16).astype(np.float32),
+                'audio': np.random.randn(1, cfg.audio_channels, 32).astype(np.float32),
+            }
+            out = sess.run(None, inputs)
+            self.assertEqual(len(out), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `export_to_onnx` utility for supported models
- expose helper via package `__init__`
- add `scripts/export_onnx.py` for quick exports
- test ONNX exports via `onnxruntime`
- document ONNX export feature
- note planned ONNX export step in plan

## Testing
- `pytest tests/test_onnx_utils.py -q` *(fails: UnsupportedOperatorError)*

------
https://chatgpt.com/codex/tasks/task_e_6865898830c483319e19c4becd5b4330