### PR TITLE
Add temporal reasoner and time-aware planner

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -599,6 +599,10 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   **Implemented in `src/federated_kg_memory.py` with tests.**
   `KnowledgeGraphMemory` accepts an optional timestamp for each triple and `query_triples()` can filter by a time range.
   **Implemented in `src/knowledge_graph_memory.py` with `tests/test_knowledge_graph_memory.py` and `tests/test_time_aware_kg.py`.**
+- Implement a `TemporalReasoner` that queries these timestamped triples and infers
+  their chronological order. `HierarchicalPlanner.compose_plan()` accepts the
+  reasoner and can reorder intermediate nodes for time-aware planning.
+- **Implemented in `src/temporal_reasoner.py` with tests.**
 - Add a `TelemetryLogger` in `telemetry.py` that exports GPU, CPU and network metrics via OpenTelemetry and Prometheus. Integrate the logger with `DistributedTrainer` and `MemoryServer`.
   `MemoryServer` now starts and stops a provided `TelemetryLogger` automatically.
   **Implemented in `src/telemetry.py`.**

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -276,6 +276,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 29. **Structured knowledge graph memory**: Store facts as triples in a `KnowledgeGraphMemory` and retrieve them through `HierarchicalMemory` for better planning context.
     The new `GraphNeuralReasoner` loads these triples and predicts missing relations so `HierarchicalPlanner.query_relation()` can infer edges not explicitly stored.
     `KnowledgeGraphMemory` now records optional timestamps per triple and supports temporal range queries for time-sensitive reasoning.
+29. **Temporal reasoner**: `TemporalReasoner` queries these timestamped triples
+    to infer before/after relationships. `HierarchicalPlanner.compose_plan()`
+    can optionally reorder intermediate steps using the reasoner for time-aware
+    planning.
 29. **Self-alignment evaluator**: Integrate
     `deliberative_alignment.check_alignment()` into `eval_harness` and track
     alignment metrics alongside existing benchmarks. *Implemented in

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -200,6 +200,7 @@ from .data_provenance_ledger import DataProvenanceLedger
 from .fairness_evaluator import FairnessEvaluator
 from .risk_dashboard import RiskDashboard
 from .graph_neural_reasoner import GraphNeuralReasoner
+from .temporal_reasoner import TemporalReasoner
 from .lora_merger import merge_adapters
 from .edge_rl_trainer import EdgeRLTrainer
 from .adaptive_micro_batcher import AdaptiveMicroBatcher

--- a/src/temporal_reasoner.py
+++ b/src/temporal_reasoner.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Iterable, Tuple, List
+
+from .knowledge_graph_memory import KnowledgeGraphMemory, TimedTriple
+from .graph_of_thought import GraphOfThought
+
+
+class TemporalReasoner:
+    """Infer ordering of events stored in :class:`KnowledgeGraphMemory`."""
+
+    def __init__(self, kg: KnowledgeGraphMemory) -> None:
+        self.kg = kg
+
+    # ------------------------------------------------------------
+    def query(
+        self,
+        subject: str | None = None,
+        predicate: str | None = None,
+        object: str | None = None,
+        start_time: float | None = None,
+        end_time: float | None = None,
+    ) -> List[TimedTriple]:
+        """Proxy to :meth:`KnowledgeGraphMemory.query_triples`."""
+        return self.kg.query_triples(
+            subject=subject,
+            predicate=predicate,
+            object=object,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+    # ------------------------------------------------------------
+    def infer_order(self, triples: Iterable[Tuple[str, str, str]]) -> List[TimedTriple]:
+        """Return triples sorted by timestamp, ignoring missing entries."""
+        events: List[TimedTriple] = []
+        for s, p, o in triples:
+            matches = self.kg.query_triples(s, p, o)
+            if not matches:
+                continue
+            # choose earliest timestamp if multiple
+            best = min(
+                matches,
+                key=lambda t: float("inf") if t.timestamp is None else t.timestamp,
+            )
+            events.append(best)
+        events.sort(key=lambda t: float("inf") if t.timestamp is None else t.timestamp)
+        return events
+
+    # ------------------------------------------------------------
+    def order_nodes_by_time(self, graph: GraphOfThought, nodes: Iterable[int]) -> List[int]:
+        """Return ``nodes`` sorted by the timestamps of their ``'triple'`` metadata."""
+        nodes = list(nodes)
+        if len(nodes) <= 2:
+            return nodes
+        start, end = nodes[0], nodes[-1]
+        middle = nodes[1:-1]
+        pairs: List[Tuple[int, float | None]] = []
+        for n in middle:
+            node = graph.nodes.get(n)
+            triple = node.metadata.get("triple") if node is not None else None
+            ts: float | None = None
+            if triple is not None and len(triple) >= 3:
+                res = self.kg.query_triples(*triple[:3])
+                if res:
+                    ts = res[0].timestamp
+            pairs.append((n, ts))
+        pairs.sort(key=lambda x: float("inf") if x[1] is None else x[1])
+        ordered = [start] + [n for n, _ in pairs] + [end]
+        return ordered
+
+
+__all__ = ["TemporalReasoner"]

--- a/tests/test_hierarchical_planner.py
+++ b/tests/test_hierarchical_planner.py
@@ -1,13 +1,66 @@
 import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
 import torch
-from asi.graph_of_thought import GraphOfThought
-from asi.hierarchical_planner import HierarchicalPlanner
-from asi.world_model_rl import WorldModel, RLBridgeConfig
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+gnr_mod = types.ModuleType('asi.graph_neural_reasoner')
+class DummyGNR:
+    def predict_link(self, src: str, dst: str) -> float:
+        return 0.0
+gnr_mod.GraphNeuralReasoner = DummyGNR
+sys.modules['asi.graph_neural_reasoner'] = gnr_mod
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+got_mod = _load('asi.graph_of_thought', 'src/graph_of_thought.py')
+GraphOfThought = got_mod.GraphOfThought
+
+kg_mod = _load('asi.knowledge_graph_memory', 'src/knowledge_graph_memory.py')
+KnowledgeGraphMemory = kg_mod.KnowledgeGraphMemory
+TimedTriple = kg_mod.TimedTriple
+
+wm_mod = types.ModuleType('asi.world_model_rl')
+
+class DummyWM(torch.nn.Module):
+    def forward(self, state: torch.Tensor, action: torch.Tensor):
+        return state, torch.tensor(0.0)
+
+def rollout_policy(model: DummyWM, policy, init_state: torch.Tensor, steps: int = 1):
+    state = init_state
+    states = []
+    rewards = []
+    for _ in range(steps):
+        action = policy(state)
+        state, r = model(state, action)
+        states.append(state)
+        rewards.append(float(r))
+    return states, rewards
+
+wm_mod.WorldModel = DummyWM
+wm_mod.rollout_policy = rollout_policy
+sys.modules['asi.world_model_rl'] = wm_mod
+WorldModel = DummyWM
+
+tr_mod = _load('asi.temporal_reasoner', 'src/temporal_reasoner.py')
+TemporalReasoner = tr_mod.TemporalReasoner
+
+hp_mod = _load('asi.hierarchical_planner', 'src/hierarchical_planner.py')
+HierarchicalPlanner = hp_mod.HierarchicalPlanner
 
 class TestHierarchicalPlanner(unittest.TestCase):
     def test_compose_plan(self):
-        cfg = RLBridgeConfig(state_dim=1, action_dim=1, epochs=1)
-        model = WorldModel(cfg)
+        model = WorldModel()
         graph = GraphOfThought()
         graph.add_step("start", node_id=0)
         graph.add_step("goal", node_id=1)
@@ -15,8 +68,8 @@ class TestHierarchicalPlanner(unittest.TestCase):
         planner = HierarchicalPlanner(graph, model, lambda s: torch.zeros((), dtype=torch.long))
         path, states, rewards = planner.compose_plan(0, lambda n: n.id == 1, torch.zeros(1))
         self.assertEqual(path, [0, 1])
-        self.assertEqual(len(states), 2)
-        self.assertEqual(len(rewards), 2)
+        self.assertEqual(len(states), len(path) + 1)
+        self.assertEqual(len(rewards), len(path))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_temporal_reasoner.py
+++ b/tests/test_temporal_reasoner.py
@@ -1,0 +1,113 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+
+# Set up a minimal asi package and load required modules manually
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+# Provide minimal stubs for dependencies
+gnr_mod = types.ModuleType('asi.graph_neural_reasoner')
+class DummyGNR:
+    def predict_link(self, src: str, dst: str) -> float:
+        return 0.0
+gnr_mod.GraphNeuralReasoner = DummyGNR
+sys.modules['asi.graph_neural_reasoner'] = gnr_mod
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+kg_mod = _load('asi.knowledge_graph_memory', 'src/knowledge_graph_memory.py')
+KnowledgeGraphMemory = kg_mod.KnowledgeGraphMemory
+TimedTriple = kg_mod.TimedTriple
+
+got_mod = _load('asi.graph_of_thought', 'src/graph_of_thought.py')
+GraphOfThought = got_mod.GraphOfThought
+
+import torch
+import types
+
+wm_mod = types.ModuleType('asi.world_model_rl')
+
+class DummyWM(torch.nn.Module):
+    def forward(self, state: torch.Tensor, action: torch.Tensor):
+        return state + 1, torch.tensor(0.0)
+
+def rollout_policy(model: DummyWM, policy, init_state: torch.Tensor, steps: int = 1):
+    state = init_state
+    states = []
+    rewards = []
+    for _ in range(steps):
+        action = policy(state)
+        state, r = model(state, action)
+        states.append(state)
+        rewards.append(float(r))
+    return states, rewards
+
+wm_mod.WorldModel = DummyWM
+wm_mod.rollout_policy = rollout_policy
+sys.modules['asi.world_model_rl'] = wm_mod
+WorldModel = DummyWM
+
+tr_mod = _load('asi.temporal_reasoner', 'src/temporal_reasoner.py')
+TemporalReasoner = tr_mod.TemporalReasoner
+
+hp_mod = _load('asi.hierarchical_planner', 'src/hierarchical_planner.py')
+HierarchicalPlanner = hp_mod.HierarchicalPlanner
+
+
+class TestTemporalReasoner(unittest.TestCase):
+    def test_infer_order(self):
+        kg = KnowledgeGraphMemory()
+        kg.add_triples([
+            TimedTriple('e', 'r', 'a', 2.0),
+            TimedTriple('e', 'r', 'b', 1.0),
+        ])
+        reasoner = TemporalReasoner(kg)
+        ordered = reasoner.infer_order([('e', 'r', 'a'), ('e', 'r', 'b')])
+        self.assertEqual([t.object for t in ordered], ['b', 'a'])
+
+    def test_planner_ordering(self):
+        kg = KnowledgeGraphMemory()
+        kg.add_triples([
+            TimedTriple('s', 'r', 'start', 0.0),
+            TimedTriple('m1', 'r', 'mid1', 3.0),
+            TimedTriple('m2', 'r', 'mid2', 1.0),
+            TimedTriple('g', 'r', 'goal', 2.0),
+        ])
+        reasoner = TemporalReasoner(kg)
+
+        g = GraphOfThought()
+        g.add_step('start', metadata={'triple': ('s', 'r', 'start')}, node_id=0)
+        g.add_step('step1', metadata={'triple': ('m1', 'r', 'mid1')}, node_id=1)
+        g.add_step('step2', metadata={'triple': ('m2', 'r', 'mid2')}, node_id=2)
+        g.add_step('done', metadata={'triple': ('g', 'r', 'goal')}, node_id=3)
+        g.connect(0, 1)
+        g.connect(1, 2)
+        g.connect(2, 3)
+
+        wm = WorldModel()
+        planner = HierarchicalPlanner(
+            g,
+            wm,
+            lambda s: torch.zeros((), dtype=torch.long),
+            temporal_reasoner=reasoner,
+        )
+        path, states, rewards = planner.compose_plan(
+            0, lambda n: n.id == 3, torch.zeros(1), rollout_steps=1, use_temporal=True
+        )
+        self.assertEqual(path, [0, 2, 1, 3])
+        self.assertEqual(len(states), len(path) + 1)
+        self.assertEqual(len(rewards), len(path))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `TemporalReasoner` for ordering events in knowledge graphs
- support temporal reasoning inside `HierarchicalPlanner`
- document the new module in Plan and Implementation docs
- update planner tests to avoid heavy deps
- add tests for temporal reasoning

## Testing
- `python -m unittest tests.test_temporal_reasoner tests.test_hierarchical_planner -v`


------
https://chatgpt.com/codex/tasks/task_e_68686b771f388331b0dbb39c7e5a5f12