### PR TITLE
Enable resource-aware multi-agent scheduling

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -689,3 +689,7 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 ## Edge RL Trainer
 
 `src/edge_rl_trainer.py` trains world models under a compute budget. It checks `ComputeBudgetTracker.remaining()` each step and stops when resources run low. See `scripts/train_edge_rl.py` for a usage example.
+
+### Resource-aware scheduling
+
+`MultiAgentCoordinator` accepts a `ComputeBudgetTracker` instance which tracks GPU hours per agent. `RLNegotiator` considers `tracker.remaining()` when assigning tasks and each action logs usage via `tracker.consume()`. This ensures repositories are processed by agents with sufficient budget.

--- a/src/telemetry.py
+++ b/src/telemetry.py
@@ -8,7 +8,23 @@ from dataclasses import dataclass, field
 from typing import Dict, Any, Callable
 
 import psutil
-import torch
+try:  # pragma: no cover - optional torch dependency
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - allow running without torch
+    class _DummyCuda:
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+        @staticmethod
+        def utilization() -> float:
+            return 0.0
+
+        @staticmethod
+        def memory_allocated() -> int:
+            return 0
+
+    torch = type("torch", (), {"cuda": _DummyCuda})()  # type: ignore
 try:
     from prometheus_client import Gauge, start_http_server
     _HAS_PROM = True


### PR DESCRIPTION
## Summary
- track compute use with `ComputeBudgetTracker.consume`
- pass budget tracker through `MultiAgentCoordinator`
- prioritize agents with more remaining budget
- record compute for each action
- describe resource-aware scheduling in docs
- test scheduling with budgets

## Testing
- `pytest tests/test_multi_agent_coordinator.py tests/test_compute_budget_tracker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68683166fd2483319eca3aeb951895c7