### PR TITLE
Add MultiAgentCoordinator

### DIFF
--- a/src/multi_agent_coordinator.py
+++ b/src/multi_agent_coordinator.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable, Mapping, Callable, Awaitable, Any
+
+try:  # pragma: no cover - allow running as standalone module
+    from .meta_rl_refactor import MetaRLRefactorAgent
+except Exception:  # pragma: no cover - fallback for direct import
+    import importlib.util as _ilu
+    from pathlib import Path as _Path
+
+    _mrf_path = _Path(__file__).resolve().parent / "meta_rl_refactor.py"
+    _spec = _ilu.spec_from_file_location("meta_rl_refactor", _mrf_path)
+    _mod = _ilu.module_from_spec(_spec)
+    assert _spec and _spec.loader
+    _spec.loader.exec_module(_mod)  # type: ignore[attr-defined]
+    MetaRLRefactorAgent = _mod.MetaRLRefactorAgent
+
+__all__ = ["MultiAgentCoordinator"]
+
+
+class MultiAgentCoordinator:
+    """Coordinate multiple :class:`MetaRLRefactorAgent` instances.
+
+    The coordinator schedules cooperative refactoring tasks across repositories
+    and shares rewards among agents. ``apply_fn`` is an async callable executed
+    for each ``(repo, action)`` pair and may perform the actual code change.
+    ``reward_fn`` returns a numeric reward after applying the action.
+    """
+
+    def __init__(self, agents: Mapping[str, MetaRLRefactorAgent] | None = None) -> None:
+        self.agents: dict[str, MetaRLRefactorAgent] = dict(agents or {})
+        self.log: list[tuple[str, str, str, float]] = []
+
+    def register(self, name: str, agent: MetaRLRefactorAgent) -> None:
+        """Register ``agent`` under ``name``."""
+        self.agents[name] = agent
+
+    async def _apply_action(
+        self,
+        name: str,
+        agent: MetaRLRefactorAgent,
+        repo: str,
+        apply_fn: Callable[[str, str], Awaitable[Any]] | None,
+        reward_fn: Callable[[str, str], float] | None,
+    ) -> None:
+        action = agent.select_action(repo)
+        if apply_fn is not None:
+            await apply_fn(repo, action)
+        reward = reward_fn(repo, action) if reward_fn is not None else 0.0
+        agent.update(repo, action, reward, repo)
+        self.log.append((name, repo, action, reward))
+
+    async def schedule_round(
+        self,
+        repos: Iterable[str],
+        apply_fn: Callable[[str, str], Awaitable[Any]] | None = None,
+        reward_fn: Callable[[str, str], float] | None = None,
+    ) -> None:
+        """Run one coordination round across ``repos``."""
+        tasks = [
+            self._apply_action(name, agent, repo, apply_fn, reward_fn)
+            for repo in repos
+            for name, agent in self.agents.items()
+        ]
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    def train_agents(self) -> None:
+        """Train each agent on the collected log entries."""
+        for name, agent in self.agents.items():
+            entries = [
+                (action, reward)
+                for n, repo, action, reward in self.log
+                if n == name
+            ]
+            if entries:
+                agent.train(entries)
+
+

--- a/tests/test_multi_agent_coordinator.py
+++ b/tests/test_multi_agent_coordinator.py
@@ -1,0 +1,47 @@
+import importlib.machinery
+import importlib.util
+import asyncio
+import unittest
+
+loader = importlib.machinery.SourceFileLoader(
+    'multi_agent_coordinator', 'src/multi_agent_coordinator.py'
+)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+coordinator_mod = importlib.util.module_from_spec(spec)
+loader.exec_module(coordinator_mod)
+MultiAgentCoordinator = coordinator_mod.MultiAgentCoordinator
+
+loader2 = importlib.machinery.SourceFileLoader(
+    'meta_rl_refactor', 'src/meta_rl_refactor.py'
+)
+spec2 = importlib.util.spec_from_loader(loader2.name, loader2)
+meta_mod = importlib.util.module_from_spec(spec2)
+loader2.exec_module(meta_mod)
+MetaRLRefactorAgent = meta_mod.MetaRLRefactorAgent
+
+
+class TestMultiAgentCoordinator(unittest.IsolatedAsyncioTestCase):
+    async def test_schedule_round(self):
+        a1 = MetaRLRefactorAgent(epsilon=0.0)
+        a2 = MetaRLRefactorAgent(epsilon=0.0)
+        coord = MultiAgentCoordinator({'a1': a1, 'a2': a2})
+
+        calls: list[tuple[str, str]] = []
+
+        async def apply_fn(repo: str, action: str) -> None:
+            calls.append((repo, action))
+
+        def reward_fn(repo: str, action: str) -> float:
+            return 1.0
+
+        await coord.schedule_round(['r1', 'r2'], apply_fn=apply_fn, reward_fn=reward_fn)
+
+        self.assertEqual(len(calls), 4)
+
+        coord.train_agents()
+        self.assertTrue(a1.q)
+        self.assertTrue(a2.q)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `MultiAgentCoordinator` for orchestrating multiple `MetaRLRefactorAgent` instances
- add async API and training helper
- unit test for the coordinator

## Testing
- `pytest tests/test_multi_agent_coordinator.py -q`
- `pytest -k multi_agent_coordinator -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6865aa6f5498833195b37360026f7f7a