### PR TITLE
Add CrossLingual speech translator

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -315,7 +315,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     retrieval.
 41. **Cross-lingual memory retrieval**: `HierarchicalMemory` now accepts a
     translator and the `CrossLingualMemory` wrapper persists translated vectors
-    so queries in any supported language return the same results.
+    so queries in any supported language return the same results. The optional
+    `CrossLingualSpeechTranslator` transcribes audio queries offline and feeds
+    the text through `CrossLingualTranslator` for unified search.
 42. **World-model distillation**: Implement a `WorldModelDistiller` that
     compresses the large world model into a smaller student network. Target
     <5% reward loss on the embodied RL benchmarks while reducing model size by

--- a/src/data_ingest.py
+++ b/src/data_ingest.py
@@ -76,6 +76,64 @@ class CrossLingualTranslator:
         return {l: self.translate(text, l) for l in self.languages}
 
 
+class CrossLingualSpeechTranslator:
+    """Offline speech-to-text wrapper using ``speech_recognition``."""
+
+    def __init__(self, translator: CrossLingualTranslator) -> None:
+        self.translator = translator
+        try:
+            import speech_recognition as sr  # type: ignore
+
+            self._sr = sr.Recognizer()
+            self._AudioFile = sr.AudioFile
+            self._recognize = self._sr.recognize_sphinx
+        except Exception:  # pragma: no cover - optional dependency
+            self._sr = None
+            self._AudioFile = None
+            self._recognize = None
+
+    def transcribe(self, audio: str | np.ndarray | torch.Tensor) -> str:
+        """Return the transcript of ``audio`` or ``""`` on failure."""
+        if self._sr is None or self._AudioFile is None or self._recognize is None:
+            return ""
+
+        import tempfile
+        import wave
+
+        path: str
+        cleanup = False
+        if isinstance(audio, str):
+            path = audio
+        else:
+            arr = (
+                audio.detach().cpu().numpy() if isinstance(audio, torch.Tensor) else audio
+            )
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+                with wave.open(f.name, "wb") as w:
+                    w.setnchannels(1)
+                    w.setsampwidth(2)
+                    w.setframerate(16000)
+                    arr16 = np.asarray(arr, dtype=np.int16)
+                    w.writeframes(arr16.tobytes())
+                path = f.name
+                cleanup = True
+
+        try:
+            with self._AudioFile(path) as source:
+                data = self._sr.record(source)
+            return self._recognize(data)
+        except Exception:
+            return ""
+        finally:
+            if cleanup:
+                Path(path).unlink(missing_ok=True)
+
+    def translate_all(self, audio: str | np.ndarray | torch.Tensor) -> Dict[str, str]:
+        """Return translations for the transcript of ``audio``."""
+        txt = self.transcribe(audio)
+        return self.translator.translate_all(txt) if txt else {}
+
+
 def download_file(url: str, dest: Path) -> None:
     """Download ``url`` into ``dest``."""
     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -408,4 +466,5 @@ __all__ = [
     "ingest_translated_triples",
     "ActiveDataSelector",
     "CrossLingualTranslator",
+    "CrossLingualSpeechTranslator",
 ]

--- a/tests/test_cross_lingual_speech.py
+++ b/tests/test_cross_lingual_speech.py
@@ -1,0 +1,43 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from unittest.mock import patch
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+di = load('asi.data_ingest', 'src/data_ingest.py')
+clm = load('asi.cross_lingual_memory', 'src/cross_lingual_memory.py')
+
+CrossLingualMemory = clm.CrossLingualMemory
+CrossLingualTranslator = di.CrossLingualTranslator
+CrossLingualSpeechTranslator = di.CrossLingualSpeechTranslator
+
+
+class TestCrossLingualSpeech(unittest.TestCase):
+    def test_audio_query(self):
+        tr = CrossLingualTranslator(["es"])
+        speech = CrossLingualSpeechTranslator(tr)
+        mem = CrossLingualMemory(dim=4, compressed_dim=2, capacity=10,
+                                 translator=tr, speech_translator=speech)
+        mem.add("hello")
+        with patch.object(speech, 'transcribe', return_value='hello'):
+            vecs, meta = mem.search('dummy.wav', k=1)
+        self.assertEqual(len(meta), 1)
+        self.assertIn(meta[0], ["hello", "[es] hello"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support cross-lingual speech retrieval
- create `CrossLingualSpeechTranslator` for offline speech-to-text
- handle speech in `CrossLingualMemory`
- document speech retrieval in the plan
- test cross-lingual speech queries

## Testing
- `pytest tests/test_cross_lingual_speech.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68683d8ad16083319e2578b7ca37da96