### PR TITLE
Add dataset summary script

### DIFF
--- a/scripts/dataset_summary.py
+++ b/scripts/dataset_summary.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""Summarize dataset lineage and license information."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+try:  # pragma: no cover - prefer package if available
+    from asi.dataset_lineage_manager import DatasetLineageManager
+    from asi.license_inspector import LicenseInspector
+except Exception:  # pragma: no cover - fallback for tests
+    from src.dataset_lineage_manager import DatasetLineageManager  # type: ignore
+    from src.license_inspector import LicenseInspector  # type: ignore
+
+
+def summarize(root: str | Path, fmt: str = "md") -> str:
+    """Return a summary of lineage steps and licenses."""
+    mgr = DatasetLineageManager(root)
+    mgr.load()
+    inspector = LicenseInspector()
+    licenses: dict[str, bool] = {}
+    for p in Path(root).rglob("*.json"):
+        try:
+            licenses[str(p)] = inspector.inspect(p)
+        except Exception:
+            continue
+
+    if fmt == "json":
+        data = {
+            "lineage": [
+                {
+                    "note": s.note,
+                    "inputs": s.inputs,
+                    "outputs": s.outputs,
+                }
+                for s in mgr.steps
+            ],
+            "licenses": licenses,
+        }
+        return json.dumps(data, indent=2)
+
+    lines = ["# Dataset Summary", "", "## Lineage"]
+    for step in mgr.steps:
+        outputs = ", ".join(step.outputs.keys())
+        note = step.note or ""
+        lines.append(f"- {note} -> {outputs}")
+    lines.append("")
+    lines.append("## License Compliance")
+    for path, ok in licenses.items():
+        status = "OK" if ok else "NOT ALLOWED"
+        lines.append(f"- {Path(path).name}: {status}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Dataset summary")
+    parser.add_argument("root", help="Dataset root directory")
+    parser.add_argument("--format", choices=["md", "json"], default="md")
+    args = parser.parse_args(argv)
+    print(summarize(args.root, args.format))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/tests/test_dataset_summary.py
+++ b/tests/test_dataset_summary.py
@@ -1,0 +1,53 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+import importlib.machinery
+import importlib.util
+import types
+import sys
+
+sys.modules['scripts'] = types.ModuleType('scripts')
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+# prepare src package before loading script
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+src_pkg.__path__ = ['src']
+src_pkg.__spec__ = importlib.machinery.ModuleSpec('src', None, is_package=True)
+
+DatasetLineageManager = _load('src.dataset_lineage_manager', 'src/dataset_lineage_manager.py').DatasetLineageManager
+
+summary_mod = _load('scripts.dataset_summary', 'scripts/dataset_summary.py')
+summarize = summary_mod.summarize
+
+
+class TestDatasetSummary(unittest.TestCase):
+    def test_summarize_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            inp = root / 'in.txt'
+            outp = root / 'out.txt'
+            inp.write_text('i')
+            outp.write_text('o')
+            mgr = DatasetLineageManager(root)
+            mgr.record([inp], [outp], note='step1')
+            meta = root / 'meta.json'
+            meta.write_text(json.dumps({'license': 'MIT'}))
+            result = summarize(str(root), fmt='json')
+            data = json.loads(result)
+            self.assertEqual(data['lineage'][0]['note'], 'step1')
+            self.assertTrue(data['licenses'][str(meta)])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a new `dataset_summary.py` CLI under `scripts/`
- output dataset lineage and license checks in Markdown or JSON
- include unit test `test_dataset_summary.py`

## Testing
- `pytest tests/test_dataset_summary.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68686b7b6b84833181dfa136b0f09d55