### PR TITLE
Add context summary memory

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -584,6 +584,8 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Implement a `SummarizingMemory` helper that compresses infrequently used vectors with a small language-model summarizer. Provide `scripts/summarize_memory_benchmark.py` to measure storage savings and retrieval accuracy.
   **Implemented in `src/summarizing_memory.py` with the benchmarking script
   `scripts/summarize_memory_benchmark.py`.**
+- Implement a `ContextSummaryMemory` that replaces far-past vectors with text summaries and re-expands them when retrieved. Unit test `tests/test_context_summary_memory.py` verifies summarization and expansion.
+  **Implemented in `src/context_summary_memory.py` with tests.**
 - Add a `TelemetryLogger` in `telemetry.py` that exports GPU, CPU and network metrics via OpenTelemetry and Prometheus. Integrate the logger with `DistributedTrainer` and `MemoryServer`.
   `MemoryServer` now starts and stops a provided `TelemetryLogger` automatically.
   **Implemented in `src/telemetry.py`.**

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -310,7 +310,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 46. **Prompt optimization**: Build a `PromptOptimizer` that learns prompt revisions via reinforcement learning and measure evaluation gains.
 47. **Training anomaly detection**: Extend `SelfHealingTrainer` with a `TrainingAnomalyDetector` to roll back or restart runs when metrics diverge.
 48. **Parameter-efficient adaptation**: Explore low-rank fine-tuning across tasks; success is matching baseline accuracy with ≤10% extra parameters.
-49. **Context summarization memory**: Store compressed summaries for distant tokens and re-expand them on demand; success is >95% retrieval accuracy at 100× token length.
+49. **Context summarization memory**: Store compressed summaries for distant tokens and re-expand them on demand; success is >95% retrieval accuracy at 100× token length. *Implemented in `src/context_summary_memory.py` with tests.*
 50. **Dataset lineage manager**: Automatically track dataset versions and transformations, enabling reproducible training pipelines.
 51. **Multi-stage oversight**: Combine constitutional AI, deliberative alignment, and critic-in-the-loop RLHF with formal verification; success is <1% harmful output on the existing benchmarks.
 52. **Self-supervised sensorimotor pretraining**: Pretrain the embodied world model on large unlabelled multimodal logs; success is 20% fewer real-world samples to reach 90% task success.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -154,6 +154,7 @@ from .auto_labeler import AutoLabeler
 from .graphql_memory_gateway import GraphQLMemoryGateway
 from .world_model_distiller import DistillConfig, distill_world_model
 from .summarizing_memory import SummarizingMemory
+from .context_summary_memory import ContextSummaryMemory
 from .sensorimotor_pretrainer import (
     SensorimotorPretrainConfig,
     SensorimotorLogDataset,

--- a/src/context_summary_memory.py
+++ b/src/context_summary_memory.py
@@ -1,0 +1,57 @@
+"""Context summarization memory.
+
+Store compressed summaries for distant tokens and restore them on retrieval.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Any, Tuple, List
+
+import torch
+
+from .hierarchical_memory import HierarchicalMemory
+
+
+class ContextSummaryMemory(HierarchicalMemory):
+    """Hierarchical memory that replaces far-past vectors with summaries."""
+
+    def __init__(
+        self,
+        *args,
+        summarizer,
+        context_size: int = 1024,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.summarizer = summarizer
+        self.context_size = context_size
+
+    def summarize_context(self) -> None:
+        """Compress vectors beyond ``context_size`` using ``summarizer``."""
+        total = len(self.compressor.buffer.data)
+        if total <= self.context_size:
+            return
+        keep_start = total - self.context_size
+        old_vecs = self.compressor.buffer.data[:keep_start]
+        old_meta = self.store._meta[:keep_start]
+        self.compressor.buffer.data = self.compressor.buffer.data[keep_start:]
+        self.store._meta = self.store._meta[keep_start:]
+        for vec, meta in zip(old_vecs, old_meta):
+            summary = self.summarizer.summarize(vec.unsqueeze(0))
+            self.store.delete(tag=meta)
+            self.store.add(torch.zeros_like(vec).numpy(), [f"ctxsum:{summary}"])
+
+    def search(self, query: torch.Tensor, k: int = 5) -> Tuple[torch.Tensor, List[Any]]:  # type: ignore[override]
+        vecs, meta = super().search(query, k)
+        new_vecs = []
+        for v, m in zip(vecs, meta):
+            if isinstance(m, str) and m.startswith("ctxsum:"):
+                text = m.split(":", 1)[1]
+                new_vecs.append(self.summarizer.expand(text).to(query.device))
+            else:
+                new_vecs.append(v)
+        if new_vecs:
+            vecs = torch.stack(new_vecs)
+        return vecs, meta
+
+
+__all__ = ["ContextSummaryMemory"]

--- a/tests/test_context_summary_memory.py
+++ b/tests/test_context_summary_memory.py
@@ -1,0 +1,30 @@
+import unittest
+import torch
+
+from asi.context_summary_memory import ContextSummaryMemory
+
+
+class DummySummarizer:
+    def summarize(self, x):
+        return "s"
+
+    def expand(self, text):
+        return torch.ones(2)
+
+
+class TestContextSummaryMemory(unittest.TestCase):
+    def test_summarize_and_expand(self):
+        mem = ContextSummaryMemory(
+            dim=2, compressed_dim=1, capacity=4, summarizer=DummySummarizer(), context_size=1
+        )
+        data = torch.randn(3, 2)
+        mem.add(data, metadata=["a", "b", "c"])
+        mem.summarize_context()
+        vecs, meta = mem.search(data[0], k=2)
+        self.assertEqual(vecs.shape[0], len(meta))
+        self.assertTrue(any(isinstance(m, str) and m.startswith("ctxsum:") for m in meta))
+        self.assertTrue(torch.allclose(vecs[0], torch.ones(2)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement ContextSummaryMemory to summarize distant vectors and expand summaries
- expose new helper through package init
- document implementation details in Plan and Implementation
- test summarization and expansion logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6867d4c0c7488331a398b1d9025b5287