### PR TITLE
Implement low-rank adapter for parameter-efficient tuning

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -97,6 +97,7 @@ from .embodied_calibration import (
 )
 from .lora_quant import LoRAQuantLinear, apply_quant_lora
 from .gradient_compression import GradientCompressionConfig, GradientCompressor
+from .low_rank_adapter import LowRankLinear, apply_low_rank_adaptation
 from .data_ingest import (
     download_triples,
     download_triples_async,

--- a/src/low_rank_adapter.py
+++ b/src/low_rank_adapter.py
@@ -1,0 +1,83 @@
+"""Low-rank adaptation utilities for parameter-efficient fine-tuning."""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class LowRankLinear(nn.Module):
+    """Linear layer augmented with a LoRA-style low-rank adapter."""
+
+    def __init__(self, base: nn.Linear, r: int = 4, alpha: float = 1.0, dropout: float = 0.0) -> None:
+        super().__init__()
+        self.base = base
+        self.r = r
+        self.alpha = alpha
+        self.scale = alpha / r if r > 0 else 1.0
+        self.dropout = nn.Dropout(dropout) if dropout > 0 else None
+        if r > 0:
+            self.A = nn.Parameter(torch.zeros(r, base.in_features))
+            self.B = nn.Parameter(torch.zeros(base.out_features, r))
+            nn.init.kaiming_uniform_(self.A, a=math.sqrt(5))
+            nn.init.zeros_(self.B)
+        else:
+            self.register_parameter("A", None)
+            self.register_parameter("B", None)
+
+    @property
+    def weight(self) -> torch.Tensor:
+        return self.base.weight
+
+    @property
+    def bias(self) -> torch.Tensor | None:
+        return self.base.bias
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        out = self.base(x)
+        if self.r == 0:
+            return out
+        if self.dropout is not None:
+            x = self.dropout(x)
+        lora = F.linear(x, self.B @ self.A) * self.scale
+        return out + lora
+
+
+def apply_low_rank_adaptation(
+    model: nn.Module,
+    target_modules: Sequence[str],
+    r: int = 4,
+    alpha: float = 1.0,
+    dropout: float = 0.0,
+) -> nn.Module:
+    """Replace ``target_modules`` with :class:`LowRankLinear` layers.
+
+    Parameters
+    ----------
+    model:
+        The model whose modules will be replaced in-place.
+    target_modules:
+        Iterable of attribute names to adapt.
+    r:
+        Rank of the adapters.
+    alpha:
+        Scaling factor for the adapter output.
+    dropout:
+        Optional dropout probability.
+    """
+    modules = list(model.named_modules())
+    for name, module in modules:
+        for tgt in target_modules:
+            if name.split(".")[-1] == tgt and isinstance(module, nn.Linear):
+                parent = model
+                for attr in name.split(".")[:-1]:
+                    parent = getattr(parent, attr)
+                setattr(parent, tgt, LowRankLinear(module, r=r, alpha=alpha, dropout=dropout))
+    return model
+
+
+__all__ = ["LowRankLinear", "apply_low_rank_adaptation"]

--- a/tests/test_low_rank_adapter.py
+++ b/tests/test_low_rank_adapter.py
@@ -1,0 +1,25 @@
+import unittest
+import torch
+from torch import nn
+
+from asi.low_rank_adapter import LowRankLinear, apply_low_rank_adaptation
+
+
+class Dummy(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = nn.Linear(4, 2)
+
+
+class TestLowRankAdapter(unittest.TestCase):
+    def test_apply_and_forward(self):
+        model = Dummy()
+        apply_low_rank_adaptation(model, ["fc"], r=2, alpha=1.0)
+        self.assertIsInstance(model.fc, LowRankLinear)
+        x = torch.randn(3, 4)
+        y = model.fc(x)
+        self.assertEqual(y.shape, (3, 2))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `low_rank_adapter.py` implementing a LoRA-style linear layer
- expose helper `apply_low_rank_adaptation`
- test applying and running the adapter
- export in `__init__.py`

## Testing
- `pytest tests/test_low_rank_adapter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ef37a9408331b9c59022323ce139