### PR TITLE
Add cross-lingual memory wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ logger = TelemetryLogger(port=8000)
 server = serve(mem, "localhost:50070", telemetry=logger)
 ```
 
+To search across languages, wrap the memory with `CrossLingualMemory` and
+provide a `CrossLingualTranslator`:
+
+```python
+from asi.cross_lingual_memory import CrossLingualMemory
+from asi.data_ingest import CrossLingualTranslator
+
+translator = CrossLingualTranslator(["es"])
+mem = CrossLingualMemory(dim=4, compressed_dim=2, capacity=10, translator=translator)
+mem.add("hello")
+mem.search("[es] hello")
+```
+
 Visit `http://localhost:8000` to view Prometheus metrics.
 
 `RiskDashboard` combines these metrics with ethical risk scores from

--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -580,6 +580,9 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Add a `CrossLingualTranslator` helper in `data_ingest.py` to translate text
   into multiple languages during ingestion and store the augmented triples.
   **Implemented in `data_ingest.CrossLingualTranslator`.**
+- Provide a `CrossLingualMemory` wrapper that stores translated vectors and
+  lets `HierarchicalMemory` search across languages when a translator is set.
+  **Implemented in `src/cross_lingual_memory.py` with tests.**
 - Create a `WorldModelDistiller` module and a `scripts/distill_world_model.py`
   utility to train smaller student models from the large world model.
   **Implemented in `src/world_model_distiller.py` with the script

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -313,45 +313,48 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     passed through `cross_modal_fusion.encode_all()` and their fused embeddings
     are stored in `HierarchicalMemory` with language tags for language-agnostic
     retrieval.
-41. **World-model distillation**: Implement a `WorldModelDistiller` that
+41. **Cross-lingual memory retrieval**: `HierarchicalMemory` now accepts a
+    translator and the `CrossLingualMemory` wrapper persists translated vectors
+    so queries in any supported language return the same results.
+42. **World-model distillation**: Implement a `WorldModelDistiller` that
     compresses the large world model into a smaller student network. Target
     <5% reward loss on the embodied RL benchmarks while reducing model size by
     ≥4×.
 
-42. **Summarizing memory compression**: Condense rarely accessed vectors with a small language model before persisting them to disk. Success is a ≥50 % reduction in storage while retrieval accuracy drops <5 %.
-43. **Telemetry instrumentation**: Record GPU/CPU utilization and network throughput across distributed nodes using OpenTelemetry and expose the metrics via Prometheus. Overhead must remain <5 % on a 4-node cluster. *`MemoryServer` now accepts a `TelemetryLogger` to start and stop metrics automatically.*
-44. **Memory usage dashboard**: Aggregate telemetry from multiple memory nodes and present hit/miss rates in real time.
-44. **License compliance checker**: Parse dataset sources for license text during ingestion and block incompatible samples. Every stored triple should include a valid license entry.
-45. **Adaptive streaming compression**: Add `AdaptiveCompressor` to adjust the compression ratio in `StreamingCompressor` based on retrieval frequency.
-46. **Prompt optimization**: Build a `PromptOptimizer` that learns prompt revisions via reinforcement learning and measure evaluation gains.
-47. **Training anomaly detection**: Extend `SelfHealingTrainer` with a `TrainingAnomalyDetector` to roll back or restart runs when metrics diverge.
-48. **Parameter-efficient adaptation**: Explore low-rank fine-tuning across tasks; success is matching baseline accuracy with ≤10% extra parameters.
-49. **Context summarization memory**: Store compressed summaries for distant tokens and re-expand them on demand; success is >95% retrieval accuracy at 100× token length. *Implemented in `src/context_summary_memory.py` with tests.*
-50. **Dataset lineage manager**: Automatically track dataset versions and transformations, enabling reproducible training pipelines. *Implemented in `src/dataset_lineage_manager.py`.*
+43. **Summarizing memory compression**: Condense rarely accessed vectors with a small language model before persisting them to disk. Success is a ≥50 % reduction in storage while retrieval accuracy drops <5 %.
+44. **Telemetry instrumentation**: Record GPU/CPU utilization and network throughput across distributed nodes using OpenTelemetry and expose the metrics via Prometheus. Overhead must remain <5 % on a 4-node cluster. *`MemoryServer` now accepts a `TelemetryLogger` to start and stop metrics automatically.*
+45. **Memory usage dashboard**: Aggregate telemetry from multiple memory nodes and present hit/miss rates in real time.
+46. **License compliance checker**: Parse dataset sources for license text during ingestion and block incompatible samples. Every stored triple should include a valid license entry.
+47. **Adaptive streaming compression**: Add `AdaptiveCompressor` to adjust the compression ratio in `StreamingCompressor` based on retrieval frequency.
+48. **Prompt optimization**: Build a `PromptOptimizer` that learns prompt revisions via reinforcement learning and measure evaluation gains.
+49. **Training anomaly detection**: Extend `SelfHealingTrainer` with a `TrainingAnomalyDetector` to roll back or restart runs when metrics diverge.
+50. **Parameter-efficient adaptation**: Explore low-rank fine-tuning across tasks; success is matching baseline accuracy with ≤10% extra parameters.
+51. **Context summarization memory**: Store compressed summaries for distant tokens and re-expand them on demand; success is >95% retrieval accuracy at 100× token length. *Implemented in `src/context_summary_memory.py` with tests.*
+52. **Dataset lineage manager**: Automatically track dataset versions and transformations, enabling reproducible training pipelines. *Implemented in `src/dataset_lineage_manager.py`.*
     Use `DataProvenanceLedger` to append a signed hash of each lineage record. Run `scripts/check_provenance.py <root>` to verify the ledger.
-51. **Multi-stage oversight**: Combine constitutional AI, deliberative alignment, and critic-in-the-loop RLHF with formal verification; success is <1% harmful output on the existing benchmarks.
-52. **Self-supervised sensorimotor pretraining**: Pretrain the embodied world model on large unlabelled multimodal logs; success is 20% fewer real-world samples to reach 90% task success.
-53. **Gradient compression for distributed training**: Implement a `GradientCompressor`
+53. **Multi-stage oversight**: Combine constitutional AI, deliberative alignment, and critic-in-the-loop RLHF with formal verification; success is <1% harmful output on the existing benchmarks.
+54. **Self-supervised sensorimotor pretraining**: Pretrain the embodied world model on large unlabelled multimodal logs; success is 20% fewer real-world samples to reach 90% task success.
+55. **Gradient compression for distributed training**: Implement a `GradientCompressor`
     with top-k sparsification or quantized gradients and integrate it with
     `DistributedTrainer`.
-53. **ONNX export**: Provide `export_to_onnx()` and a script to save `MultiModalWorldModel` and `CrossModalFusion` as ONNX graphs.
-54. **Memory profiling**: Instrument `HierarchicalMemory` with a lightweight profiler that records query counts, hit/miss ratios and latency.
-55. **Secure federated learner**: Train models across remote peers using encrypted gradient aggregation. Accuracy should stay within 2% of centralized training.
-56. **GPU-aware scheduler**: Monitor GPU memory and compute load to dispatch jobs dynamically. Combined with `ComputeBudgetTracker`, the new `AdaptiveScheduler` automatically pauses or resumes runs based on remaining GPU hours and historical improvement.
-57. **Adversarial robustness suite**: Generate gradient-based adversarial prompts and measure model degradation. Acceptable drop is <5% accuracy on the evaluation harness.
-58. **Bias-aware dataset filtering**: Add `DatasetBiasDetector` to compute representation metrics and filter skewed samples. Goal is <5% disparity across demographic slices after filtering.
-59. **Federated world-model training**: Train `world_model_rl` across multiple nodes via gradient averaging. Throughput should scale to four nodes with <1.2× single-node time.
-60. **Parameter-efficient model editing**: Implement `GradientPatchEditor` to fix wrong outputs with minimal updates; >90% targeted fix rate with <1% perplexity change.
-61. **Reasoning trace debugger**: Extend `GraphOfThought` with a debugger that flags contradictory steps, achieving >80% detection accuracy on synthetic traces.
-62. **GraphQL memory gateway**: Expose `MemoryServer` queries through a GraphQL API and keep retrieval accuracy unchanged with <1.2× latency.
-63. **Fine-grained telemetry profiler**: Record per-module compute and memory via `FineGrainedProfiler` and ensure overhead stays below 3%.
-64. **Auto-labeling pipeline**: Use the world model to generate weak labels for unlabeled triples during ingestion and measure dataset quality improvements.
-65. **Context window profiler**: Measure memory and latency across sequence lengths. Implemented in `src/context_profiler.py` and integrated with `eval_harness.py`.
-66. **Differential privacy memory**: Use `DifferentialPrivacyMemory` to store noisy embeddings with <2% recall drop at ε=1. *Implemented in `src/dp_memory.py` with tests.*
-67. **Unified multi-modal evaluation**: Add `MultiModalEval` to `eval_harness` and target ≥90% recall on the toy dataset. *Implemented in `src/eval_harness.py` with tests.*
-68. **Multi-agent graph planning**: Integrate `MultiAgentCoordinator` with `GraphOfThoughtPlanner` to build reasoning graphs collaboratively, achieving ≥20% speed-up over single-agent planning. *Implemented in `src/multi_agent_graph_planner.py` with tests.*
-69. **Self-debugging world model**: Automatically patch the world model when rollout errors exceed 1%, keeping long-term error <1%. *Implemented in `src/world_model_debugger.py` with tests.*
-70. **Versioned model lineage**: Record hashed checkpoints and link them to dataset versions via `ModelVersionManager` for reproducible experiments. *Implemented in `src/model_version_manager.py` with tests.*
+56. **ONNX export**: Provide `export_to_onnx()` and a script to save `MultiModalWorldModel` and `CrossModalFusion` as ONNX graphs.
+57. **Memory profiling**: Instrument `HierarchicalMemory` with a lightweight profiler that records query counts, hit/miss ratios and latency.
+58. **Secure federated learner**: Train models across remote peers using encrypted gradient aggregation. Accuracy should stay within 2% of centralized training.
+59. **GPU-aware scheduler**: Monitor GPU memory and compute load to dispatch jobs dynamically. Combined with `ComputeBudgetTracker`, the new `AdaptiveScheduler` automatically pauses or resumes runs based on remaining GPU hours and historical improvement.
+60. **Adversarial robustness suite**: Generate gradient-based adversarial prompts and measure model degradation. Acceptable drop is <5% accuracy on the evaluation harness.
+61. **Bias-aware dataset filtering**: Add `DatasetBiasDetector` to compute representation metrics and filter skewed samples. Goal is <5% disparity across demographic slices after filtering.
+62. **Federated world-model training**: Train `world_model_rl` across multiple nodes via gradient averaging. Throughput should scale to four nodes with <1.2× single-node time.
+63. **Parameter-efficient model editing**: Implement `GradientPatchEditor` to fix wrong outputs with minimal updates; >90% targeted fix rate with <1% perplexity change.
+64. **Reasoning trace debugger**: Extend `GraphOfThought` with a debugger that flags contradictory steps, achieving >80% detection accuracy on synthetic traces.
+65. **GraphQL memory gateway**: Expose `MemoryServer` queries through a GraphQL API and keep retrieval accuracy unchanged with <1.2× latency.
+66. **Fine-grained telemetry profiler**: Record per-module compute and memory via `FineGrainedProfiler` and ensure overhead stays below 3%.
+67. **Auto-labeling pipeline**: Use the world model to generate weak labels for unlabeled triples during ingestion and measure dataset quality improvements.
+68. **Context window profiler**: Measure memory and latency across sequence lengths. Implemented in `src/context_profiler.py` and integrated with `eval_harness.py`.
+69. **Differential privacy memory**: Use `DifferentialPrivacyMemory` to store noisy embeddings with <2% recall drop at ε=1. *Implemented in `src/dp_memory.py` with tests.*
+70. **Unified multi-modal evaluation**: Add `MultiModalEval` to `eval_harness` and target ≥90% recall on the toy dataset. *Implemented in `src/eval_harness.py` with tests.*
+71. **Multi-agent graph planning**: Integrate `MultiAgentCoordinator` with `GraphOfThoughtPlanner` to build reasoning graphs collaboratively, achieving ≥20% speed-up over single-agent planning. *Implemented in `src/multi_agent_graph_planner.py` with tests.*
+72. **Self-debugging world model**: Automatically patch the world model when rollout errors exceed 1%, keeping long-term error <1%. *Implemented in `src/world_model_debugger.py` with tests.*
+73. **Versioned model lineage**: Record hashed checkpoints and link them to dataset versions via `ModelVersionManager` for reproducible experiments. *Implemented in `src/model_version_manager.py` with tests.*
 
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -157,6 +157,7 @@ from .auto_labeler import AutoLabeler
 from .graphql_memory_gateway import GraphQLMemoryGateway
 from .world_model_distiller import DistillConfig, distill_world_model
 from .summarizing_memory import SummarizingMemory
+from .cross_lingual_memory import CrossLingualMemory
 from .context_summary_memory import ContextSummaryMemory
 from .sensorimotor_pretrainer import (
     SensorimotorPretrainConfig,

--- a/src/cross_lingual_memory.py
+++ b/src/cross_lingual_memory.py
@@ -1,0 +1,90 @@
+import numpy as np
+import torch
+from typing import Iterable, Any, Tuple, List
+
+from .hierarchical_memory import HierarchicalMemory
+from .data_ingest import CrossLingualTranslator
+
+
+def _embed_text(text: str, dim: int) -> torch.Tensor:
+    """Deterministically embed text using a hash based RNG."""
+    seed = abs(hash(text)) % (2 ** 32)
+    rng = np.random.default_rng(seed)
+    vec = rng.standard_normal(dim).astype(np.float32)
+    return torch.from_numpy(vec)
+
+
+class CrossLingualMemory(HierarchicalMemory):
+    """HierarchicalMemory wrapper storing translations for text input."""
+
+    def __init__(
+        self,
+        *args: Any,
+        translator: CrossLingualTranslator | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, translator=translator, **kwargs)
+        self.text_dim = self.compressor.encoder.in_features
+
+    def add_texts(
+        self, texts: Iterable[str], metadata: Iterable[Any] | None = None
+    ) -> None:
+        """Embed ``texts`` and add them plus translations."""
+        base = list(texts)
+        metas = list(metadata) if metadata is not None else base
+        vecs: List[torch.Tensor] = []
+        out_meta: List[Any] = []
+        for t, m in zip(base, metas):
+            v = _embed_text(t, self.text_dim)
+            vecs.append(v)
+            out_meta.append(m)
+            if self.translator is not None:
+                for trans in self.translator.translate_all(t).values():
+                    vecs.append(_embed_text(trans, self.text_dim))
+                    out_meta.append(trans)
+        stacked = torch.stack(vecs)
+        super().add(stacked, out_meta)
+
+    # ------------------------------------------------------------------
+    # Convenience wrappers
+
+    def add(
+        self, x: torch.Tensor | str, metadata: Iterable[Any] | None = None
+    ) -> None:  # type: ignore[override]
+        """Add embeddings or raw text with translations."""
+        if isinstance(x, str):
+            self.add_texts([x], metadata)
+        else:
+            super().add(x, metadata)
+
+    def search_text(self, text: str, k: int = 5) -> Tuple[torch.Tensor, List[Any]]:
+        """Search for ``text`` across languages."""
+        queries = [text]
+        if self.translator is not None:
+            queries += list(self.translator.translate_all(text).values())
+        results: List[tuple[float, torch.Tensor, Any]] = []
+        for q in queries:
+            q_vec = _embed_text(q, self.text_dim)
+            vecs, meta = super().search(q_vec, k)
+            scores = torch.nn.functional.cosine_similarity(
+                vecs, q_vec.expand_as(vecs), dim=1
+            )
+            results.extend([(s.item(), v, m) for s, v, m in zip(scores, vecs, meta)])
+        if not results:
+            return torch.empty(0, self.text_dim), []
+        results.sort(key=lambda x: x[0], reverse=True)
+        top = results[:k]
+        out_vecs = torch.stack([r[1] for r in top])
+        out_meta = [r[2] for r in top]
+        return out_vecs, out_meta
+
+    def search(
+        self, query: torch.Tensor | str, k: int = 5
+    ) -> Tuple[torch.Tensor, List[Any]]:  # type: ignore[override]
+        """Search by embedding or text."""
+        if isinstance(query, str):
+            return self.search_text(query, k)
+        return super().search(query, k)
+
+
+__all__ = ["CrossLingualMemory"]

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -17,6 +17,7 @@ from .vector_store import VectorStore, FaissVectorStore, LocalitySensitiveHashIn
 from .pq_vector_store import PQVectorStore
 from .async_vector_store import AsyncFaissVectorStore
 from .hopfield_memory import HopfieldMemory
+from .data_ingest import CrossLingualTranslator
 
 
 class SSDCache:
@@ -117,6 +118,7 @@ class HierarchicalMemory:
         adaptive_evict: bool = False,
         evict_check_interval: int = 100,
         use_kg: bool = False,
+        translator: "CrossLingualTranslator | None" = None,
     ) -> None:
         if temporal_decay is None:
             self.compressor = StreamingCompressor(dim, compressed_dim, capacity)
@@ -151,6 +153,7 @@ class HierarchicalMemory:
         self.query_count = 0
         self.kg: KnowledgeGraphMemory | None = KnowledgeGraphMemory() if use_kg else None
         self.last_trace: dict | None = None
+        self.translator = translator
 
     def __len__(self) -> int:
         """Return the number of stored vectors."""

--- a/tests/test_cross_lingual_memory.py
+++ b/tests/test_cross_lingual_memory.py
@@ -1,0 +1,37 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import sys
+import types
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+di = load('asi.data_ingest', 'src/data_ingest.py')
+hm = load('asi.hierarchical_memory', 'src/hierarchical_memory.py')
+clm = load('asi.cross_lingual_memory', 'src/cross_lingual_memory.py')
+
+CrossLingualMemory = clm.CrossLingualMemory
+CrossLingualTranslator = di.CrossLingualTranslator
+
+class TestCrossLingualMemory(unittest.TestCase):
+    def test_retrieval_across_languages(self):
+        tr = CrossLingualTranslator(["es"])
+        mem = CrossLingualMemory(dim=4, compressed_dim=2, capacity=10, translator=tr)
+        mem.add("hello")
+        vecs, meta = mem.search("[es] hello", k=1)
+        self.assertEqual(len(meta), 1)
+        self.assertIn(meta[0], ["hello", "[es] hello"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add CrossLingualMemory module and tests
- allow HierarchicalMemory to accept a translator
- mention cross-lingual retrieval in docs
- document memory wrapper usage in README

## Testing
- `pip install torch numpy requests pillow psutil aiohttp`
- `pip install -e .`
- `pytest tests/test_cross_lingual_memory.py -q` *(fails: ModuleNotFoundError: No module named 'asi.streaming_compression')*


------
https://chatgpt.com/codex/tasks/task_e_6868377c73348331a9dac30270b2e069