### PR TITLE
Integrate telemetry with MemoryServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ meta-rl-refactor sample_log.csv
 
 Run the scripts directly with `python` to see parameter and FLOP estimates.
 
+## Telemetry
+
+`MemoryServer` can record resource usage via `TelemetryLogger`. Metrics start
+and stop automatically with the server:
+
+```python
+from asi.hierarchical_memory import HierarchicalMemory
+from asi.memory_service import serve
+from asi.telemetry import TelemetryLogger
+
+mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+logger = TelemetryLogger(port=8000)
+server = serve(mem, "localhost:50070", telemetry=logger)
+```
+
+Visit `http://localhost:8000` to view Prometheus metrics.
+
 ## Testing
 
 1. Install requirements: `pip install -r requirements.txt`.

--- a/asi/__init__.py
+++ b/asi/__init__.py
@@ -8,9 +8,20 @@ _src = Path(__file__).resolve().parent.parent / "src"
 if _src.exists() and str(_src) not in sys.path:
     sys.path.insert(0, str(_src))
 
+# Import core modules early to avoid circular imports
+try:
+    hm = importlib.import_module("src.hierarchical_memory")
+    globals()["hierarchical_memory"] = hm
+    sys.modules[f"{__name__}.hierarchical_memory"] = hm
+except Exception:  # pragma: no cover - optional
+    pass
+
 # Re-export every module in ``src`` so ``asi.foo`` works in tests
 for _mod in pkgutil.iter_modules([str(_src)]):
-    mod = importlib.import_module(f"src.{_mod.name}")
+    try:
+        mod = importlib.import_module(f"src.{_mod.name}")
+    except Exception:  # pragma: no cover - optional deps may fail
+        continue
     globals()[_mod.name] = mod
     sys.modules[f"{__name__}.{_mod.name}"] = mod
 

--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -578,6 +578,7 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   utility to train smaller student models from the large world model.
 - Implement a `SummarizingMemory` helper that compresses infrequently used vectors with a small language-model summarizer. Provide `scripts/summarize_memory_benchmark.py` to measure storage savings and retrieval accuracy.
 - Add a `TelemetryLogger` in `telemetry.py` that exports GPU, CPU and network metrics via OpenTelemetry and Prometheus. Integrate the logger with `DistributedTrainer` and `MemoryServer`.
+  `MemoryServer` now starts and stops a provided `TelemetryLogger` automatically.
 - Extend `data_ingest.py` with a `LicenseInspector` that parses dataset metadata for license terms and rejects incompatible samples. Include a `scripts/license_check.py` CLI to audit stored triples.
 - Add an `AdaptiveCompressor` that tunes the compression ratio in `StreamingCompressor` based on retrieval frequency so rarely accessed vectors use fewer bytes.
 - Create a `PromptOptimizer` module that rewrites prompts via reinforcement learning and tracks evaluation improvements automatically.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -303,7 +303,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     ≥4×.
 
 42. **Summarizing memory compression**: Condense rarely accessed vectors with a small language model before persisting them to disk. Success is a ≥50 % reduction in storage while retrieval accuracy drops <5 %.
-43. **Telemetry instrumentation**: Record GPU/CPU utilization and network throughput across distributed nodes using OpenTelemetry and expose the metrics via Prometheus. Overhead must remain <5 % on a 4-node cluster.
+43. **Telemetry instrumentation**: Record GPU/CPU utilization and network throughput across distributed nodes using OpenTelemetry and expose the metrics via Prometheus. Overhead must remain <5 % on a 4-node cluster. *`MemoryServer` now accepts a `TelemetryLogger` to start and stop metrics automatically.*
 44. **License compliance checker**: Parse dataset sources for license text during ingestion and block incompatible samples. Every stored triple should include a valid license entry.
 45. **Adaptive streaming compression**: Add `AdaptiveCompressor` to adjust the compression ratio in `StreamingCompressor` based on retrieval frequency.
 46. **Prompt optimization**: Build a `PromptOptimizer` that learns prompt revisions via reinforcement learning and measure evaluation gains.

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -668,11 +668,15 @@ if _HAS_GRPC:
 
         def start(self) -> None:
             """Start serving requests."""
+            if self.telemetry:
+                self.telemetry.start()
             self.server.start()
 
         def stop(self, grace: float = 0) -> None:
             """Stop the server."""
             self.server.stop(grace)
+            if self.telemetry:
+                self.telemetry.stop()
 
 
 def push_remote(address: str, vector: torch.Tensor, metadata: Any | None = None, timeout: float = 5.0) -> bool:

--- a/src/memory_service.py
+++ b/src/memory_service.py
@@ -3,11 +3,19 @@
 from __future__ import annotations
 
 from .hierarchical_memory import HierarchicalMemory, MemoryServer
+from .telemetry import TelemetryLogger
 
 
-def serve(memory: HierarchicalMemory, address: str, max_workers: int = 4) -> MemoryServer:
+def serve(
+    memory: HierarchicalMemory,
+    address: str,
+    max_workers: int = 4,
+    telemetry: TelemetryLogger | None = None,
+) -> MemoryServer:
     """Start a :class:`MemoryServer` at ``address`` and return it."""
-    server = MemoryServer(memory, address=address, max_workers=max_workers)
+    server = MemoryServer(
+        memory, address=address, max_workers=max_workers, telemetry=telemetry
+    )
     server.start()
     return server
 

--- a/tests/test_memory_server_telemetry.py
+++ b/tests/test_memory_server_telemetry.py
@@ -1,0 +1,34 @@
+import unittest
+import time
+import torch
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from src.hierarchical_memory import HierarchicalMemory
+from src.memory_service import serve
+from src.telemetry import TelemetryLogger
+
+try:
+    import grpc  # noqa: F401
+    _HAS_GRPC = True
+except Exception:  # pragma: no cover - optional
+    _HAS_GRPC = False
+
+
+class TestMemoryServerTelemetry(unittest.TestCase):
+    def test_server_telemetry(self):
+        if not _HAS_GRPC:
+            self.skipTest("grpcio not available")
+        mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+        logger = TelemetryLogger(interval=0.1)
+        server = serve(mem, "localhost:50210", telemetry=logger)
+        time.sleep(0.2)
+        stats = logger.get_stats()
+        server.stop(0)
+        self.assertIn("cpu", stats)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `serve()` to pass through a TelemetryLogger
- start/stop telemetry in `MemoryServer`
- document telemetry usage in README
- note telemetry integration in docs
- add unit test covering telemetry with gRPC server
- make `asi.__init__` resilient to optional deps

## Testing
- `python -m pytest tests/test_memory_server_telemetry.py tests/test_telemetry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686728682edc83318aa69979f3d5e227