### PR TITLE
Add dataset bias filtering support

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -142,7 +142,12 @@ from .dataset_versioner import DatasetVersioner
 from .streaming_compression import AdaptiveCompressor, TemporalVectorCompressor
 from .context_profiler import profile_model, ContextWindowProfiler
 from .gpu_aware_scheduler import GPUAwareScheduler
-from .dataset_bias_detector import compute_word_freq, bias_score
+from .dataset_bias_detector import (
+    compute_word_freq,
+    bias_score,
+    text_bias_score,
+    file_bias_score,
+)
 from .auto_labeler import AutoLabeler
 from .graphql_memory_gateway import GraphQLMemoryGateway
 from .world_model_distiller import DistillConfig, distill_world_model

--- a/src/dataset_bias_detector.py
+++ b/src/dataset_bias_detector.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 from collections import Counter
 from pathlib import Path
-from typing import Iterable, Dict
+from typing import Iterable, Dict, Union
 
 
 def compute_word_freq(text_files: Iterable[str | Path]) -> Dict[str, int]:
@@ -25,4 +25,20 @@ def bias_score(freq: Dict[str, int]) -> float:
     return entropy / np.log(len(counts) + 1e-8)
 
 
-__all__ = ["compute_word_freq", "bias_score"]
+def text_bias_score(text: str) -> float:
+    """Return the bias score for a single ``text``."""
+    freq = Counter(text.split())
+    return bias_score(freq)
+
+
+def file_bias_score(path: Union[str, Path]) -> float:
+    """Return the bias score for the text file at ``path``."""
+    return text_bias_score(Path(path).read_text())
+
+
+__all__ = [
+    "compute_word_freq",
+    "bias_score",
+    "text_bias_score",
+    "file_bias_score",
+]

--- a/tests/test_dataset_bias_detector.py
+++ b/tests/test_dataset_bias_detector.py
@@ -1,0 +1,25 @@
+import unittest
+import tempfile
+from pathlib import Path
+
+from asi.dataset_bias_detector import compute_word_freq, bias_score, text_bias_score
+from asi.auto_dataset_filter import filter_text_files
+
+
+class TestDatasetBiasDetector(unittest.TestCase):
+    def test_bias_score_and_filter(self):
+        with tempfile.TemporaryDirectory() as d:
+            p1 = Path(d) / "a.txt"
+            p2 = Path(d) / "b.txt"
+            p1.write_text("hello hello hello")
+            p2.write_text("alpha beta gamma delta")
+            freq = compute_word_freq([p1, p2])
+            score = bias_score(freq)
+            self.assertGreaterEqual(score, 0.0)
+
+            kept = filter_text_files([p1, p2], bias_threshold=0.8)
+            self.assertEqual(kept, [p2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- integrate dataset bias detection with `filter_text_files`
- expose new helpers `text_bias_score` and `file_bias_score`
- update top-level `__init__`
- add regression test for bias detection

## Testing
- `pytest -q tests/test_dataset_bias_detector.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6865f501f9dc83319c8d549c004d1c4c