### PR TITLE
Add cross-lingual embedding ingestion

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -304,7 +304,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 40. **Cross-lingual data ingestion**: Integrate a `CrossLingualTranslator`
     into `data_ingest` so text is stored in multiple languages. *Implemented*
     via the optional ``translator`` argument of ``download_triples()`` which
-    saves translated files alongside the originals.
+    saves translated files alongside the originals. Translated triples are now
+    passed through `cross_modal_fusion.encode_all()` and their fused embeddings
+    are stored in `HierarchicalMemory` with language tags for language-agnostic
+    retrieval.
 41. **World-model distillation**: Implement a `WorldModelDistiller` that
     compresses the large world model into a smaller student network. Target
     <5% reward loss on the embodied RL benchmarks while reducing model size by

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -113,6 +113,7 @@ from .data_ingest import (
     synthesize_from_world_model,
     offline_synthesizer,
     filter_dataset,
+    ingest_translated_triples,
     ActiveDataSelector,
     CrossLingualTranslator,
 )


### PR DESCRIPTION
## Summary
- ingest translated triples through cross-modal fusion and store in HierarchicalMemory
- expose new ingestion helper in `asi.__init__`
- document cross-lingual retrieval

## Testing
- `pytest tests/test_data_ingest.py tests/test_cross_lingual_translator.py -q` *(fails: aiohttp missing)*

------
https://chatgpt.com/codex/tasks/task_e_6868315d6d2c8331a65aeb790e890539