### PR TITLE
Add scheduling and federated training scripts

### DIFF
--- a/scripts/federated_world_model_train.py
+++ b/scripts/federated_world_model_train.py
@@ -1,0 +1,30 @@
+import argparse
+import torch
+from asi.world_model_rl import RLBridgeConfig, TransitionDataset
+from asi.federated_world_model_trainer import FederatedWorldModelTrainer, FederatedTrainerConfig
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Federated world model training")
+    parser.add_argument("--rounds", type=int, default=1)
+    parser.add_argument("--local-epochs", type=int, default=1, dest="local_epochs")
+    args = parser.parse_args()
+
+    cfg = RLBridgeConfig(state_dim=4, action_dim=2)
+    data1 = [
+        (torch.randn(4), 0, torch.randn(4), torch.randn(()))
+        for _ in range(8)
+    ]
+    data2 = [
+        (torch.randn(4), 1, torch.randn(4), torch.randn(()))
+        for _ in range(8)
+    ]
+    ds1 = TransitionDataset(data1)
+    ds2 = TransitionDataset(data2)
+    tcfg = FederatedTrainerConfig(rounds=args.rounds, local_epochs=args.local_epochs)
+    trainer = FederatedWorldModelTrainer(cfg, [ds1, ds2], trainer_cfg=tcfg)
+    model = trainer.train()
+    torch.save(model.state_dict(), "federated_model.pt")
+    print("saved model to federated_model.pt")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/graphql_memory_server.py
+++ b/scripts/graphql_memory_server.py
@@ -1,0 +1,28 @@
+import argparse
+import time
+import torch
+from asi.hierarchical_memory import HierarchicalMemory
+from asi.memory_service import serve
+from asi.graphql_memory_gateway import GraphQLMemoryGateway
+
+def benchmark(queries: int, dim: int) -> None:
+    mem = HierarchicalMemory(dim=dim, compressed_dim=dim // 2, capacity=queries * 2)
+    server = serve(mem, "localhost:50555")
+    gateway = GraphQLMemoryGateway("localhost:50555")
+    vecs = torch.randn(queries, dim)
+    for v in vecs:
+        mem.add(v.unsqueeze(0))
+    start = time.perf_counter()
+    for v in vecs:
+        qstr = "{ query(vector: [%s], k: 1) }" % ",".join(f"{x:.4f}" for x in v.tolist())
+        gateway.execute(qstr)
+    elapsed = time.perf_counter() - start
+    server.stop(0)
+    print(f"{queries} queries in {elapsed:.3f}s -> {queries/elapsed:.2f}/s")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark GraphQL memory gateway")
+    parser.add_argument("--queries", type=int, default=10)
+    parser.add_argument("--dim", type=int, default=16)
+    args = parser.parse_args()
+    benchmark(args.queries, args.dim)

--- a/src/eval_harness.py
+++ b/src/eval_harness.py
@@ -223,6 +223,18 @@ def _eval_self_alignment() -> Tuple[bool, str]:
     return ok, "aligned" if ok else "violations"
 
 
+def _eval_adversarial_robustness() -> Tuple[bool, str]:
+    """Generate a simple adversarial example and verify output."""
+    from asi.adversarial_robustness import AdversarialRobustnessSuite
+
+    def model(p: str) -> float:
+        return float(len(p))
+
+    suite = AdversarialRobustnessSuite(model)
+    adv = suite.generate("hello", ["hello", "hi", "hey"])
+    return adv == "hi", f"adv={adv}"
+
+
 EVALUATORS: Dict[str, Callable[[], Tuple[bool, str]]] = {
     "moe_router": _eval_moe_router,
     "flash_attention3": _eval_flash_attention3,
@@ -241,6 +253,7 @@ EVALUATORS: Dict[str, Callable[[], Tuple[bool, str]]] = {
     "autobench": _eval_autobench,
     "neural_arch_search": _eval_neural_arch_search,
     "self_alignment": _eval_self_alignment,
+    "adversarial_robustness": _eval_adversarial_robustness,
 }
 
 


### PR DESCRIPTION
## Summary
- integrate optional GPUAwareScheduler with DistributedTrainer
- add anomaly-based restarts to SelfHealingTrainer
- register adversarial robustness evaluation
- add scripts for federated world-model training and GraphQL memory gateway

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch/numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6865e12366d083319efbea86c6b494f1