### PR TITLE
Add collaboration portal web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ Visit `http://localhost:8000` to view Prometheus metrics.
 `InterpretabilityDashboard` on the next port to display attention heatmaps and
 memory statistics in a simple web UI.
 
+### Collaboration Portal
+
+`CollaborationPortal` exposes active tasks, telemetry metrics and reasoning logs
+through a lightweight web server.
+
+```python
+from asi.collaboration_portal import CollaborationPortal
+from asi.telemetry import TelemetryLogger
+from asi.reasoning_history import ReasoningHistoryLogger
+
+tel = TelemetryLogger()
+tel.start()
+hist = ReasoningHistoryLogger()
+portal = CollaborationPortal(["refactor repo"], tel, hist)
+portal.start(port=8090)
+```
+
+Visit `http://localhost:8090` to inspect progress.
+
 ## Testing
 
 1. Install requirements: `pip install -r requirements.txt` (or run

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -364,6 +364,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 73. **Versioned model lineage**: Record hashed checkpoints and link them to dataset versions via `ModelVersionManager` for reproducible experiments. *Implemented in `src/model_version_manager.py` with tests.*
 74. **Dataset anonymization**: Sanitize text, image and audio files during ingestion using `DatasetAnonymizer`. The `download_triples()` helper now scrubs PII and logs a summary via `DatasetLineageManager`.
 75. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps to aid debugging.
+76. **Collaboration portal**: `CollaborationPortal` lists active tasks and exposes
+    telemetry metrics alongside reasoning logs through a small web server.
 
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -208,3 +208,4 @@ from .interpretability_dashboard import InterpretabilityDashboard
 from .collaborative_healing import CollaborativeHealingLoop
 from .compute_budget_tracker import ComputeBudgetTracker
 from .budget_aware_scheduler import BudgetAwareScheduler
+from .collaboration_portal import CollaborationPortal

--- a/src/collaboration_portal.py
+++ b/src/collaboration_portal.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Iterable, Any
+
+from .telemetry import TelemetryLogger
+from .reasoning_history import ReasoningHistoryLogger
+
+
+class CollaborationPortal:
+    """Expose tasks, telemetry metrics and reasoning logs over HTTP."""
+
+    def __init__(
+        self,
+        tasks: Iterable[str] | None = None,
+        telemetry: TelemetryLogger | None = None,
+        reasoning: ReasoningHistoryLogger | None = None,
+    ) -> None:
+        self.tasks = list(tasks or [])
+        self.telemetry = telemetry
+        self.reasoning = reasoning
+        self.httpd: HTTPServer | None = None
+        self.thread: threading.Thread | None = None
+        self.port: int | None = None
+
+    # --------------------------------------------------------------
+    def add_task(self, task: str) -> None:
+        self.tasks.append(task)
+
+    # --------------------------------------------------------------
+    def complete_task(self, task: str) -> None:
+        if task in self.tasks:
+            self.tasks.remove(task)
+
+    # --------------------------------------------------------------
+    def get_tasks(self) -> list[str]:
+        return list(self.tasks)
+
+    # --------------------------------------------------------------
+    def get_metrics(self) -> dict[str, Any]:
+        return self.telemetry.get_stats() if self.telemetry else {}
+
+    # --------------------------------------------------------------
+    def get_logs(self) -> list[tuple[str, str]]:
+        return self.reasoning.get_history() if self.reasoning else []
+
+    # --------------------------------------------------------------
+    def to_html(self) -> str:
+        tasks = "".join(f"<li>{t}</li>" for t in self.tasks) or "<li>None</li>"
+        logs = (
+            "".join(f"<li>{ts}: {msg}</li>" for ts, msg in self.get_logs())
+            or "<li>None</li>"
+        )
+        metrics = self.get_metrics()
+        rows = "".join(
+            f"<tr><td>{k}</td><td>{v:.3f}</td></tr>" for k, v in metrics.items()
+        )
+        return (
+            "<html><body><h1>Collaboration Portal</h1>"
+            "<h2>Active Tasks</h2><ul>" + tasks + "</ul>"
+            "<h2>Telemetry</h2><table border='1'>"
+            "<tr><th>Metric</th><th>Value</th></tr>" + rows + "</table>"
+            "<h2>Reasoning Log</h2><ul>" + logs + "</ul>"
+            "</body></html>"
+        )
+
+    # --------------------------------------------------------------
+    def start(self, host: str = "localhost", port: int = 8070) -> None:
+        if self.httpd is not None:
+            return
+        portal = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: D401
+                if self.path == "/tasks":
+                    data = json.dumps(portal.get_tasks()).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                elif self.path == "/metrics":
+                    data = json.dumps(portal.get_metrics()).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                elif self.path == "/logs":
+                    data = json.dumps(portal.get_logs()).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                else:
+                    html = portal.to_html().encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/html")
+                    self.end_headers()
+                    self.wfile.write(html)
+
+            def log_message(self, format: str, *args: Any) -> None:  # noqa: D401
+                return
+
+        self.httpd = HTTPServer((host, port), Handler)
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    # --------------------------------------------------------------
+    def stop(self) -> None:
+        if self.httpd is None:
+            return
+        assert self.thread is not None
+        self.httpd.shutdown()
+        self.thread.join(timeout=1.0)
+        self.httpd.server_close()
+        self.httpd = None
+        self.thread = None
+        self.port = None
+
+
+__all__ = ["CollaborationPortal"]

--- a/tests/test_collaboration_portal.py
+++ b/tests/test_collaboration_portal.py
@@ -1,0 +1,41 @@
+import unittest
+import http.client
+import json
+import time
+
+from asi.collaboration_portal import CollaborationPortal
+from asi.telemetry import TelemetryLogger
+from asi.reasoning_history import ReasoningHistoryLogger
+
+
+class TestCollaborationPortal(unittest.TestCase):
+    def test_endpoints(self):
+        tel = TelemetryLogger(interval=0.1)
+        tel.start()
+        rh = ReasoningHistoryLogger()
+        rh.log("start")
+        portal = CollaborationPortal(["t1"], tel, rh)
+        portal.start(port=0)
+        port = portal.port
+        assert port is not None
+
+        conn = http.client.HTTPConnection("localhost", port)
+        conn.request("GET", "/tasks")
+        tasks = json.loads(conn.getresponse().read())
+        self.assertIn("t1", tasks)
+
+        time.sleep(0.2)
+        conn.request("GET", "/metrics")
+        metrics = json.loads(conn.getresponse().read())
+        self.assertIn("cpu", metrics)
+
+        conn.request("GET", "/logs")
+        logs = json.loads(conn.getresponse().read())
+        self.assertEqual(logs[0][1], "start")
+
+        portal.stop()
+        tel.stop()
+
+
+if __name__ == "__main__":  # pragma: no cover - test helper
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `CollaborationPortal` for serving active tasks, telemetry and reasoning logs
- expose portal in the package
- document how to run it in the README
- note the new portal in Plan
- test endpoints via new unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', and others)*

------
https://chatgpt.com/codex/tasks/task_e_68686b323f8c83319dc3ce252c8f9785