### PR TITLE
Implement DatasetLineageManager

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -600,6 +600,8 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Implement a `ParameterEfficientAdapter` that applies low-rank adapters to target modules for cross-task fine-tuning. **Implemented in `src/parameter_efficient_adapter.py` with tests.**
 - Add a `DatasetVersioner` module that logs dataset hashes and transformation steps. Extend `data_ingest` so all downloads and synthetic samples record their provenance in a version file.
   **Implemented in `src/dataset_versioner.py` and wired through `data_ingest`.**
+- Add a `DatasetLineageManager` that records transformation steps and resulting file hashes for reproducible pipelines.
+  **Implemented in `src/dataset_lineage_manager.py` with tests.**
 - Implement a `ContextWindowProfiler` that measures memory footprint and wall-clock time at various sequence lengths. **Implemented as `src/context_profiler.py` and integrated with `eval_harness.py`.**
 - Extend `HierarchicalMemory` with an adaptive eviction policy that prunes rarely used vectors and emit statistics on hit/miss ratios.
   **Implemented** via `adaptive_evict` in `HierarchicalMemory` with `get_stats()` to report usage metrics.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -311,7 +311,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 47. **Training anomaly detection**: Extend `SelfHealingTrainer` with a `TrainingAnomalyDetector` to roll back or restart runs when metrics diverge.
 48. **Parameter-efficient adaptation**: Explore low-rank fine-tuning across tasks; success is matching baseline accuracy with ≤10% extra parameters.
 49. **Context summarization memory**: Store compressed summaries for distant tokens and re-expand them on demand; success is >95% retrieval accuracy at 100× token length. *Implemented in `src/context_summary_memory.py` with tests.*
-50. **Dataset lineage manager**: Automatically track dataset versions and transformations, enabling reproducible training pipelines.
+50. **Dataset lineage manager**: Automatically track dataset versions and transformations, enabling reproducible training pipelines. *Implemented in `src/dataset_lineage_manager.py`.*
 51. **Multi-stage oversight**: Combine constitutional AI, deliberative alignment, and critic-in-the-loop RLHF with formal verification; success is <1% harmful output on the existing benchmarks.
 52. **Self-supervised sensorimotor pretraining**: Pretrain the embodied world model on large unlabelled multimodal logs; success is 20% fewer real-world samples to reach 90% task success.
 53. **Gradient compression for distributed training**: Implement a `GradientCompressor`

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -141,6 +141,7 @@ from .duplicate_detector import DuplicateDetector
 from .telemetry import TelemetryLogger, FineGrainedProfiler
 from .license_inspector import LicenseInspector
 from .dataset_versioner import DatasetVersioner
+from .dataset_lineage_manager import DatasetLineageManager
 from .streaming_compression import AdaptiveCompressor, TemporalVectorCompressor
 from .context_profiler import profile_model, ContextWindowProfiler
 from .gpu_aware_scheduler import GPUAwareScheduler

--- a/src/dataset_lineage_manager.py
+++ b/src/dataset_lineage_manager.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import hashlib
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable, List, Dict
+
+
+def _hash_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@dataclass
+class LineageStep:
+    note: str
+    inputs: List[str]
+    outputs: Dict[str, str]
+
+
+class DatasetLineageManager:
+    """Record dataset transformations and resulting file hashes."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.log_path = self.root / "dataset_lineage.json"
+        if self.log_path.exists():
+            data = json.loads(self.log_path.read_text())
+            self.steps: List[LineageStep] = [LineageStep(**d) for d in data]
+        else:
+            self.steps = []
+
+    # --------------------------------------------------------------
+    def record(
+        self,
+        inputs: Iterable[str | Path],
+        outputs: Iterable[str | Path],
+        note: str = "",
+    ) -> None:
+        out_hashes = {str(p): _hash_file(Path(p)) for p in outputs}
+        step = LineageStep(note, [str(p) for p in inputs], out_hashes)
+        self.steps.append(step)
+        self.log_path.write_text(
+            json.dumps([asdict(s) for s in self.steps], indent=2)
+        )
+
+    # --------------------------------------------------------------
+    def load(self) -> List[LineageStep]:
+        """Reload steps from the log file."""
+        if self.log_path.exists():
+            data = json.loads(self.log_path.read_text())
+            self.steps = [LineageStep(**d) for d in data]
+        return self.steps
+
+
+__all__ = ["DatasetLineageManager", "LineageStep"]

--- a/tests/test_dataset_lineage_manager.py
+++ b/tests/test_dataset_lineage_manager.py
@@ -1,0 +1,44 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+import importlib.machinery
+import importlib.util
+import types
+
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+loader = importlib.machinery.SourceFileLoader('src.dataset_lineage_manager', 'src/dataset_lineage_manager.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+dlm = importlib.util.module_from_spec(spec)
+dlm.__package__ = 'src'
+sys.modules['src.dataset_lineage_manager'] = dlm
+loader.exec_module(dlm)
+DatasetLineageManager = dlm.DatasetLineageManager
+
+
+class TestDatasetLineageManager(unittest.TestCase):
+    def test_record_and_load(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            inp = root / "input.txt"
+            outp = root / "output.txt"
+            inp.write_text("in")
+            outp.write_text("out")
+            mgr = DatasetLineageManager(root)
+            mgr.record([inp], [outp], note="step1")
+            data = json.loads((root / "dataset_lineage.json").read_text())
+            self.assertEqual(data[0]["note"], "step1")
+            self.assertEqual(data[0]["inputs"], [str(inp)])
+            self.assertIn(str(outp), data[0]["outputs"])
+            steps = mgr.load()
+            self.assertEqual(len(steps), 1)
+            self.assertEqual(steps[0].note, "step1")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add DatasetLineageManager for tracking dataset transformations
- mark dataset lineage manager task done in docs
- document implementation details in Implementation.md
- expose DatasetLineageManager from the package
- test DatasetLineageManager

## Testing
- `pytest tests/test_dataset_lineage_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6867d86bd9a08331a803f2470bf10952