### PR TITLE
Add world model powered AutoLabeler

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -597,4 +597,4 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Extend `graph_of_thought.py` with a `ReasoningDebugger` that flags contradictions or loops in reasoning traces.
 - Implement a `GraphQLMemoryGateway` that exposes `MemoryServer` retrieval endpoints via GraphQL. Provide `scripts/graphql_memory_server.py` to benchmark query overhead.
 - Add a `FineGrainedProfiler` in `telemetry.py` to record per-module compute and memory usage and stream the metrics through `TelemetryLogger`.
-- Create an `AutoLabeler` that invokes the world model during ingestion to generate weak labels for unlabeled triples.
+- Create an `AutoLabeler` that invokes the world model during ingestion to generate weak labels for unlabeled triples. **Implemented in `src/auto_labeler.py` with unit tests.**

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -143,7 +143,7 @@ from .streaming_compression import AdaptiveCompressor, TemporalVectorCompressor
 from .context_profiler import profile_model, ContextWindowProfiler
 from .gpu_aware_scheduler import GPUAwareScheduler
 from .dataset_bias_detector import compute_word_freq, bias_score
-from .auto_labeler import AutoLabeler
+from .auto_labeler import AutoLabeler, AutoLabelerConfig
 from .graphql_memory_gateway import GraphQLMemoryGateway
 from .world_model_distiller import DistillConfig, distill_world_model
 from .summarizing_memory import SummarizingMemory

--- a/src/auto_labeler.py
+++ b/src/auto_labeler.py
@@ -1,22 +1,63 @@
-"""Generate weak labels for unlabeled triples."""
+"""Generate weak labels for unlabeled triples using a world model."""
 
 from __future__ import annotations
 
-from typing import Iterable
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence, Tuple
+
+import numpy as np
+import torch
+
+from .multimodal_world_model import MultiModalWorldModel
+
+
+Tokenizer = Callable[[str], Sequence[int]]
+
+
+@dataclass
+class AutoLabelerConfig:
+    """Configuration for :class:`AutoLabeler`."""
+
+    num_labels: int
+    tokenizer: Tokenizer | None = None
 
 
 class AutoLabeler:
-    """Simple heuristic labeler using word counts."""
+    """Use a trained world model to assign weak labels."""
 
-    def __init__(self, vocab_size: int) -> None:
-        self.vocab_size = vocab_size
+    def __init__(self, model: MultiModalWorldModel, cfg: AutoLabelerConfig) -> None:
+        self.model = model
+        self.cfg = cfg
+        tok = cfg.tokenizer
+        if tok is None:
+            size = model.cfg.vocab_size
 
-    def label(self, texts: Iterable[str]) -> list[int]:
-        labels = []
-        for t in texts:
-            val = sum(ord(c) for c in t) % self.vocab_size
-            labels.append(val)
-        return labels
+            def tok(text: str) -> Sequence[int]:
+                return [ord(c) % size for c in text]
+
+        self.tokenizer = tok
+        self.classifier = torch.nn.Linear(model.cfg.embed_dim, cfg.num_labels)
+
+    def _prep_batch(self, triples: Iterable[Tuple[str, np.ndarray, int]]) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        texts, imgs, acts = zip(*triples)
+        tokens = [torch.tensor(self.tokenizer(t), dtype=torch.long) for t in texts]
+        tokens = torch.nn.utils.rnn.pad_sequence(tokens, batch_first=True)
+        images = torch.tensor(np.stack(imgs), dtype=torch.float32)
+        actions = torch.tensor(acts, dtype=torch.long)
+        return tokens, images, actions
+
+    def label(self, triples: Iterable[Tuple[str, np.ndarray, int]]) -> list[int]:
+        tokens, images, actions = self._prep_batch(triples)
+        device = next(self.model.parameters()).device
+        tokens = tokens.to(device)
+        images = images.to(device)
+        actions = actions.to(device)
+        self.model.eval()
+        with torch.no_grad():
+            state = self.model.encode_obs(tokens, images)
+            logits = self.classifier(state)
+            preds = torch.argmax(logits, dim=-1)
+        return preds.cpu().tolist()
 
 
-__all__ = ["AutoLabeler"]
+__all__ = ["AutoLabeler", "AutoLabelerConfig"]

--- a/tests/test_auto_labeler.py
+++ b/tests/test_auto_labeler.py
@@ -1,0 +1,24 @@
+import unittest
+import numpy as np
+import torch
+
+from asi.auto_labeler import AutoLabeler, AutoLabelerConfig
+from asi.multimodal_world_model import MultiModalWorldModel, MultiModalWorldModelConfig
+
+
+class TestAutoLabeler(unittest.TestCase):
+    def test_label(self):
+        cfg = MultiModalWorldModelConfig(vocab_size=10, img_channels=1, action_dim=2, embed_dim=4)
+        model = MultiModalWorldModel(cfg)
+        labeler = AutoLabeler(model, AutoLabelerConfig(num_labels=3))
+        texts = ["aa", "bb"]
+        images = [np.zeros((1, 4, 4), dtype=np.float32) for _ in texts]
+        actions = [0, 1]
+        labels = labeler.label(zip(texts, images, actions))
+        self.assertEqual(len(labels), 2)
+        for l in labels:
+            self.assertTrue(0 <= l < 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `AutoLabeler` that leverages `MultiModalWorldModel`
- expose `AutoLabelerConfig`
- add unit test for the new labeler
- document the implementation in `docs/Implementation.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865f501f9dc83319c8d549c004d1c4c