### PR TITLE
Implement retrieval benchmark

### DIFF
--- a/scripts/cross_modal_retrieval_benchmark.py
+++ b/scripts/cross_modal_retrieval_benchmark.py
@@ -1,0 +1,51 @@
+import argparse
+import random
+import torch
+from asi.cross_modal_fusion import (
+    CrossModalFusion,
+    CrossModalFusionConfig,
+    MultiModalDataset,
+    retrieval_accuracy,
+)
+from asi.hierarchical_memory import HierarchicalMemory
+
+
+def simple_tokenizer(text: str):
+    return [ord(c) % 50 for c in text]
+
+
+def generate_dataset(n: int, seq_len: int = 8):
+    triples = []
+    for _ in range(n):
+        text = "".join(chr(97 + random.randint(0, 25)) for _ in range(seq_len))
+        img = torch.randn(3, 16, 16)
+        aud = torch.randn(1, 32)
+        triples.append((text, img, aud))
+    return triples
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Cross-modal retrieval benchmark")
+    parser.add_argument("--samples", type=int, default=1000, help="Number of triples")
+    parser.add_argument("--latent-dim", type=int, default=64, help="Latent dimension")
+    parser.add_argument("--k", type=int, default=1, help="Top-k retrieval")
+    args = parser.parse_args()
+
+    cfg = CrossModalFusionConfig(
+        vocab_size=50,
+        text_dim=args.latent_dim,
+        img_channels=3,
+        audio_channels=1,
+        latent_dim=args.latent_dim,
+    )
+    model = CrossModalFusion(cfg)
+    triples = generate_dataset(args.samples)
+    dataset = MultiModalDataset(triples, simple_tokenizer)
+    memory = HierarchicalMemory(dim=args.latent_dim, compressed_dim=args.latent_dim // 2, capacity=args.samples * 2)
+
+    acc = retrieval_accuracy(model, dataset, memory, batch_size=32, k=args.k)
+    print(f"retrieval_accuracy: {acc:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -79,6 +79,7 @@ from .cross_modal_fusion import (
     MultiModalDataset,
     train_fusion_model,
     encode_all,
+    retrieval_accuracy,
 )
 from .world_model_rl import (
     RLBridgeConfig,

--- a/src/cross_modal_fusion.py
+++ b/src/cross_modal_fusion.py
@@ -185,10 +185,30 @@ def encode_all(
     return all_t, all_i, all_a
 
 
+def retrieval_accuracy(
+    model: CrossModalFusion,
+    dataset: Dataset,
+    memory: "HierarchicalMemory",
+    batch_size: int = 8,
+    k: int = 1,
+) -> float:
+    """Return retrieval accuracy after encoding ``dataset`` into ``memory``."""
+
+    t_vecs, i_vecs, a_vecs = encode_all(model, dataset, batch_size=batch_size, memory=memory)
+    correct = 0
+    for idx in range(len(dataset)):
+        query = (t_vecs[idx] + i_vecs[idx] + a_vecs[idx]) / 3.0
+        out, meta = memory.search(query, k=k)
+        if meta and meta[0] == idx:
+            correct += 1
+    return correct / len(dataset)
+
+
 __all__ = [
     "CrossModalFusionConfig",
     "CrossModalFusion",
     "MultiModalDataset",
     "train_fusion_model",
     "encode_all",
+    "retrieval_accuracy",
 ]

--- a/tests/test_cross_modal_retrieval.py
+++ b/tests/test_cross_modal_retrieval.py
@@ -1,0 +1,46 @@
+import importlib.machinery
+import importlib.util
+import sys
+import unittest
+import torch
+
+loader = importlib.machinery.SourceFileLoader('cmf', 'src/cross_modal_fusion.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+cmf = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = cmf
+sys.modules['asi.cross_modal_fusion'] = cmf
+loader.exec_module(cmf)
+CrossModalFusionConfig = cmf.CrossModalFusionConfig
+CrossModalFusion = cmf.CrossModalFusion
+MultiModalDataset = cmf.MultiModalDataset
+retrieval_accuracy = cmf.retrieval_accuracy
+
+from asi.hierarchical_memory import HierarchicalMemory
+
+
+def simple_tokenizer(text: str):
+    return [ord(c) % 50 for c in text]
+
+
+class TestCrossModalRetrieval(unittest.TestCase):
+    def test_accuracy(self):
+        cfg = CrossModalFusionConfig(
+            vocab_size=50,
+            text_dim=8,
+            img_channels=3,
+            audio_channels=1,
+            latent_dim=4,
+        )
+        model = CrossModalFusion(cfg)
+        triples = [
+            ("aa", torch.randn(3, 16, 16), torch.randn(1, 32)),
+            ("bb", torch.randn(3, 16, 16), torch.randn(1, 32)),
+        ]
+        dataset = MultiModalDataset(triples, simple_tokenizer)
+        mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+        acc = retrieval_accuracy(model, dataset, mem, batch_size=1, k=1)
+        self.assertGreaterEqual(acc, 0.5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add retrieval accuracy helper for cross-modal fusion
- expose helper through package
- provide a benchmark script for cross-modal retrieval
- test retrieval accuracy integration

## Testing
- `pip install -q numpy torch faiss-cpu aiohttp grpcio grpcio-tools requests pillow scikit-learn umap-learn plotly psutil graphql-core`
- `pip install -e . -q`
- `pytest tests/test_cross_modal_retrieval.py::TestCrossModalRetrieval::test_accuracy -q`
- `pytest tests/test_cross_modal_fusion.py::TestCrossModalFusion::test_encode_and_store -q`

------
https://chatgpt.com/codex/tasks/task_e_686742fc3164833199423404fcaff223