### PR TITLE
Add encrypted vector store

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -32,7 +32,7 @@ Citations point to the most recent public work so you can drill straight into th
 | **C-8** | **Distributed Hierarchical Memory Backend** | Share the vector store across nodes via a gRPC service (see `MemoryServer`, `RemoteMemory`) | Throughput scales to 4+ nodes with <1.2× single-node latency |
 | **C-9** | **Hopfield Associative Memory** | Store binary patterns as attractors and recall them from noisy cues | Recall accuracy >95 % on 32-bit vectors with up to 20 % noise |
 
-**Path to “trillion-token” context:** combine *C-1/2/3* for linear-or-sub-linear scaling, add **hierarchical retrieval** (store distant tokens in an external vector DB and re-inject on-demand).  Recurrence handles the whole stream; retrieval gives random access—context length becomes limited only by storage, not RAM.
+**Path to “trillion-token” context:** combine *C-1/2/3* for linear-or-sub-linear scaling, add **hierarchical retrieval** (store distant tokens in an external vector DB and re-inject on-demand).  Recurrence handles the whole stream; retrieval gives random access—context length becomes limited only by storage, not RAM.  Privacy-preserving retrieval is now possible via `EncryptedVectorStore`, which stores AES-encrypted embeddings and manages keys through `HierarchicalMemory`.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ scikit-learn
 umap-learn
 plotly
 pyyaml
+cryptography

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -28,6 +28,7 @@ from .distributed_trainer import DistributedTrainer, MemoryConfig
 from .remote_memory import RemoteMemory
 from .edge_memory_client import EdgeMemoryClient
 from .vector_store import VectorStore, FaissVectorStore
+from .encrypted_vector_store import EncryptedVectorStore
 from .pq_vector_store import PQVectorStore
 from .async_vector_store import AsyncFaissVectorStore
 from .iter_align import IterativeAligner

--- a/src/encrypted_vector_store.py
+++ b/src/encrypted_vector_store.py
@@ -1,0 +1,74 @@
+import os
+import io
+from pathlib import Path
+
+import numpy as np
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from .vector_store import VectorStore
+
+
+class EncryptedVectorStore(VectorStore):
+    """Vector store that encrypts embeddings with AES-GCM when persisted."""
+
+    def __init__(self, dim: int, key: bytes) -> None:
+        super().__init__(dim)
+        if len(key) not in (16, 24, 32):
+            raise ValueError("key must be 16, 24, or 32 bytes")
+        self._key = key
+
+    # ------------------------------------------------------------------
+    @property
+    def key(self) -> bytes:
+        return self._key
+
+    def set_key(self, key: bytes) -> None:
+        if len(key) not in (16, 24, 32):
+            raise ValueError("key must be 16, 24, or 32 bytes")
+        self._key = key
+
+    def rotate_key(self, new_key: bytes, path: str | Path | None = None) -> None:
+        """Update encryption key and optionally re-save the store."""
+        self.set_key(new_key)
+        if path is not None:
+            self.save(path)
+
+    # ------------------------------------------------------------------
+    def save(self, path: str | Path) -> None:  # type: ignore[override]
+        """Persist encrypted vectors and metadata to ``path``."""
+        vecs = (
+            np.concatenate(self._vectors, axis=0)
+            if self._vectors
+            else np.empty((0, self.dim), dtype=np.float32)
+        )
+        meta = np.array(self._meta, dtype=object)
+        buf = io.BytesIO()
+        np.savez_compressed(buf, dim=self.dim, vectors=vecs, meta=meta)
+        data = buf.getvalue()
+        aes = AESGCM(self._key)
+        nonce = os.urandom(12)
+        enc = aes.encrypt(nonce, data, None)
+        with open(path, "wb") as f:
+            f.write(nonce + enc)
+
+    @classmethod
+    def load(cls, path: str | Path, key: bytes) -> "EncryptedVectorStore":
+        """Load an encrypted vector store from ``path``."""
+        if len(key) not in (16, 24, 32):
+            raise ValueError("key must be 16, 24, or 32 bytes")
+        with open(path, "rb") as f:
+            blob = f.read()
+        nonce, enc = blob[:12], blob[12:]
+        aes = AESGCM(key)
+        data = aes.decrypt(nonce, enc, None)
+        buf = io.BytesIO(data)
+        npz = np.load(buf, allow_pickle=True)
+        store = cls(int(npz["dim"]), key)
+        vectors = npz["vectors"]
+        meta = npz["meta"].tolist()
+        if vectors.size:
+            store.add(vectors, metadata=meta)
+        return store
+
+
+__all__ = ["EncryptedVectorStore"]

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -14,6 +14,7 @@ except Exception:  # pragma: no cover - optional dependency
 from .streaming_compression import StreamingCompressor, TemporalVectorCompressor
 from .knowledge_graph_memory import KnowledgeGraphMemory, TimedTriple
 from .vector_store import VectorStore, FaissVectorStore, LocalitySensitiveHashIndex
+from .encrypted_vector_store import EncryptedVectorStore
 from .pq_vector_store import PQVectorStore
 from .async_vector_store import AsyncFaissVectorStore
 from .hopfield_memory import HopfieldMemory
@@ -119,6 +120,7 @@ class HierarchicalMemory:
         evict_check_interval: int = 100,
         use_kg: bool = False,
         translator: "CrossLingualTranslator | None" = None,
+        encryption_key: bytes | None = None,
     ) -> None:
         if temporal_decay is None:
             self.compressor = StreamingCompressor(dim, compressed_dim, capacity)
@@ -138,7 +140,13 @@ class HierarchicalMemory:
             self.store = PQVectorStore(dim=compressed_dim, path=db_path)
         else:
             if db_path is None:
-                self.store = VectorStore(dim=compressed_dim)
+                if encryption_key is None:
+                    self.store = VectorStore(dim=compressed_dim)
+                else:
+                    from .encrypted_vector_store import EncryptedVectorStore
+                    self.store = EncryptedVectorStore(
+                        dim=compressed_dim, key=encryption_key
+                    )
             else:
                 self.store = FaissVectorStore(dim=compressed_dim, path=db_path)
         self.cache: SSDCache | None = None
@@ -154,6 +162,10 @@ class HierarchicalMemory:
         self.kg: KnowledgeGraphMemory | None = KnowledgeGraphMemory() if use_kg else None
         self.last_trace: dict | None = None
         self.translator = translator
+        if isinstance(self.store, EncryptedVectorStore):
+            self.encryption_key = self.store.key
+        else:
+            self.encryption_key = None
 
     def __len__(self) -> int:
         """Return the number of stored vectors."""
@@ -311,6 +323,14 @@ class HierarchicalMemory:
             "hit_rate": rate,
             "evict_limit": float(self.evict_limit or 0),
         }
+
+    def rotate_encryption_key(
+        self, new_key: bytes, path: str | Path | None = None
+    ) -> None:
+        """Rotate the encryption key if using :class:`EncryptedVectorStore`."""
+        if isinstance(self.store, EncryptedVectorStore):
+            self.store.rotate_key(new_key, path)
+            self.encryption_key = new_key
 
     def query_triples(
         self,

--- a/tests/test_encrypted_vector_store.py
+++ b/tests/test_encrypted_vector_store.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import importlib.util
+import tempfile
+import unittest
+import numpy as np
+try:
+    import torch
+except Exception:  # pragma: no cover - torch optional
+    torch = None
+
+SRC_DIR = os.path.join(os.path.dirname(__file__), "..", "src")
+spec_vs = importlib.util.spec_from_file_location(
+    "src.vector_store", os.path.join(SRC_DIR, "vector_store.py")
+)
+vector_store = importlib.util.module_from_spec(spec_vs)
+sys.modules["src.vector_store"] = vector_store
+spec_vs.loader.exec_module(vector_store)
+
+spec_enc = importlib.util.spec_from_file_location(
+    "src.encrypted_vector_store",
+    os.path.join(SRC_DIR, "encrypted_vector_store.py"),
+    submodule_search_locations=[SRC_DIR],
+)
+encrypted_vector_store = importlib.util.module_from_spec(spec_enc)
+sys.modules["src.encrypted_vector_store"] = encrypted_vector_store
+spec_enc.loader.exec_module(encrypted_vector_store)
+
+EncryptedVectorStore = encrypted_vector_store.EncryptedVectorStore
+VectorStore = vector_store.VectorStore
+
+
+class TestEncryptedVectorStore(unittest.TestCase):
+    def test_save_load_encrypted(self):
+        key = b"0" * 32
+        store = EncryptedVectorStore(dim=2, key=key)
+        store.add(np.array([[1.0, 0.0], [0.0, 1.0]]), metadata=["a", "b"])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "store.enc")
+            store.save(path)
+            loaded = EncryptedVectorStore.load(path, key)
+            q = np.array([0.0, 1.0], dtype=np.float32)
+            vecs_e, meta_e = loaded.search(q, k=1)
+        base = VectorStore(dim=2)
+        base.add(np.array([[1.0, 0.0], [0.0, 1.0]]), metadata=["a", "b"])
+        vecs_b, meta_b = base.search(q, k=1)
+        np.testing.assert_allclose(vecs_e, vecs_b)
+        self.assertEqual(meta_e, meta_b)
+
+    def test_hierarchical_memory_integration(self):
+        if torch is None:
+            self.skipTest("torch not available")
+        torch.manual_seed(0)
+        spec_hm = importlib.util.spec_from_file_location(
+            "src.hierarchical_memory",
+            os.path.join(SRC_DIR, "hierarchical_memory.py"),
+            submodule_search_locations=[SRC_DIR],
+        )
+        hierarchical_memory = importlib.util.module_from_spec(spec_hm)
+        sys.modules["src.hierarchical_memory"] = hierarchical_memory
+        spec_hm.loader.exec_module(hierarchical_memory)
+        HierarchicalMemory = hierarchical_memory.HierarchicalMemory
+
+        key = b"1" * 32
+        mem = HierarchicalMemory(
+            dim=4, compressed_dim=2, capacity=10, encryption_key=key
+        )
+        data = torch.randn(3, 4)
+        mem.add(data, metadata=["x", "y", "z"])
+        q = data[0]
+        out, meta = mem.search(q, k=1)
+        self.assertEqual(out.shape, (1, 4))
+        self.assertIn(meta[0], ["x", "y", "z"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support AES-GCM encrypted persistence via `EncryptedVectorStore`
- integrate encryption in `HierarchicalMemory`
- expose the new store in package init
- document privacy-preserving retrieval in `Plan.md`
- add `cryptography` dependency
- test encrypted storage and retrieval

## Testing
- `PYTHONPATH=src pytest tests/test_encrypted_vector_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68686b2ec0ec8331b17f3aa25bb6df75