### PR TITLE
Add self-reflection analyzer

### DIFF
--- a/Self_Reflection.md
+++ b/Self_Reflection.md
@@ -17,3 +17,16 @@ changes remain stable. Users should manually review Codex's pull requests before
 
 \nThe project vision begins with the note: "Below is a shopping list of concrete algorithmic
 gaps..." as described in docs/Plan.md.
+
+## Self-reflection tools
+
+Reasoning summaries can be stored via `ReasoningHistoryLogger`. The logger now
+includes an `analyze()` method that clusters repeated steps and flags
+contradictions such as `X` versus `not X`. Histories saved with `save()` can be
+inspected on the command line:
+
+```bash
+python -m asi.self_reflection history.json
+```
+
+The report lists the most common steps and highlights any inconsistencies.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -363,7 +363,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 72. **Self-debugging world model**: Automatically patch the world model when rollout errors exceed 1%, keeping long-term error <1%. *Implemented in `src/world_model_debugger.py` with tests.*
 73. **Versioned model lineage**: Record hashed checkpoints and link them to dataset versions via `ModelVersionManager` for reproducible experiments. *Implemented in `src/model_version_manager.py` with tests.*
 74. **Dataset anonymization**: Sanitize text, image and audio files during ingestion using `DatasetAnonymizer`. The `download_triples()` helper now scrubs PII and logs a summary via `DatasetLineageManager`.
-75. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps to aid debugging.
+75. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps. The logger now provides `analyze()` to cluster repeated steps and flag inconsistencies. Use `python -m asi.self_reflection` to print a report from saved histories.
 
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."

--- a/src/reasoning_history.py
+++ b/src/reasoning_history.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Tuple
+from typing import Dict, List, Tuple
+import json
+from collections import Counter
 
 
 @dataclass
@@ -18,5 +20,43 @@ class ReasoningHistoryLogger:
     def get_history(self) -> List[Tuple[str, str]]:
         return list(self.entries)
 
+    def save(self, path: str) -> None:
+        """Save history entries to ``path`` as JSON."""
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(self.entries, fh)
 
-__all__ = ["ReasoningHistoryLogger"]
+    @classmethod
+    def load(cls, path: str) -> "ReasoningHistoryLogger":
+        """Load entries from ``path`` and return a logger."""
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        logger = cls()
+        for ts, summary in data:
+            logger.entries.append((ts, summary))
+        return logger
+
+    def analyze(self) -> "HistoryAnalysis":
+        """Cluster steps and detect contradictions."""
+        counts: Counter[str] = Counter()
+        contradictions: set[Tuple[str, str]] = set()
+        for _ts, summary in self.entries:
+            steps = [s.strip() for s in summary.split("->")]
+            for step in steps:
+                counts[step] += 1
+                neg = f"not {step}"
+                if counts[neg]:
+                    contradictions.add((step, neg))
+                if step.startswith("not "):
+                    base = step[4:]
+                    if counts[base]:
+                        contradictions.add((base, step))
+        return HistoryAnalysis(dict(counts), sorted(contradictions))
+
+
+@dataclass
+class HistoryAnalysis:
+    clusters: Dict[str, int]
+    inconsistencies: List[Tuple[str, str]]
+
+
+__all__ = ["ReasoningHistoryLogger", "HistoryAnalysis"]

--- a/src/self_reflection.py
+++ b/src/self_reflection.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Sequence
+
+from .reasoning_history import ReasoningHistoryLogger
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Print a report of reasoning history analysis."""
+    parser = argparse.ArgumentParser(description="Summarise reasoning history")
+    parser.add_argument("history", help="Path to history JSON file")
+    args = parser.parse_args(argv)
+
+    logger = ReasoningHistoryLogger.load(args.history)
+    analysis = logger.analyze()
+
+    lines = ["Reasoning step clusters:"]
+    for step, count in sorted(analysis.clusters.items(), key=lambda x: -x[1]):
+        lines.append(f"- {step}: {count}")
+    if analysis.inconsistencies:
+        lines.append("Inconsistencies:")
+        for a, b in analysis.inconsistencies:
+            lines.append(f"- {a} vs {b}")
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    main()

--- a/tests/test_self_reflection_analyzer.py
+++ b/tests/test_self_reflection_analyzer.py
@@ -1,0 +1,42 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from asi.reasoning_history import ReasoningHistoryLogger
+
+
+class TestHistoryAnalysis(unittest.TestCase):
+    def test_analyze(self):
+        logger = ReasoningHistoryLogger()
+        logger.log("start -> middle")
+        logger.log("start -> not middle")
+        analysis = logger.analyze()
+        self.assertEqual(analysis.clusters.get("start"), 2)
+        self.assertIn(("middle", "not middle"), analysis.inconsistencies)
+
+
+class TestSelfReflectionCLI(unittest.TestCase):
+    def test_cli_report(self):
+        logger = ReasoningHistoryLogger()
+        logger.log("start -> middle")
+        logger.log("start -> not middle")
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            json.dump(logger.entries, f)
+            fname = f.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-m", "asi.self_reflection", fname],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0)
+            self.assertIn("Inconsistencies", proc.stdout)
+        finally:
+            os.unlink(fname)
+
+
+if __name__ == "__main__":  # pragma: no cover - test helper
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `ReasoningHistoryLogger` with analysis helpers
- add `asi.self_reflection` CLI for summarising history files
- test reasoning history clustering and CLI output
- mention new tools in `Self_Reflection.md` and `docs/Plan.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68686b3412bc8331873536a105df8f9c