### PR TITLE
Add spiking layers and integrate with world model

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -151,6 +151,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
   `aiohttp` for faster monitoring of open pull requests.
 - `src/lora_quant.py` provides 4-bit LoRA adapters and `apply_quant_lora()` to
   inject them into existing models.
+- `src/spiking_layers.py` defines `LIFNeuron` and `SpikingLinear`. Set
+  `use_spiking=True` in `MultiModalWorldModelConfig` to replace MLP blocks with
+  these energy-efficient neurons.
 - `src/cross_modal_fusion.py` encodes text, images and audio in a shared space
   with a contrastive training helper.
 - `src/multimodal_world_model.py` unifies these embeddings with actions for

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -208,3 +208,4 @@ from .interpretability_dashboard import InterpretabilityDashboard
 from .collaborative_healing import CollaborativeHealingLoop
 from .compute_budget_tracker import ComputeBudgetTracker
 from .budget_aware_scheduler import BudgetAwareScheduler
+from .spiking_layers import LIFNeuron, SpikingLinear

--- a/src/spiking_layers.py
+++ b/src/spiking_layers.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class _SpikeFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input: torch.Tensor, threshold: float) -> torch.Tensor:
+        ctx.save_for_backward(input)
+        return (input >= threshold).to(input.dtype)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor, None]:
+        (input,) = ctx.saved_tensors
+        sg = torch.sigmoid(input) * (1 - torch.sigmoid(input))
+        return grad_output * sg, None
+
+
+class LIFNeuron(nn.Module):
+    """Simplified leaky integrate-and-fire neuron."""
+
+    def __init__(self, decay: float = 0.9, threshold: float = 1.0) -> None:
+        super().__init__()
+        self.decay = decay
+        self.threshold = threshold
+        self.register_buffer("mem", torch.tensor(0.0))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        if self.mem.numel() != x.numel() or self.mem.shape != x.shape:
+            self.mem = torch.zeros_like(x)
+        self.mem = self.mem * self.decay + x
+        spk = _SpikeFn.apply(self.mem, self.threshold)
+        self.mem = self.mem - spk * self.threshold
+        return spk
+
+    def reset_state(self) -> None:
+        self.mem.zero_()
+
+
+class SpikingLinear(nn.Module):
+    """Linear layer followed by an LIF neuron."""
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = True,
+        *,
+        decay: float = 0.9,
+        threshold: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features, bias=bias)
+        self.neuron = LIFNeuron(decay=decay, threshold=threshold)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        return self.neuron(self.linear(x))
+
+    def reset_state(self) -> None:
+        self.neuron.reset_state()
+
+
+__all__ = ["LIFNeuron", "SpikingLinear"]

--- a/tests/test_multimodal_world_model.py
+++ b/tests/test_multimodal_world_model.py
@@ -3,13 +3,29 @@ from unittest.mock import patch
 import importlib.machinery
 import importlib.util
 import sys
+import types
 import torch
 
 loader = importlib.machinery.SourceFileLoader('mmwm', 'src/multimodal_world_model.py')
 spec = importlib.util.spec_from_loader(loader.name, loader)
 mmwm = importlib.util.module_from_spec(spec)
 sys.modules[loader.name] = mmwm
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+loader_sl = importlib.machinery.SourceFileLoader('asi.spiking_layers', 'src/spiking_layers.py')
+spec_sl = importlib.util.spec_from_loader(loader_sl.name, loader_sl)
+sl = importlib.util.module_from_spec(spec_sl)
+sl.__package__ = 'asi'
+sys.modules['asi.spiking_layers'] = sl
+loader_sl.exec_module(sl)
 sys.modules['asi.multimodal_world_model'] = mmwm
+mmwm.__package__ = 'asi'
+loader_lq = importlib.machinery.SourceFileLoader('asi.lora_quant', 'src/lora_quant.py')
+spec_lq = importlib.util.spec_from_loader(loader_lq.name, loader_lq)
+lq = importlib.util.module_from_spec(spec_lq)
+lq.__package__ = 'asi'
+sys.modules['asi.lora_quant'] = lq
+loader_lq.exec_module(lq)
 loader.exec_module(mmwm)
 MultiModalWorldModelConfig = mmwm.MultiModalWorldModelConfig
 MultiModalWorldModel = mmwm.MultiModalWorldModel

--- a/tests/test_spiking_layers.py
+++ b/tests/test_spiking_layers.py
@@ -1,0 +1,34 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import sys
+import torch
+
+loader = importlib.machinery.SourceFileLoader('sl', 'src/spiking_layers.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+sl = importlib.util.module_from_spec(spec)
+sys.modules['sl'] = sl
+sl.__package__ = 'src'
+loader.exec_module(sl)
+LIFNeuron = sl.LIFNeuron
+SpikingLinear = sl.SpikingLinear
+
+
+class TestSpikingLayers(unittest.TestCase):
+    def test_forward_shape(self):
+        layer = SpikingLinear(4, 3)
+        x = torch.randn(2, 4)
+        out = layer(x)
+        self.assertEqual(out.shape, (2, 3))
+
+    def test_gradient_flow(self):
+        layer = SpikingLinear(5, 2)
+        x = torch.randn(4, 5, requires_grad=True)
+        out = layer(x).sum()
+        out.backward()
+        self.assertIsNotNone(layer.linear.weight.grad)
+        self.assertFalse(torch.all(layer.linear.weight.grad == 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement basic LIF-based spiking layers
- allow MultiModalWorldModel to swap linear layers for spiking versions
- add unit tests for spiking layers and update world model tests
- document the new option in Plan

## Testing
- `python -m pytest tests/test_spiking_layers.py tests/test_multimodal_world_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68686b2da18883318afc8b58e460e32e