### PR TITLE
Add accelerator-aware scheduling

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -625,9 +625,9 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Add `export_to_onnx()` in `src/onnx_utils.py` and `scripts/export_onnx.py` to save ONNX graphs for `MultiModalWorldModel` and `CrossModalFusion`. Run `python scripts/export_onnx.py --out-dir models` to generate them.
 - Implement a `SecureFederatedLearner` that aggregates encrypted gradients from remote peers so training can proceed without sharing raw data. Provide a `scripts/federated_train.py` CLI.
   **Implemented in `src/secure_federated_learner.py` with `scripts/federated_train.py`.**
-- Add a `GPUAwareScheduler` module to monitor GPU memory and compute load and dispatch jobs accordingly. Integrate it with `DistributedTrainer`.
-  Combine it with `ComputeBudgetTracker` in `adaptive_scheduler.py` so jobs pause when the GPU-hour budget runs out and resume once progress improves.
-  **Implemented in `src/gpu_aware_scheduler.py` and extended by `src/adaptive_scheduler.py` for use in `DistributedTrainer`.**
+- Add an `AcceleratorScheduler` that detects GPU, TPU or CPU utilisation and dispatches queued jobs when the requested device has available capacity. Integrate it with `DistributedTrainer`.
+  Combine it with `ComputeBudgetTracker` in `adaptive_scheduler.py` so jobs pause when the accelerator budget runs out and resume once progress improves.
+  **Implemented in `src/accelerator_scheduler.py` with a backwards-compatible alias `GPUAwareScheduler` and extended by `src/adaptive_scheduler.py`.**
 - Develop an `AdversarialRobustnessSuite` that generates adversarial prompts and reports failure cases through `eval_harness`.
   **Implemented in `src/adversarial_robustness.py`.**
 - Implement a `DatasetBiasDetector` module that computes representation metrics and integrates with `AutoDatasetFilter`. Provide a `dataset_bias_report.py` utility for bias analysis.
@@ -673,7 +673,9 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Extend `GraphOfThought` with `summarize_trace()` and an `explain` flag so
   reasoning steps can be rendered in plain language for debugging.
 - Provide a `ResourceBroker` module coordinating multiple clusters and a demo
-  script `scripts/resource_broker_demo.py`.
+  script `scripts/resource_broker_demo.py`. The broker now reports per-accelerator
+  utilisation via `get_load()` and allows allocating jobs to specific
+  accelerator types.
 - Add `research_ingest.py` which fetches new papers and outputs daily summaries
   under `research_logs/`.
 - Expand `GenerativeDataAugmentor` with `synthesize_3d()` for basic 3D asset

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -145,6 +145,7 @@ from .dataset_versioner import DatasetVersioner
 from .dataset_lineage_manager import DatasetLineageManager
 from .streaming_compression import AdaptiveCompressor, TemporalVectorCompressor
 from .context_profiler import profile_model, ContextWindowProfiler
+from .accelerator_scheduler import AcceleratorScheduler
 from .gpu_aware_scheduler import GPUAwareScheduler
 from .adaptive_scheduler import AdaptiveScheduler
 from .dataset_bias_detector import (

--- a/src/accelerator_scheduler.py
+++ b/src/accelerator_scheduler.py
@@ -1,0 +1,81 @@
+"""Dispatch jobs based on accelerator utilization."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from typing import Callable, Deque, Dict
+
+import psutil
+try:  # pragma: no cover - optional torch dependency
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - allow running without torch
+    torch = None  # type: ignore
+
+try:  # pragma: no cover - optional tpu dependency
+    import torch_xla.core.xla_model as xm  # type: ignore
+    _HAS_XLA = True
+except Exception:  # pragma: no cover - allow running without torch_xla
+    xm = None  # type: ignore
+    _HAS_XLA = False
+
+
+class AcceleratorScheduler:
+    """Queue jobs and execute when device utilization is low."""
+
+    def __init__(self, max_util: float = 0.9, check_interval: float = 1.0) -> None:
+        self.max_util = max_util
+        self.check_interval = check_interval
+        self.queues: Dict[str, Deque[Callable[[], None]]] = {
+            "cpu": deque(),
+            "gpu": deque(),
+            "tpu": deque(),
+        }
+        self.thread = threading.Thread(target=self._loop, daemon=True)
+        self.thread.start()
+
+    # --------------------------------------------------------------
+    def add(self, job: Callable[[], None], accelerator: str = "gpu") -> None:
+        self.queues.setdefault(accelerator, deque()).append(job)
+
+    # --------------------------------------------------------------
+    def _utilization(self, accelerator: str) -> float:
+        if accelerator == "gpu" and torch is not None and torch.cuda.is_available():
+            try:
+                return (
+                    torch.cuda.memory_allocated()
+                    / torch.cuda.get_device_properties(0).total_memory
+                )
+            except Exception:
+                return 0.0
+        if accelerator == "tpu" and _HAS_XLA:
+            try:
+                info = xm.get_memory_info("xla:0")
+                used = info.get("kb_total", 0) - info.get("kb_free", 0)
+                total = info.get("kb_total", 1)
+                return used / total
+            except Exception:
+                return 0.0
+        if accelerator == "cpu":
+            return psutil.cpu_percent(interval=None) / 100.0
+        return 0.0
+
+    # --------------------------------------------------------------
+    def get_utilization(self) -> Dict[str, float]:
+        return {acc: self._utilization(acc) for acc in self.queues}
+
+    # --------------------------------------------------------------
+    def _loop(self) -> None:
+        while True:
+            ran = False
+            for acc, queue in self.queues.items():
+                if queue and self._utilization(acc) < self.max_util:
+                    job = queue.popleft()
+                    job()
+                    ran = True
+            if not ran:
+                time.sleep(self.check_interval)
+
+
+__all__ = ["AcceleratorScheduler"]

--- a/src/adaptive_scheduler.py
+++ b/src/adaptive_scheduler.py
@@ -3,16 +3,34 @@ from __future__ import annotations
 import threading
 import time
 from collections import deque
-from typing import Callable, Deque
+from typing import Callable, Deque, Dict
 
-import torch
+try:  # pragma: no cover - optional torch dependency
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - allow running without torch
+    class _DummyCuda:
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+        @staticmethod
+        def memory_allocated() -> int:
+            return 0
+
+        @staticmethod
+        def get_device_properties(_: int):
+            class P:
+                total_memory = 1
+            return P()
+
+    torch = type("torch", (), {"cuda": _DummyCuda})()  # type: ignore
 
 from .compute_budget_tracker import ComputeBudgetTracker
-from .gpu_aware_scheduler import GPUAwareScheduler
+from .accelerator_scheduler import AcceleratorScheduler
 
 
-class AdaptiveScheduler(GPUAwareScheduler):
-    """GPU-aware scheduler with compute budget checks and progress gating."""
+class AdaptiveScheduler(AcceleratorScheduler):
+    """Accelerator-aware scheduler with compute budget checks and progress gating."""
 
     def __init__(
         self,
@@ -29,7 +47,7 @@ class AdaptiveScheduler(GPUAwareScheduler):
         self.min_improvement = min_improvement
         self._stop = threading.Event()
         self.budget.start(run_id)
-        super().__init__(max_mem=max_mem, check_interval=check_interval)
+        super().__init__(max_util=max_mem, check_interval=check_interval)
 
     # --------------------------------------------------------------
     def record_improvement(self, val: float) -> None:
@@ -49,23 +67,21 @@ class AdaptiveScheduler(GPUAwareScheduler):
     # --------------------------------------------------------------
     def _loop(self) -> None:  # type: ignore[override]
         while not self._stop.is_set():
-            if not self.queue:
+            if not any(self.queues[acc] for acc in self.queues):
                 time.sleep(self.check_interval)
                 continue
             if self._should_pause():
                 time.sleep(self.check_interval)
                 continue
-            mem = (
-                torch.cuda.memory_allocated() / torch.cuda.get_device_properties(0).total_memory
-                if torch.cuda.is_available()
-                else 0.0
-            )
-            if mem < self.max_mem:
-                job = self.queue.popleft()
-                res = job()
-                if isinstance(res, (int, float)):
-                    self.record_improvement(float(res))
-            else:
+            ran = False
+            for acc, queue in self.queues.items():
+                if queue and self._utilization(acc) < self.max_util:
+                    job = queue.popleft()
+                    res = job()
+                    if isinstance(res, (int, float)):
+                        self.record_improvement(float(res))
+                    ran = True
+            if not ran:
                 time.sleep(self.check_interval)
         self.budget.stop()
 
@@ -75,6 +91,11 @@ class AdaptiveScheduler(GPUAwareScheduler):
         if self.thread.is_alive():
             self.thread.join(timeout=1.0)
         self.budget.stop()
+
+    # --------------------------------------------------------------
+    def report_load(self) -> Dict[str, float]:
+        """Return current accelerator utilisation."""
+        return self.get_utilization()
 
 
 __all__ = ["AdaptiveScheduler"]

--- a/src/gpu_aware_scheduler.py
+++ b/src/gpu_aware_scheduler.py
@@ -1,43 +1,15 @@
-"""Dispatch jobs based on GPU usage."""
+"""Backward-compatible wrapper for AcceleratorScheduler."""
 
 from __future__ import annotations
 
-import threading
-import time
-from collections import deque
-from typing import Callable
-
-import torch
+from .accelerator_scheduler import AcceleratorScheduler
 
 
-class GPUAwareScheduler:
-    """Queue jobs and execute when GPU memory is free."""
+class GPUAwareScheduler(AcceleratorScheduler):
+    """Alias of :class:`AcceleratorScheduler` for GPU jobs."""
 
     def __init__(self, max_mem: float = 0.9, check_interval: float = 1.0) -> None:
-        self.max_mem = max_mem
-        self.check_interval = check_interval
-        self.queue: deque[Callable[[], None]] = deque()
-        self.thread = threading.Thread(target=self._loop, daemon=True)
-        self.thread.start()
-
-    def add(self, job: Callable[[], None]) -> None:
-        self.queue.append(job)
-
-    def _loop(self) -> None:
-        while True:
-            if not self.queue:
-                time.sleep(self.check_interval)
-                continue
-            mem = (
-                torch.cuda.memory_allocated() / torch.cuda.get_device_properties(0).total_memory
-                if torch.cuda.is_available()
-                else 0.0
-            )
-            if mem < self.max_mem:
-                job = self.queue.popleft()
-                job()
-            else:
-                time.sleep(self.check_interval)
+        super().__init__(max_util=max_mem, check_interval=check_interval)
 
 
 __all__ = ["GPUAwareScheduler"]

--- a/src/resource_broker.py
+++ b/src/resource_broker.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict
 
 from .telemetry import TelemetryLogger
@@ -10,6 +10,8 @@ from .telemetry import TelemetryLogger
 class Cluster:
     capacity: int
     used: int = 0
+    accel_capacity: Dict[str, int] = field(default_factory=dict)
+    accel_used: Dict[str, int] = field(default_factory=dict)
 
 
 class ResourceBroker:
@@ -18,15 +20,25 @@ class ResourceBroker:
     def __init__(self) -> None:
         self.clusters: Dict[str, Cluster] = {}
 
-    def register_cluster(self, name: str, capacity: int) -> None:
-        self.clusters[name] = Cluster(capacity)
+    def register_cluster(self, name: str, capacity: int, accelerators: Dict[str, int] | None = None) -> None:
+        self.clusters[name] = Cluster(capacity, 0, accelerators or {}, {k: 0 for k in (accelerators or {})})
 
-    def allocate(self, job_name: str) -> str:
-        """Return cluster assigned to ``job_name``."""
+    def allocate(self, job_name: str, accelerator: str = "cpu") -> str:
+        """Return cluster assigned to ``job_name`` for ``accelerator``."""
         if not self.clusters:
             raise RuntimeError("no clusters registered")
-        chosen = min(self.clusters.items(), key=lambda kv: kv[1].used)[0]
-        self.clusters[chosen].used += 1
+        available = [
+            (n, c)
+            for n, c in self.clusters.items()
+            if c.accel_capacity.get(accelerator, c.capacity if accelerator == "cpu" else 0)
+            > c.accel_used.get(accelerator, 0)
+        ]
+        if not available:
+            raise RuntimeError("no capacity for accelerator")
+        chosen = min(available, key=lambda kv: kv[1].accel_used.get(accelerator, 0))[0]
+        cl = self.clusters[chosen]
+        cl.used += 1
+        cl.accel_used[accelerator] = cl.accel_used.get(accelerator, 0) + 1
         return chosen
 
     def scale_decision(self, metrics: Dict[str, float]) -> str:
@@ -36,6 +48,19 @@ class ResourceBroker:
         if util < 30:
             return "scale_down"
         return "stable"
+
+    def get_load(self) -> Dict[str, float]:
+        total = {"cpu": 0, "gpu": 0, "tpu": 0}
+        used = {"cpu": 0, "gpu": 0, "tpu": 0}
+        for cl in self.clusters.values():
+            for acc in total.keys():
+                cap = cl.accel_capacity.get(acc, cl.capacity if acc == "cpu" else 0)
+                total[acc] += cap
+                used[acc] += cl.accel_used.get(acc, 0)
+        load = {}
+        for acc in total:
+            load[acc] = used[acc] / total[acc] if total[acc] else 0.0
+        return load
 
 
 __all__ = ["ResourceBroker"]

--- a/tests/test_accelerator_scheduler.py
+++ b/tests/test_accelerator_scheduler.py
@@ -1,0 +1,49 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import time
+
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+
+loader = importlib.machinery.SourceFileLoader('src.accelerator_scheduler', 'src/accelerator_scheduler.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+mod.__package__ = 'src'
+sys.modules[loader.name] = mod
+loader.exec_module(mod)
+AcceleratorScheduler = mod.AcceleratorScheduler
+
+
+class TestAcceleratorScheduler(unittest.TestCase):
+    def test_multi_device(self):
+        mod.psutil.cpu_percent = lambda interval=None: 0.0
+        if hasattr(mod, 'torch') and mod.torch is not None:
+            mod.torch.cuda.is_available = lambda: True
+            mod.torch.cuda.memory_allocated = lambda: 0
+            class Props:
+                total_memory = 1
+            mod.torch.cuda.get_device_properties = lambda idx: Props()
+        mod._HAS_XLA = True
+        class XM:
+            @staticmethod
+            def get_memory_info(dev):
+                return {'kb_total': 1, 'kb_free': 1}
+        mod.xm = XM()
+
+        sched = AcceleratorScheduler(check_interval=0.01)
+        ran = []
+        sched.add(lambda: ran.append('cpu'), 'cpu')
+        sched.add(lambda: ran.append('gpu'), 'gpu')
+        sched.add(lambda: ran.append('tpu'), 'tpu')
+        time.sleep(0.05)
+        self.assertEqual(set(ran), {'cpu', 'gpu', 'tpu'})
+        util = sched.get_utilization()
+        self.assertIsInstance(util, dict)
+        self.assertIn('cpu', util)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_adaptive_scheduler.py
+++ b/tests/test_adaptive_scheduler.py
@@ -20,7 +20,7 @@ def _load(name, path):
 
 TelemetryLogger = _load('asi.telemetry', 'src/telemetry.py').TelemetryLogger
 ComputeBudgetTracker = _load('asi.compute_budget_tracker', 'src/compute_budget_tracker.py').ComputeBudgetTracker
-_load('asi.gpu_aware_scheduler', 'src/gpu_aware_scheduler.py')
+_load('asi.accelerator_scheduler', 'src/accelerator_scheduler.py')
 AdaptiveScheduler = _load('asi.adaptive_scheduler', 'src/adaptive_scheduler.py').AdaptiveScheduler
 
 
@@ -56,6 +56,15 @@ class TestAdaptiveScheduler(unittest.TestCase):
         time.sleep(0.4)
         sched.stop()
         self.assertLessEqual(len(ran), 2)
+
+    def test_report_load(self):
+        logger = TelemetryLogger(interval=0.05)
+        tracker = ComputeBudgetTracker(1.0, telemetry=logger)
+        sched = AdaptiveScheduler(tracker, 'run', check_interval=0.05)
+        load = sched.report_load()
+        self.assertIsInstance(load, dict)
+        self.assertIn('cpu', load)
+        sched.stop()
 
 
 if __name__ == '__main__':

--- a/tests/test_resource_broker.py
+++ b/tests/test_resource_broker.py
@@ -26,10 +26,12 @@ ResourceBroker = rb.ResourceBroker
 class TestResourceBroker(unittest.TestCase):
     def test_allocate_and_decide(self):
         broker = ResourceBroker()
-        broker.register_cluster('a', 2)
-        broker.register_cluster('b', 1)
-        c = broker.allocate('job')
+        broker.register_cluster('a', 2, {'gpu': 1})
+        broker.register_cluster('b', 1, {'gpu': 1})
+        c = broker.allocate('job', 'gpu')
         self.assertIn(c, {'a', 'b'})
+        load = broker.get_load()
+        self.assertIn('gpu', load)
         decision = broker.scale_decision({'cpu': 90})
         self.assertEqual(decision, 'scale_up')
 


### PR DESCRIPTION
## Summary
- create `AcceleratorScheduler` to dispatch jobs based on GPU/TPU/CPU utilization
- alias old `GPUAwareScheduler` to `AcceleratorScheduler`
- update `AdaptiveScheduler` to use accelerator scheduler and report load
- extend `ResourceBroker` with per-accelerator tracking
- document usage of accelerator scheduler and broker
- add unit tests for new functionality

## Testing
- `pytest tests/test_adaptive_scheduler.py tests/test_resource_broker.py tests/test_accelerator_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68683d8ca6548331aeaf948143f9a742