### PR TITLE
Add multi-agent reasoning debugger

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -627,7 +627,7 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   **Implemented in `src/federated_world_model_trainer.py` with script `scripts/federated_world_model_train.py`.**
 - Add a `GradientPatchEditor` helper to apply small updates that fix incorrect outputs without full fine-tuning.
   **Implemented in `src/gradient_patch_editor.py`.**
-- Extend `graph_of_thought.py` with a `ReasoningDebugger` that flags contradictions or loops in reasoning traces.
+- Extend `graph_of_thought.py` with a `ReasoningDebugger` that consolidates contradictions and loops from multiple agents.
   **Implemented in `src/graph_of_thought.py`.**
 - Implement a `GraphQLMemoryGateway` that exposes `MemoryServer` retrieval endpoints via GraphQL. Provide `scripts/graphql_memory_server.py` to benchmark query overhead.
   **Implemented in `src/graphql_memory_gateway.py` with `scripts/graphql_memory_server.py`.**

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -214,7 +214,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     `RetrievalExplainer` extends `HierarchicalMemory.search()` with similarity scores and provenance so these traces are visible through the memory dashboard.
 12. **Graph-of-thought planning**: Implement `GraphOfThought` (see
     `src/graph_of_thought.py`) and measure refactor quality gains over the
-    baseline meta-RL agent.
+    baseline meta-RL agent. The `ReasoningDebugger` now aggregates loops and
+    contradictions across multiple agents.
 12. **Neuro-symbolic world model**: Integrate `NeuroSymbolicExecutor` with
     `world_model_rl.rollout_policy()` and log constraint violations.
     *Implemented as `src/neuro_symbolic_executor.py`.*

--- a/tests/test_reasoning_debugger.py
+++ b/tests/test_reasoning_debugger.py
@@ -1,15 +1,39 @@
 import unittest
-from asi.graph_of_thought import GraphOfThought, ReasoningDebugger
+import importlib.machinery
+import importlib.util
+import sys
+
+loader = importlib.machinery.SourceFileLoader('graph_of_thought', 'src/graph_of_thought.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mod
+loader.exec_module(mod)
+GraphOfThought = mod.GraphOfThought
+ReasoningDebugger = mod.ReasoningDebugger
+
 
 class TestReasoningDebugger(unittest.TestCase):
-    def test_debug(self):
-        g = GraphOfThought()
-        a = g.add_step("start")
-        b = g.add_step("not start")
-        g.connect(a, b)
-        dbg = ReasoningDebugger(g)
-        self.assertTrue(dbg.find_contradictions())
-        self.assertTrue(dbg.find_loops())
+    def test_single_and_multi_agent(self):
+        g1 = GraphOfThought()
+        a1 = g1.add_step('start')
+        b1 = g1.add_step('not start')
+        g1.connect(a1, b1)
+        g1.connect(b1, a1)
+
+        g2 = GraphOfThought()
+        c1 = g2.add_step('start')
+        g2.connect(c1, c1)
+
+        dbg = ReasoningDebugger({'one': g1, 'two': g2})
+        loops = dbg.find_loops()
+        self.assertIn('one', loops)
+        self.assertIn('two', loops)
+        self.assertTrue(any(loops.values()))
+
+        contrad = dbg.find_contradictions()
+        self.assertTrue(any(a != c for a, _, c, _ in contrad))
+        self.assertIsInstance(dbg.report(), str)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend ReasoningDebugger to accept multiple agent graphs
- aggregate contradictory paths and loops
- test updated multi-agent report
- document the new capability in Plan and Implementation

## Testing
- `pytest tests/test_graph_of_thought.py tests/test_reasoning_debugger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6868315f055883319ea6b66dd250e268