### PR TITLE
Add dataset discovery pipeline

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -392,3 +392,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 [25]: https://github.com/features/actions?utm_source=chatgpt.com "GitHub Actions for automated repository processing"
 [26]: https://arxiv.org/abs/2211.00564?utm_source=chatgpt.com "Transformer Circuits: Mechanistic Interpretability"
 74. **Federated knowledge graph memory**: Replicate triples across nodes via `FederatedKGMemoryServer` so that after network partitions all servers agree on the same graph. Success is 100% retrieval consistency across two peers after concurrent updates.
+75. **Dataset discovery pipeline**: `dataset_discovery.py` scans RSS feeds from
+    HuggingFace and Kaggle, storing dataset names, URLs and license text in a
+    lightweight SQLite database. `license_inspector.py` loads the database to
+    flag incompatible licenses. The plan is to crowd‑source additional data hub
+    scrapers so community members can contribute new sources via pull requests.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -148,6 +148,12 @@ from .license_inspector import LicenseInspector
 from .dataset_versioner import DatasetVersioner
 from .dataset_lineage_manager import DatasetLineageManager
 from .dataset_anonymizer import DatasetAnonymizer
+from .dataset_discovery import (
+    DiscoveredDataset,
+    discover_huggingface,
+    discover_kaggle,
+    store_datasets,
+)
 from .streaming_compression import AdaptiveCompressor, TemporalVectorCompressor
 from .context_profiler import profile_model, ContextWindowProfiler
 from .accelerator_scheduler import AcceleratorScheduler

--- a/src/dataset_discovery.py
+++ b/src/dataset_discovery.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sqlite3
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import requests
+
+
+@dataclass
+class DiscoveredDataset:
+    """Metadata for a discovered dataset."""
+
+    name: str
+    url: str
+    source: str
+    license: str = ""
+    license_text: str = ""
+
+
+def _parse_rss(text: str, source: str) -> List[DiscoveredDataset]:
+    root = ET.fromstring(text)
+    out: List[DiscoveredDataset] = []
+    for item in root.findall('.//item'):
+        title = item.findtext('title', default='')
+        link = item.findtext('link', default='')
+        lic = item.findtext('license', default='')
+        out.append(DiscoveredDataset(title, link, source, lic, lic))
+    return out
+
+
+def discover_huggingface(rss_url: str = 'https://huggingface.co/datasets/rss/new') -> List[DiscoveredDataset]:
+    """Return datasets listed on HuggingFace via RSS."""
+    resp = requests.get(rss_url, timeout=10)
+    resp.raise_for_status()
+    return _parse_rss(resp.text, 'huggingface')
+
+
+def discover_kaggle(rss_url: str = 'https://www.kaggle.com/datasets.rss') -> List[DiscoveredDataset]:
+    """Return datasets listed on Kaggle via RSS."""
+    resp = requests.get(rss_url, timeout=10)
+    resp.raise_for_status()
+    return _parse_rss(resp.text, 'kaggle')
+
+
+def store_datasets(dsets: Iterable[DiscoveredDataset], db_path: str | Path) -> None:
+    """Store discovered datasets in ``db_path`` SQLite database."""
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(
+            'CREATE TABLE IF NOT EXISTS datasets ('
+            'name TEXT, source TEXT, url TEXT, license TEXT, license_text TEXT,'
+            'UNIQUE(name, source))'
+        )
+        conn.executemany(
+            'INSERT OR REPLACE INTO datasets(name, source, url, license, license_text) '
+            'VALUES (?, ?, ?, ?, ?)',
+            [(d.name, d.source, d.url, d.license, d.license_text) for d in dsets],
+        )
+    conn.close()
+
+
+__all__ = [
+    'DiscoveredDataset',
+    'discover_huggingface',
+    'discover_kaggle',
+    'store_datasets',
+]

--- a/tests/test_dataset_discovery.py
+++ b/tests/test_dataset_discovery.py
@@ -1,0 +1,49 @@
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+import importlib.machinery
+import importlib.util
+import types
+
+src_pkg = types.ModuleType('src')
+src_pkg.__path__ = ['src']
+src_pkg.__spec__ = importlib.machinery.ModuleSpec('src', None, is_package=True)
+import sys
+sys.modules['src'] = src_pkg
+loader = importlib.machinery.SourceFileLoader('src.dataset_discovery', 'src/dataset_discovery.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+dd = importlib.util.module_from_spec(spec)
+dd.__package__ = 'src'
+sys.modules['src.dataset_discovery'] = dd
+loader.exec_module(dd)
+DiscoveredDataset = dd.DiscoveredDataset
+parse_hf = dd.discover_huggingface
+store_datasets = dd.store_datasets
+
+from asi.license_inspector import LicenseInspector
+
+
+class TestDatasetDiscovery(unittest.TestCase):
+    def test_store_and_inspect(self):
+        rss = """<rss><channel>
+        <item><title>ds1</title><link>http://x/ds1</link><license>MIT</license></item>
+        <item><title>ds2</title><link>http://x/ds2</link><license>Apache</license></item>
+        </channel></rss>"""
+        dsets = dd._parse_rss(rss, 'hf')
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / 'db.sqlite'
+            store_datasets(dsets, db)
+            conn = sqlite3.connect(db)
+            cur = conn.execute('select count(*) from datasets')
+            self.assertEqual(cur.fetchone()[0], 2)
+            conn.close()
+            insp = LicenseInspector(['mit'])
+            res = insp.inspect_db(db)
+            self.assertTrue(res['hf:ds1'])
+            self.assertFalse(res['hf:ds2'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_license_inspector.py
+++ b/tests/test_license_inspector.py
@@ -2,7 +2,22 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
-from asi.license_inspector import LicenseInspector
+import importlib.machinery
+import importlib.util
+import types
+import sys
+
+src_pkg = types.ModuleType('src')
+src_pkg.__path__ = ['src']
+src_pkg.__spec__ = importlib.machinery.ModuleSpec('src', None, is_package=True)
+sys.modules['src'] = src_pkg
+loader = importlib.machinery.SourceFileLoader('src.license_inspector', 'src/license_inspector.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+li = importlib.util.module_from_spec(spec)
+li.__package__ = 'src'
+sys.modules['src.license_inspector'] = li
+loader.exec_module(li)
+LicenseInspector = li.LicenseInspector
 
 
 class TestLicenseInspector(unittest.TestCase):


### PR DESCRIPTION
## Summary
- implement dataset_discovery module for scanning RSS feeds
- store discovered datasets in a SQLite DB
- extend LicenseInspector with DB inspection utilities
- update Plan with dataset discovery pipeline
- adjust tests and add dataset discovery tests

## Testing
- `pip install requests -q`
- `PYTHONPATH=. pytest tests/test_license_inspector.py tests/test_dataset_discovery.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68686b8a32dc83319b601ef9e59a96ea