### PR TITLE
Add cross‑lingual summary memory support

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -592,6 +592,7 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   `scripts/summarize_memory_benchmark.py`.**
 - Implement a `ContextSummaryMemory` that replaces far-past vectors with text summaries and re-expands them when retrieved. Unit test `tests/test_context_summary_memory.py` verifies summarization and expansion.
   **Implemented in `src/context_summary_memory.py` with tests.**
+- Extend `ContextSummaryMemory` with a `translator` argument so summaries are stored in multiple languages and returned in the query language. Tested in `tests/test_cross_lingual_summary_memory.py`.
 - Implement a `KnowledgeGraphMemory` that stores `(subject, predicate, object)` triples and hooks into `HierarchicalMemory` via `use_kg=True`. Unit tests cover insertion and retrieval.
   **Implemented in `src/knowledge_graph_memory.py` with `tests/test_knowledge_graph_memory.py`.**
 - Add a `TelemetryLogger` in `telemetry.py` that exports GPU, CPU and network metrics via OpenTelemetry and Prometheus. Integrate the logger with `DistributedTrainer` and `MemoryServer`.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -316,6 +316,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 41. **Cross-lingual memory retrieval**: `HierarchicalMemory` now accepts a
     translator and the `CrossLingualMemory` wrapper persists translated vectors
     so queries in any supported language return the same results.
+41a. **Cross-lingual summarization memory**: `ContextSummaryMemory` stores summaries
+     in the source language and translated forms. Results are translated back
+     to the query language. See `docs/Implementation.md` for details.
 42. **World-model distillation**: Implement a `WorldModelDistiller` that
     compresses the large world model into a smaller student network. Target
     <5% reward loss on the embodied RL benchmarks while reducing model size by

--- a/src/context_summary_memory.py
+++ b/src/context_summary_memory.py
@@ -4,11 +4,12 @@ Store compressed summaries for distant tokens and restore them on retrieval.
 """
 from __future__ import annotations
 
-from typing import Iterable, Any, Tuple, List
+from typing import Iterable, Any, Tuple, List, Dict
 
 import torch
 
 from .hierarchical_memory import HierarchicalMemory
+from .data_ingest import CrossLingualTranslator
 
 
 class ContextSummaryMemory(HierarchicalMemory):
@@ -19,9 +20,10 @@ class ContextSummaryMemory(HierarchicalMemory):
         *args,
         summarizer,
         context_size: int = 1024,
+        translator: CrossLingualTranslator | None = None,
         **kwargs,
     ) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, translator=translator, **kwargs)
         self.summarizer = summarizer
         self.context_size = context_size
 
@@ -37,21 +39,40 @@ class ContextSummaryMemory(HierarchicalMemory):
         self.store._meta = self.store._meta[keep_start:]
         for vec, meta in zip(old_vecs, old_meta):
             summary = self.summarizer.summarize(vec.unsqueeze(0))
+            info: Dict[str, Any] = {"summary": summary}
+            if self.translator is not None:
+                info["translations"] = self.translator.translate_all(summary)
             self.store.delete(tag=meta)
-            self.store.add(torch.zeros_like(vec).numpy(), [f"ctxsum:{summary}"])
+            self.store.add(torch.zeros_like(vec).numpy(), [{"ctxsum": info}])
 
-    def search(self, query: torch.Tensor, k: int = 5) -> Tuple[torch.Tensor, List[Any]]:  # type: ignore[override]
+    def search(
+        self, query: torch.Tensor, k: int = 5, language: str | None = None
+    ) -> Tuple[torch.Tensor, List[Any]]:  # type: ignore[override]
         vecs, meta = super().search(query, k)
         new_vecs = []
+        out_meta: List[Any] = []
         for v, m in zip(vecs, meta):
-            if isinstance(m, str) and m.startswith("ctxsum:"):
+            if isinstance(m, dict) and "ctxsum" in m:
+                info = m["ctxsum"]
+                text = info["summary"]
+                new_vecs.append(self.summarizer.expand(text).to(query.device))
+                if language is not None and self.translator is not None:
+                    trans = info.get("translations", {}).get(language)
+                    if trans is None:
+                        trans = self.translator.translate(text, language)
+                    out_meta.append(trans)
+                else:
+                    out_meta.append(m)
+            elif isinstance(m, str) and m.startswith("ctxsum:"):
                 text = m.split(":", 1)[1]
                 new_vecs.append(self.summarizer.expand(text).to(query.device))
+                out_meta.append(m)
             else:
                 new_vecs.append(v)
+                out_meta.append(m)
         if new_vecs:
             vecs = torch.stack(new_vecs)
-        return vecs, meta
+        return vecs, out_meta
 
 
 __all__ = ["ContextSummaryMemory"]

--- a/tests/test_context_summary_memory.py
+++ b/tests/test_context_summary_memory.py
@@ -22,7 +22,7 @@ class TestContextSummaryMemory(unittest.TestCase):
         mem.summarize_context()
         vecs, meta = mem.search(data[0], k=2)
         self.assertEqual(vecs.shape[0], len(meta))
-        self.assertTrue(any(isinstance(m, str) and m.startswith("ctxsum:") for m in meta))
+        self.assertTrue(any(isinstance(m, dict) and "ctxsum" in m for m in meta))
         self.assertTrue(torch.allclose(vecs[0], torch.ones(2)))
 
 

--- a/tests/test_cross_lingual_summary_memory.py
+++ b/tests/test_cross_lingual_summary_memory.py
@@ -1,0 +1,58 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import torch
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+
+di = load('asi.data_ingest', 'src/data_ingest.py')
+cs = load('asi.context_summary_memory', 'src/context_summary_memory.py')
+
+CrossLingualTranslator = di.CrossLingualTranslator
+ContextSummaryMemory = cs.ContextSummaryMemory
+
+
+class DummySummarizer:
+    def summarize(self, x):
+        return 'hello'
+
+    def expand(self, text):
+        return torch.ones(2)
+
+
+class TestCrossLingualSummaryMemory(unittest.TestCase):
+    def test_add_and_search_translated(self):
+        tr = CrossLingualTranslator(['es', 'fr'])
+        mem = ContextSummaryMemory(
+            dim=2,
+            compressed_dim=1,
+            capacity=4,
+            summarizer=DummySummarizer(),
+            context_size=1,
+            translator=tr,
+        )
+        data = torch.randn(3, 2)
+        mem.add(data, metadata=['a', 'b', 'c'])
+        mem.summarize_context()
+        vecs, meta = mem.search(data[0], k=2, language='es')
+        self.assertTrue(any(isinstance(m, str) and m.startswith('[es]') for m in meta))
+        self.assertEqual(vecs.shape[0], len(meta))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `ContextSummaryMemory` with a `translator` parameter
- store summaries along with their translations and return them in the query language
- add new test for cross‑lingual summary memory
- update docs to describe the new capability

## Testing
- `pytest tests/test_cross_lingual_summary_memory.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest tests/test_context_summary_memory.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68683d9d5bac833188ac6592438caa9c