### PR TITLE
Implement GradientCompressor utilities

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -562,7 +562,8 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Integrate a `DifferentialPrivacyOptimizer` into training loops so models can optionally clip gradients and inject noise during updates. **Implemented in `src/differential_privacy_optimizer.py` and integrated with `world_model_rl.train_world_model`.**
 - Add a `GradientCompressor` utility that performs top-k or quantized gradient
   compression. `DistributedTrainer` uses it when ``grad_compression`` is
-  provided.
+  provided. **Implemented in `src/gradient_compression.py` and wired through
+  `distributed_trainer.py`.**
 - Add a `LocalitySensitiveHashIndex` option in `vector_store.py` so `HierarchicalMemory` can perform approximate nearest neighbor search with sub-linear query time. **Implemented in `vector_store.LocalitySensitiveHashIndex` and wired through `HierarchicalMemory`.**
 - Create an `EmbeddingVisualizer` module that runs UMAP/t-SNE on cross-modal embeddings and serves interactive plots through a minimal web interface.
 **Implemented in `src/embedding_visualizer.py`.**

--- a/src/gradient_compression.py
+++ b/src/gradient_compression.py
@@ -42,3 +42,7 @@ class GradientCompressor:
         if self.cfg.bits is not None:
             out = self._quantize(out)
         return out
+
+    def compress_dict(self, grads: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Apply compression to all tensors in a gradient dict."""
+        return {k: self.compress(v) for k, v in grads.items()}

--- a/tests/test_gradient_compression.py
+++ b/tests/test_gradient_compression.py
@@ -1,0 +1,40 @@
+import importlib.machinery
+import importlib.util
+import sys
+import unittest
+import torch
+
+loader = importlib.machinery.SourceFileLoader('asi.gradient_compression', 'src/gradient_compression.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+sys.modules['asi.gradient_compression'] = mod
+loader.exec_module(mod)
+GradientCompressionConfig = mod.GradientCompressionConfig
+GradientCompressor = mod.GradientCompressor
+
+class TestGradientCompressor(unittest.TestCase):
+    def test_topk(self):
+        cfg = GradientCompressionConfig(topk=2)
+        comp = GradientCompressor(cfg)
+        grad = torch.tensor([1.0, 0.5, 0.2])
+        out = comp.compress(grad)
+        self.assertEqual(int((out != 0).sum()), 2)
+
+    def test_quantize(self):
+        cfg = GradientCompressionConfig(bits=4)
+        comp = GradientCompressor(cfg)
+        grad = torch.linspace(-1, 1, 5)
+        out = comp.compress(grad)
+        self.assertTrue(torch.all(out.abs() <= 1.0))
+
+    def test_dict(self):
+        cfg = GradientCompressionConfig(topk=1, bits=8)
+        comp = GradientCompressor(cfg)
+        grads = {'a': torch.tensor([0.1, 0.9]), 'b': torch.tensor([1.5, -0.5])}
+        out = comp.compress_dict(grads)
+        self.assertEqual(set(out.keys()), {'a', 'b'})
+        self.assertEqual(int((out['a'] != 0).sum()), 1)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- mark GradientCompressor as implemented in docs
- extend GradientCompressor with `compress_dict`
- add unit tests for gradient compression

## Testing
- `pytest tests/test_gradient_compression.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6867475b49888331a292de67d47b0dac