### PR TITLE
Add analogical retrieval module

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -364,6 +364,11 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 73. **Versioned model lineage**: Record hashed checkpoints and link them to dataset versions via `ModelVersionManager` for reproducible experiments. *Implemented in `src/model_version_manager.py` with tests.*
 74. **Dataset anonymization**: Sanitize text, image and audio files during ingestion using `DatasetAnonymizer`. The `download_triples()` helper now scrubs PII and logs a summary via `DatasetLineageManager`.
 75. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps to aid debugging.
+76. **Analogy-based retrieval evaluation**: Use `analogical_retrieval.analogy_search()`
+    on a small word-analogy dataset. For each tuple `(A, B, Q)` compute the
+    offset `B - A` and query `HierarchicalMemory.search(mode="analogy")`. Report
+    the percentage of cases where the top result matches the expected word; aim
+    for ≥70% accuracy on the toy set.
 
 [1]: https://medium.com/%40shekharsomani98/implementation-of-mixture-of-experts-using-switch-transformers-8f25b60c33d3?utm_source=chatgpt.com "Implementation of Mixture of Experts using Switch Transformers"
 [2]: https://tridao.me/blog/2024/flash3/?utm_source=chatgpt.com "FlashAttention-3: Fast and Accurate Attention with Asynchrony and ..."

--- a/src/analogical_retrieval.py
+++ b/src/analogical_retrieval.py
@@ -1,0 +1,44 @@
+import torch
+from typing import Tuple
+
+
+def analogy_offset(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Return the offset vector ``b - a`` used for analogy arithmetic."""
+    if a.shape != b.shape:
+        raise ValueError("a and b must have the same shape")
+    return b - a
+
+
+def apply_analogy(query: torch.Tensor, offset: torch.Tensor) -> torch.Tensor:
+    """Apply ``offset`` to ``query`` (i.e. ``query + offset``)."""
+    if query.shape != offset.shape:
+        raise ValueError("offset dimension mismatch")
+    return query + offset
+
+
+def analogy_vector(query: torch.Tensor, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Return the vector for ``query : a :: ? : b`` using ``b - a``."""
+    return apply_analogy(query, analogy_offset(a, b))
+
+
+def analogy_search(
+    memory: "HierarchicalMemory",
+    query: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    k: int = 5,
+    **kwargs,
+):
+    """Shortcut for analogy retrieval through ``HierarchicalMemory``."""
+    from .hierarchical_memory import HierarchicalMemory  # circular import
+
+    offset = analogy_offset(a, b)
+    return memory.search(query, k=k, mode="analogy", offset=offset, **kwargs)
+
+
+__all__ = [
+    "analogy_offset",
+    "apply_analogy",
+    "analogy_vector",
+    "analogy_search",
+]

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -370,12 +370,20 @@ class HierarchicalMemory:
         k: int = 5,
         return_scores: bool = False,
         return_provenance: bool = False,
+        *,
+        mode: str = "standard",
+        offset: torch.Tensor | None = None,
     ) -> Tuple[torch.Tensor, List[Any]] | Tuple[torch.Tensor, List[Any], List[float], List[Any]]:
         """Retrieve top-k decoded vectors and their metadata.
 
         When ``return_scores`` or ``return_provenance`` is ``True`` additional
         lists of cosine similarity scores and provenance metadata are returned.
         """
+        if mode == "analogy":
+            if offset is None:
+                raise ValueError("offset must be provided for analogy mode")
+            query = query + offset
+
         if isinstance(self.store, AsyncFaissVectorStore):
             import asyncio
 

--- a/tests/test_analogical_retrieval.py
+++ b/tests/test_analogical_retrieval.py
@@ -1,0 +1,45 @@
+import unittest
+import torch
+
+from asi.hierarchical_memory import HierarchicalMemory
+from asi.analogical_retrieval import analogy_offset, apply_analogy, analogy_search
+
+
+class TestAnalogicalRetrieval(unittest.TestCase):
+    def test_offset_and_apply(self):
+        a = torch.tensor([1.0, 0.0, 0.0])
+        b = torch.tensor([0.0, 1.0, 0.0])
+        off = analogy_offset(a, b)
+        torch.testing.assert_close(off, torch.tensor([-1.0, 1.0, 0.0]))
+        q = torch.tensor([1.0, 0.0, 1.0])
+        out = apply_analogy(q, off)
+        torch.testing.assert_close(out, torch.tensor([0.0, 1.0, 1.0]))
+
+    def test_memory_analogy_search(self):
+        mem = HierarchicalMemory(dim=3, compressed_dim=3, capacity=10)
+        # identity autoencoder for reproducibility
+        mem.compressor.encoder.weight.data.copy_(torch.eye(3))
+        mem.compressor.encoder.bias.data.zero_()
+        mem.compressor.decoder.weight.data.copy_(torch.eye(3))
+        mem.compressor.decoder.bias.data.zero_()
+
+        vectors = {
+            "man": torch.tensor([1.0, 0.0, 0.0]),
+            "woman": torch.tensor([0.0, 1.0, 0.0]),
+            "king": torch.tensor([1.0, 0.0, 1.0]),
+            "queen": torch.tensor([0.0, 1.0, 1.0]),
+        }
+        for k, v in vectors.items():
+            mem.add(v, metadata=[k])
+
+        off = analogy_offset(vectors["man"], vectors["woman"])
+        vec, meta = mem.search(vectors["king"], k=1, mode="analogy", offset=off)
+        self.assertEqual(meta[0], "queen")
+
+        # shortcut helper
+        vec2, meta2 = analogy_search(mem, vectors["king"], vectors["man"], vectors["woman"], k=1)
+        self.assertEqual(meta2[0], "queen")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `asi.analogical_retrieval` for analogy vector arithmetic
- extend `HierarchicalMemory.search()` with `mode="analogy"`
- add tests for analogical retrieval
- document analogy evaluation in `docs/Plan.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68686b8c3fac8331a5b96a58004c2274