### PR TITLE
Add CONTRIBUTING guide and setup script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thank you for improving the ASI prototype. To get started:
+
+1. Use Python 3.10 or newer.
+2. Install dependencies with `pip install -r requirements.txt`.
+3. Install the package in editable mode with `pip install -e .`.
+4. Run tests with `pytest` before submitting a pull request.
+
+You can run `scripts/setup_test_env.sh` to automate steps 2 and 3.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ meta-rl-refactor sample_log.csv
 ## Setup
 
 1. Use Python 3.10 or newer with PyTorch installed.
-2. Install dependencies with `pip install -r requirements.txt`.
+2. Install dependencies with `pip install -r requirements.txt` or run
+   `scripts/setup_test_env.sh` to automate the process.
 3. Optional: `pip install flash-attn` to enable the FlashAttention-3 wrapper in `src/flash_attention3.py`.
 4. Optional: `pip install faiss-cpu` to enable disk-backed vector storage in `src/vector_store.py`.
 5. Run `pip install -e .` to enable imports from the `asi` package.
@@ -30,8 +31,10 @@ Run the scripts directly with `python` to see parameter and FLOP estimates.
 
 ## Testing
 
-1. Install requirements: `pip install -r requirements.txt`.
-2. Install the package in editable mode: `pip install -e .`.
+1. Install requirements: `pip install -r requirements.txt` (or run
+   `scripts/setup_test_env.sh`).
+2. Install the package in editable mode: `pip install -e .` (already done by
+   the setup script).
 3. Run tests with `pytest`.
 
 ## Style
@@ -48,3 +51,8 @@ Continuous evaluation runs `scripts/continuous_eval.py` after each pull request.
 The script invokes `eval_harness` and `autobench` to track benchmark progress.
 See [.github/workflows/continuous_eval.yml](.github/workflows/continuous_eval.yml)
 for the GitHub Actions setup or schedule it locally with `cron`.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on running the setup script
+and tests before opening a pull request.

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Lightweight setup script for local testing.
+# Installs dependencies and the package in editable mode.
+set -e
+pip install -r requirements.txt
+pip install -e .


### PR DESCRIPTION
## Summary
- clarify dependency installation in README
- add CONTRIBUTING instructions
- add a setup script for installing requirements

## Testing
- `pytest -q` *(fails: 74 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686728688f64833187b3e917ccbb5a6b