### PR TITLE
Implement sensorimotor pretrainer and oversight

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -598,3 +598,11 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Implement a `GraphQLMemoryGateway` that exposes `MemoryServer` retrieval endpoints via GraphQL. Provide `scripts/graphql_memory_server.py` to benchmark query overhead.
 - Add a `FineGrainedProfiler` in `telemetry.py` to record per-module compute and memory usage and stream the metrics through `TelemetryLogger`.
 - Create an `AutoLabeler` that invokes the world model during ingestion to generate weak labels for unlabeled triples.
+- Implement a `SensorimotorPretrainer` that performs self-supervised pretraining
+  of `MultiModalWorldModel` on raw sensor logs. Provided
+  `pretrain_sensorimotor()` in `src/sensorimotor_pretrainer.py` with a unit
+  test.
+- Add a `MultiStageOversight` helper combining `CollectiveConstitution`,
+  `DeliberativeAligner`, `CriticRLHFTrainer`, and formal verification checks to
+  enforce multi-stage safety. Implemented in `src/multi_stage_oversight.py` with
+  tests.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -147,6 +147,11 @@ from .auto_labeler import AutoLabeler
 from .graphql_memory_gateway import GraphQLMemoryGateway
 from .world_model_distiller import DistillConfig, distill_world_model
 from .summarizing_memory import SummarizingMemory
+from .sensorimotor_pretrainer import (
+    SensorimotorPretrainConfig,
+    SensorimotorLogDataset,
+    pretrain_sensorimotor,
+)
 from .prompt_optimizer import PromptOptimizer
 from .training_anomaly_detector import TrainingAnomalyDetector
 from .gradient_patch_editor import GradientPatchEditor, PatchConfig
@@ -157,3 +162,4 @@ from .federated_world_model_trainer import (
 )
 from .adversarial_robustness import AdversarialRobustnessSuite
 from .graph_of_thought import ReasoningDebugger
+from .multi_stage_oversight import MultiStageOversight

--- a/src/multi_stage_oversight.py
+++ b/src/multi_stage_oversight.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Iterable, Sequence, Callable, List, Tuple
+
+import torch
+
+from .collective_constitution import CollectiveConstitution
+from .deliberative_alignment import DeliberativeAligner
+from .critic_rlhf import CriticScorer, CriticRLHFTrainer
+from .formal_verifier import verify_model, VerificationResult
+
+
+class MultiStageOversight:
+    """Combine multiple safety checks for model outputs."""
+
+    def __init__(
+        self,
+        principles: Iterable[str],
+        policy_text: str,
+        actions: Sequence[str],
+        checks: Iterable[Callable[[], Tuple[bool, str]]] | None = None,
+    ) -> None:
+        self.constitution = CollectiveConstitution()
+        self.rules = self.constitution.derive_rules(principles)
+        self.aligner = DeliberativeAligner(policy_text)
+        self.scorer = CriticScorer()
+        self.trainer = CriticRLHFTrainer(torch.nn.Linear(1, len(actions)), actions, self.scorer)
+        self.checks = list(checks or [])
+
+    # --------------------------------------------------------------
+    def review(self, text: str) -> tuple[bool, List[str]]:
+        """Run all oversight stages and return ``(passed, messages)``."""
+        messages: List[str] = []
+
+        # Constitutional filter
+        if not self.constitution.label_responses([text], self.rules)[0][1]:
+            messages.append("constitution_fail")
+
+        # Deliberative alignment
+        if not self.aligner.analyze(text):
+            messages.append("alignment_fail")
+
+        # Critic RLHF training step
+        _ = self.trainer.train_step(torch.zeros(1, 1))
+        if self.scorer.score(text) < 0:
+            messages.append("critic_flag")
+
+        # Formal verification of the policy network
+        if self.checks:
+            result: VerificationResult = verify_model(self.trainer.model, self.checks)
+            if not result.passed:
+                messages.extend(result.messages)
+
+        return len(messages) == 0, messages
+
+
+__all__ = ["MultiStageOversight"]

--- a/src/sensorimotor_pretrainer.py
+++ b/src/sensorimotor_pretrainer.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple, Any
+
+import torch
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+
+from .multimodal_world_model import MultiModalWorldModel
+
+
+@dataclass
+class SensorimotorPretrainConfig:
+    """Hyperparameters for sensorimotor pretraining."""
+
+    epochs: int = 1
+    batch_size: int = 8
+
+
+class SensorimotorLogDataset(Dataset):
+    """Simple container for unlabeled sensorimotor transition logs."""
+
+    def __init__(self, entries: Iterable[Tuple[Any, Any, Any, Any, Any]], tokenizer) -> None:
+        self.data = list(entries)
+        self.tokenizer = tokenizer
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return len(self.data)
+
+    def __getitem__(self, idx: int):  # type: ignore[override]
+        t, img, a, nt, nimg = self.data[idx]
+        return (
+            torch.tensor(self.tokenizer(t), dtype=torch.long),
+            torch.tensor(img, dtype=torch.float32),
+            torch.tensor(a, dtype=torch.long),
+            torch.tensor(self.tokenizer(nt), dtype=torch.long),
+            torch.tensor(nimg, dtype=torch.float32),
+        )
+
+
+def pretrain_sensorimotor(
+    model: MultiModalWorldModel,
+    dataset: Dataset,
+    cfg: SensorimotorPretrainConfig,
+) -> MultiModalWorldModel:
+    """Train ``model`` to predict next observations in an unsupervised manner."""
+
+    loader = DataLoader(dataset, batch_size=cfg.batch_size, shuffle=True)
+    opt = torch.optim.Adam(model.parameters(), lr=model.cfg.lr)
+    device = next(model.parameters()).device
+    loss_fn = nn.MSELoss()
+    model.train()
+    for _ in range(cfg.epochs):
+        for t, img, a, nt, nimg in loader:
+            t = t.to(device)
+            img = img.to(device)
+            a = a.to(device)
+            nt = nt.to(device)
+            nimg = nimg.to(device)
+            state = model.encode_obs(t, img)
+            pred_state, _ = model.predict_dynamics(state, a)
+            target = model.encode_obs(nt, nimg)
+            loss = loss_fn(pred_state, target)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+    return model
+
+
+__all__ = [
+    "SensorimotorPretrainConfig",
+    "SensorimotorLogDataset",
+    "pretrain_sensorimotor",
+]

--- a/tests/test_multi_stage_oversight.py
+++ b/tests/test_multi_stage_oversight.py
@@ -1,0 +1,24 @@
+import unittest
+import torch
+
+from asi.multi_stage_oversight import MultiStageOversight
+from asi.formal_verifier import check_grad_norm
+
+
+class TestMultiStageOversight(unittest.TestCase):
+    def test_review(self):
+        model = torch.nn.Linear(1, 2)
+        ovs = MultiStageOversight(
+            ["be kind"],
+            "no bad",
+            ["good", "bad"],
+            checks=[lambda: check_grad_norm(model, 10.0)],
+        )
+        ok, _ = ovs.review("good")
+        self.assertTrue(ok)
+        bad, _ = ovs.review("bad")
+        self.assertFalse(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sensorimotor_pretrainer.py
+++ b/tests/test_sensorimotor_pretrainer.py
@@ -1,0 +1,36 @@
+import unittest
+import torch
+import numpy as np
+
+from asi.sensorimotor_pretrainer import (
+    SensorimotorPretrainConfig,
+    SensorimotorLogDataset,
+    pretrain_sensorimotor,
+)
+from asi.multimodal_world_model import MultiModalWorldModel, MultiModalWorldModelConfig
+
+
+def tokenizer(t: str):
+    return [ord(c) % 10 for c in t]
+
+
+class TestSensorimotorPretrainer(unittest.TestCase):
+    def test_pretrain_runs(self):
+        cfg = MultiModalWorldModelConfig(vocab_size=10, img_channels=1, action_dim=2)
+        model = MultiModalWorldModel(cfg)
+        data = []
+        for _ in range(4):
+            t = "hi"
+            img = np.zeros((1, 8, 8), dtype=np.float32)
+            a = 1
+            nt = "hi"
+            nimg = np.ones((1, 8, 8), dtype=np.float32)
+            data.append((t, img, a, nt, nimg))
+        dataset = SensorimotorLogDataset(data, tokenizer)
+        pcfg = SensorimotorPretrainConfig(epochs=1, batch_size=2)
+        out = pretrain_sensorimotor(model, dataset, pcfg)
+        self.assertIsInstance(out, MultiModalWorldModel)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `SensorimotorPretrainer` for self-supervised pretraining
- implement `MultiStageOversight` safety pipeline
- expose new helpers in package
- document in Implementation.md
- provide unit tests

## Testing
- `pytest -q` *(fails: numpy/torch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865f501f9dc83319c8d549c004d1c4c