### PR TITLE
Implement gradient compression docs

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -562,7 +562,8 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Integrate a `DifferentialPrivacyOptimizer` into training loops so models can optionally clip gradients and inject noise during updates. **Implemented in `src/differential_privacy_optimizer.py` and integrated with `world_model_rl.train_world_model`.**
 - Add a `GradientCompressor` utility that performs top-k or quantized gradient
   compression. `DistributedTrainer` uses it when ``grad_compression`` is
-  provided.
+  provided. **Implemented in `src/gradient_compression.py` and integrated with
+  `DistributedTrainer`.**
 - Add a `LocalitySensitiveHashIndex` option in `vector_store.py` so `HierarchicalMemory` can perform approximate nearest neighbor search with sub-linear query time. **Implemented in `vector_store.LocalitySensitiveHashIndex` and wired through `HierarchicalMemory`.**
 - Create an `EmbeddingVisualizer` module that runs UMAP/t-SNE on cross-modal embeddings and serves interactive plots through a minimal web interface.
 **Implemented in `src/embedding_visualizer.py`.**

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -315,7 +315,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 52. **Self-supervised sensorimotor pretraining**: Pretrain the embodied world model on large unlabelled multimodal logs; success is 20% fewer real-world samples to reach 90% task success.
 53. **Gradient compression for distributed training**: Implement a `GradientCompressor`
     with top-k sparsification or quantized gradients and integrate it with
-    `DistributedTrainer`.
+    `DistributedTrainer`. *Implemented via `src/gradient_compression.py` and
+    tested in `tests/test_distributed_trainer.py`.*
 53. **ONNX export**: Provide `export_to_onnx()` and a script to save `MultiModalWorldModel` and `CrossModalFusion` as ONNX graphs.
 54. **Memory profiling**: Instrument `HierarchicalMemory` with a lightweight profiler that records query counts, hit/miss ratios and latency.
 55. **Secure federated learner**: Train models across remote peers using encrypted gradient aggregation. Accuracy should stay within 2% of centralized training.

--- a/tests/test_gradient_compression.py
+++ b/tests/test_gradient_compression.py
@@ -1,0 +1,35 @@
+import unittest
+import torch
+
+from asi.gradient_compression import GradientCompressionConfig, GradientCompressor
+
+
+class TestGradientCompressor(unittest.TestCase):
+    def test_topk(self):
+        cfg = GradientCompressionConfig(topk=2)
+        comp = GradientCompressor(cfg)
+        g = torch.tensor([1.0, -3.0, 2.0, 0.5])
+        out = comp.compress(g.clone())
+        self.assertEqual(int((out != 0).sum()), 2)
+        # Ensure top magnitudes preserved
+        idx = torch.topk(g.abs(), 2).indices
+        self.assertTrue(torch.all(out[idx] != 0))
+
+    def test_quantize(self):
+        g = torch.tensor([0.1, -0.2, 0.3, -0.4])
+        cfg = GradientCompressionConfig(bits=4)
+        comp = GradientCompressor(cfg)
+        out = comp.compress(g.clone())
+        self.assertTrue(torch.allclose(out, g, atol=0.1))
+
+    def test_combined(self):
+        g = torch.tensor([0.6, -0.3, 0.2, 0.1])
+        cfg = GradientCompressionConfig(topk=1, bits=3)
+        comp = GradientCompressor(cfg)
+        out = comp.compress(g.clone())
+        self.assertEqual(int((out != 0).sum()), 1)
+        self.assertTrue(torch.allclose(out[out != 0], torch.tensor([0.6]), atol=0.2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document gradient compression in Plan and Implementation docs
- add unit test for `GradientCompressor`

## Testing
- `pytest tests/test_gradient_compression.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6867475b49888331a292de67d47b0dac