### PR TITLE
Add GOT visualizer and CLI

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -364,6 +364,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 73. **Versioned model lineage**: Record hashed checkpoints and link them to dataset versions via `ModelVersionManager` for reproducible experiments. *Implemented in `src/model_version_manager.py` with tests.*
 74. **Dataset anonymization**: Sanitize text, image and audio files during ingestion using `DatasetAnonymizer`. The `download_triples()` helper now scrubs PII and logs a summary via `DatasetLineageManager`.
 75. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps to aid debugging.
+76. **Graph-of-thought visualizer**: Use `src/got_visualizer.py` and the CLI
+    `scripts/got_visualizer.py trace.json --out graph.html` to render reasoning
+    traces for collaborative editing sessions.
 
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."

--- a/scripts/got_visualizer.py
+++ b/scripts/got_visualizer.py
@@ -1,0 +1,23 @@
+import argparse
+import json
+from pathlib import Path
+
+from asi.got_visualizer import GOTVisualizer
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Render reasoning trace")
+    parser.add_argument("json", help="Path to JSON trace")
+    parser.add_argument("--out", help="Output HTML file")
+    args = parser.parse_args(argv)
+
+    viz = GOTVisualizer.from_json(args.json)
+    html = viz.to_html()
+    if args.out:
+        Path(args.out).write_text(html, encoding="utf-8")
+    else:
+        print(html)
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -142,6 +142,7 @@ except Exception:  # pragma: no cover - optional
 from .differential_privacy_optimizer import DifferentialPrivacyOptimizer, DifferentialPrivacyConfig
 
 from .embedding_visualizer import EmbeddingVisualizer
+from .got_visualizer import GOTVisualizer
 from .duplicate_detector import DuplicateDetector
 from .telemetry import TelemetryLogger, FineGrainedProfiler
 from .license_inspector import LicenseInspector

--- a/src/got_visualizer.py
+++ b/src/got_visualizer.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Dict, Iterable, List, Tuple
+
+import plotly.graph_objects as go
+
+
+class GOTVisualizer:
+    """Render reasoning graphs with Plotly."""
+
+    def __init__(self, nodes: Iterable[Dict[str, Any]], edges: Iterable[Tuple[str, str]]) -> None:
+        self.nodes = list(nodes)
+        self.edges = list(edges)
+
+    @classmethod
+    def from_json(cls, path: str) -> "GOTVisualizer":
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        nodes = data.get("nodes", [])
+        raw_edges = data.get("edges", [])
+        if raw_edges and isinstance(raw_edges[0], dict):
+            edges = [(e["source"], e["target"]) for e in raw_edges]
+        else:
+            edges = [(src, dst) for src, dst in raw_edges]
+        return cls(nodes, edges)
+
+    # --------------------------------------------------------------
+    def _layout(self) -> Dict[str, Tuple[float, float]]:
+        n = max(len(self.nodes), 1)
+        pos: Dict[str, Tuple[float, float]] = {}
+        for i, node in enumerate(self.nodes):
+            angle = 2 * math.pi * i / n
+            pos[str(node["id"])] = (math.cos(angle), math.sin(angle))
+        return pos
+
+    # --------------------------------------------------------------
+    def to_figure(self) -> go.Figure:
+        pos = self._layout()
+        edge_x: List[float] = []
+        edge_y: List[float] = []
+        for src, dst in self.edges:
+            x0, y0 = pos.get(str(src), (0, 0))
+            x1, y1 = pos.get(str(dst), (0, 0))
+            edge_x += [x0, x1, None]
+            edge_y += [y0, y1, None]
+        edge_trace = go.Scatter(
+            x=edge_x,
+            y=edge_y,
+            mode="lines",
+            line=dict(color="#888", width=1),
+            hoverinfo="none",
+        )
+        node_x = []
+        node_y = []
+        texts = []
+        for node in self.nodes:
+            nid = str(node["id"])
+            x, y = pos[nid]
+            node_x.append(x)
+            node_y.append(y)
+            texts.append(node.get("text", nid))
+        node_trace = go.Scatter(
+            x=node_x,
+            y=node_y,
+            mode="markers+text",
+            text=texts,
+            textposition="bottom center",
+            marker=dict(size=10, color="#1f77b4"),
+        )
+        fig = go.Figure(data=[edge_trace, node_trace])
+        fig.update_layout(showlegend=False, xaxis=dict(visible=False), yaxis=dict(visible=False))
+        return fig
+
+    # --------------------------------------------------------------
+    def to_html(self, title: str = "Reasoning Graph") -> str:
+        fig = self.to_figure()
+        fig.update_layout(title=title)
+        return fig.to_html(include_plotlyjs="cdn")
+
+
+__all__ = ["GOTVisualizer"]

--- a/src/graph_of_thought.py
+++ b/src/graph_of_thought.py
@@ -167,6 +167,31 @@ class ReasoningDebugger:
                             contrad.append(pair)
         return contrad
 
+    def export_graph_data(self) -> Dict[str, list[dict]]:
+        """Return nodes and edges formatted for ``GOTVisualizer``."""
+        nodes: List[dict] = []
+        edges: List[dict] = []
+        for agent, graph in self.graphs.items():
+            for nid, node in graph.nodes.items():
+                nodes.append(
+                    {
+                        "id": f"{agent}:{nid}",
+                        "agent": agent,
+                        "orig_id": nid,
+                        "text": node.text,
+                        "metadata": node.metadata or {},
+                    }
+                )
+            for src, dsts in graph.edges.items():
+                for dst in dsts:
+                    edges.append(
+                        {
+                            "source": f"{agent}:{src}",
+                            "target": f"{agent}:{dst}",
+                        }
+                    )
+        return {"nodes": nodes, "edges": edges}
+
     def report(self) -> str:
         """Return a consolidated text report of detected issues."""
         loops = self.find_loops()

--- a/tests/test_got_visualizer.py
+++ b/tests/test_got_visualizer.py
@@ -1,0 +1,24 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import sys
+
+loader = importlib.machinery.SourceFileLoader('got_visualizer', 'src/got_visualizer.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mod
+loader.exec_module(mod)
+GOTVisualizer = mod.GOTVisualizer
+
+
+class TestGOTVisualizer(unittest.TestCase):
+    def test_html_generation(self):
+        nodes = [{"id": "a:0", "text": "start"}, {"id": "a:1", "text": "end"}]
+        edges = [("a:0", "a:1")]
+        vis = GOTVisualizer(nodes, edges)
+        html = vis.to_html()
+        self.assertIn("<html", html.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reasoning_debugger.py
+++ b/tests/test_reasoning_debugger.py
@@ -34,6 +34,10 @@ class TestReasoningDebugger(unittest.TestCase):
         self.assertTrue(any(a != c for a, _, c, _ in contrad))
         self.assertIsInstance(dbg.report(), str)
 
+        data = dbg.export_graph_data()
+        self.assertIn("nodes", data)
+        self.assertIn("edges", data)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `GOTVisualizer` for Plotly graphs
- expose CLI `scripts/got_visualizer.py`
- extend `ReasoningDebugger` with `export_graph_data`
- document collaborative graph editing usage
- add unit tests

## Testing
- `pytest tests/test_got_visualizer.py tests/test_reasoning_debugger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68686b8791bc8331bf8002b27c169e78