### PR TITLE
Add federated RL trainer

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -392,3 +392,4 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 [25]: https://github.com/features/actions?utm_source=chatgpt.com "GitHub Actions for automated repository processing"
 [26]: https://arxiv.org/abs/2211.00564?utm_source=chatgpt.com "Transformer Circuits: Mechanistic Interpretability"
 74. **Federated knowledge graph memory**: Replicate triples across nodes via `FederatedKGMemoryServer` so that after network partitions all servers agree on the same graph. Success is 100% retrieval consistency across two peers after concurrent updates.
+76. **Federated RL self-play**: `FederatedRLTrainer` wraps self-play loops and shares gradients via `SecureFederatedLearner`. Reward should match single-node training within 2% using two peers.

--- a/scripts/federated_rl_train.py
+++ b/scripts/federated_rl_train.py
@@ -1,0 +1,22 @@
+import argparse
+import torch
+from asi.self_play_skill_loop import SelfPlaySkillLoopConfig
+from asi.federated_rl_trainer import FederatedRLTrainer, FederatedRLTrainerConfig
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Federated self-play RL training")
+    parser.add_argument("--rounds", type=int, default=1)
+    parser.add_argument("--agents", type=int, default=2)
+    args = parser.parse_args()
+
+    sp_cfg = SelfPlaySkillLoopConfig()
+    frl_cfg = FederatedRLTrainerConfig(rounds=args.rounds)
+    trainer = FederatedRLTrainer(sp_cfg, frl_cfg=frl_cfg)
+    model = trainer.train(num_agents=args.agents)
+    torch.save(model.state_dict(), "federated_rl_policy.pt")
+    print("saved model to federated_rl_policy.pt")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -202,6 +202,11 @@ from .risk_dashboard import RiskDashboard
 from .graph_neural_reasoner import GraphNeuralReasoner
 from .lora_merger import merge_adapters
 from .edge_rl_trainer import EdgeRLTrainer
+from .federated_rl_trainer import (
+    FederatedRLTrainer,
+    FederatedRLTrainerConfig,
+    PolicyNet,
+)
 from .adaptive_micro_batcher import AdaptiveMicroBatcher
 from .retrieval_explainer import RetrievalExplainer
 from .interpretability_dashboard import InterpretabilityDashboard

--- a/src/federated_rl_trainer.py
+++ b/src/federated_rl_trainer.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+
+from .self_play_env import SimpleEnv, rollout_env
+from .self_play_skill_loop import SelfPlaySkillLoopConfig
+from .secure_federated_learner import SecureFederatedLearner
+
+
+@dataclass
+class FederatedRLTrainerConfig:
+    """Configuration for federated self-play training."""
+
+    rounds: int = 1
+    local_steps: int = 5
+    lr: float = 1e-3
+
+
+class _TrajectoryDataset(Dataset):
+    def __init__(self, states: Iterable[torch.Tensor], actions: Iterable[int]):
+        self.states = list(states)
+        self.actions = torch.tensor(list(actions), dtype=torch.long)
+
+    def __len__(self) -> int:
+        return len(self.states)
+
+    def __getitem__(self, idx: int):
+        return self.states[idx], self.actions[idx]
+
+
+class PolicyNet(nn.Module):
+    """Tiny policy network for vector observations."""
+
+    def __init__(self, state_dim: int, action_dim: int, hidden: int = 32) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(state_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, action_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - pass through
+        return self.net(x)
+
+
+class FederatedRLTrainer:
+    """Run self-play locally and aggregate gradients via a secure learner."""
+
+    def __init__(
+        self,
+        sp_cfg: SelfPlaySkillLoopConfig,
+        learner: SecureFederatedLearner | None = None,
+        frl_cfg: FederatedRLTrainerConfig | None = None,
+    ) -> None:
+        self.sp_cfg = sp_cfg
+        self.cfg = frl_cfg or FederatedRLTrainerConfig()
+        self.learner = learner or SecureFederatedLearner()
+        self.policy = PolicyNet(sp_cfg.env_state_dim, sp_cfg.action_dim)
+
+    # --------------------------------------------------
+    def _policy_act(self, obs: torch.Tensor) -> torch.Tensor:
+        with torch.no_grad():
+            logits = self.policy(obs.unsqueeze(0))
+        return logits.argmax(dim=-1).squeeze(0)
+
+    def _collect_experience(
+        self, env: SimpleEnv
+    ) -> Tuple[List[torch.Tensor], List[int]]:
+        states, _, actions = rollout_env(
+            env, self._policy_act, steps=self.cfg.local_steps, return_actions=True
+        )
+        return states, actions
+
+    def _local_gradients(
+        self, states: Iterable[torch.Tensor], actions: Iterable[int]
+    ) -> List[torch.Tensor]:
+        dataset = _TrajectoryDataset(states, actions)
+        loader = DataLoader(dataset, batch_size=len(dataset))
+        params = [p for p in self.policy.parameters() if p.requires_grad]
+        grads = [torch.zeros_like(p) for p in params]
+        loss_fn = nn.CrossEntropyLoss()
+        for s, a in loader:
+            logits = self.policy(s)
+            loss = loss_fn(logits, a)
+            self.policy.zero_grad()
+            loss.backward()
+            for g, p in zip(grads, params):
+                g += p.grad.detach().clone()
+        return grads
+
+    def _apply_gradients(self, flat: torch.Tensor) -> None:
+        start = 0
+        for p in self.policy.parameters():
+            num = p.numel()
+            g = flat[start : start + num].view_as(p)
+            p.data -= self.cfg.lr * g
+            start += num
+
+    def train(self, num_agents: int) -> PolicyNet:
+        envs = [SimpleEnv(self.sp_cfg.env_state_dim) for _ in range(num_agents)]
+        for _ in range(self.cfg.rounds):
+            enc_grads = []
+            for env in envs:
+                states, actions = self._collect_experience(env)
+                grads = self._local_gradients(states, actions)
+                flat = torch.cat([g.view(-1) for g in grads])
+                enc_grads.append(self.learner.encrypt(flat))
+            agg = self.learner.aggregate([self.learner.decrypt(g) for g in enc_grads])
+            self._apply_gradients(agg)
+        return self.policy
+
+
+__all__ = [
+    "FederatedRLTrainer",
+    "FederatedRLTrainerConfig",
+    "PolicyNet",
+]

--- a/tests/test_federated_rl_trainer.py
+++ b/tests/test_federated_rl_trainer.py
@@ -1,0 +1,47 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import torch
+
+pkg = types.ModuleType("src")
+pkg.__path__ = ["src"]
+pkg.__spec__ = importlib.machinery.ModuleSpec("src", None, is_package=True)
+sys.modules["src"] = pkg
+
+mods = [
+    "self_play_env",
+    "self_play_skill_loop",
+    "secure_federated_learner",
+    "federated_rl_trainer",
+]
+
+for m in mods:
+    loader = importlib.machinery.SourceFileLoader(f"src.{m}", f"src/{m}.py")
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "src"
+    sys.modules[f"src.{m}"] = mod
+    loader.exec_module(mod)
+
+FederatedRLTrainer = sys.modules["src.federated_rl_trainer"].FederatedRLTrainer
+FederatedRLTrainerConfig = sys.modules[
+    "src.federated_rl_trainer"
+].FederatedRLTrainerConfig
+SelfPlaySkillLoopConfig = sys.modules[
+    "src.self_play_skill_loop"
+].SelfPlaySkillLoopConfig
+
+
+class TestFederatedRLTrainer(unittest.TestCase):
+    def test_train_runs(self):
+        sp_cfg = SelfPlaySkillLoopConfig(cycles=1, steps=2, epochs=1, batch_size=1)
+        cfg = FederatedRLTrainerConfig(rounds=1, local_steps=2, lr=0.1)
+        trainer = FederatedRLTrainer(sp_cfg, frl_cfg=cfg)
+        model = trainer.train(num_agents=2)
+        self.assertIsInstance(model, torch.nn.Module)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `FederatedRLTrainer` for aggregating self-play gradients with `SecureFederatedLearner`
- provide CLI entry `scripts/federated_rl_train.py`
- export trainer in package init
- note federated RL self-play in the research Plan
- unit tests for the new trainer

## Testing
- `python -m pytest tests/test_federated_rl_trainer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68686b756bbc83319ba13c4412164f5d