### PR TITLE
Add energy-aware scheduler

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -706,6 +706,10 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   counters and reports kWh and CO₂ emissions. `TelemetryLogger` can start this
   tracker and `ComputeBudgetTracker` now exposes per-run carbon usage.
   **Implemented in `src/carbon_tracker.py` with tests.**
+- Introduce an `EnergyAwareScheduler` that queries `TelemetryLogger.get_carbon_intensity()`
+  and delays or migrates jobs when the value exceeds a threshold. Enable it by
+  passing `energy_scheduler=True` to `AdaptiveScheduler`. It complements the
+  existing `BudgetAwareScheduler` for compute-aware training.
 - Add an `AdaptiveMicroBatcher` that monitors GPU memory via `TelemetryLogger`
   and adjusts micro-batch sizes automatically. `DistributedTrainer` and
   `EdgeRLTrainer` accept it through the optional `micro_batcher` argument.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -232,6 +232,7 @@ from .graph_ui import GraphUI
 from .collaborative_healing import CollaborativeHealingLoop
 from .compute_budget_tracker import ComputeBudgetTracker
 from .budget_aware_scheduler import BudgetAwareScheduler
+from .energy_aware_scheduler import EnergyAwareScheduler
 from .doc_summarizer import summarize_module
 
 from .hpc_scheduler import submit_job, monitor_job, cancel_job

--- a/src/adaptive_scheduler.py
+++ b/src/adaptive_scheduler.py
@@ -41,7 +41,24 @@ class AdaptiveScheduler:
         check_interval: float = 1.0,
         window: int = 3,
         min_improvement: float = 0.01,
+        *,
+        energy_scheduler: bool = False,
+        intensity_threshold: float = 0.5,
     ) -> None:
+        if energy_scheduler and type(self) is AdaptiveScheduler:
+            from .energy_aware_scheduler import EnergyAwareScheduler
+            self.__class__ = EnergyAwareScheduler
+            EnergyAwareScheduler.__init__(
+                self,
+                budget,
+                run_id,
+                max_mem=max_mem,
+                check_interval=check_interval,
+                window=window,
+                min_improvement=min_improvement,
+                intensity_threshold=intensity_threshold,
+            )
+            return
         self.budget = budget
         self.run_id = run_id
         self.telemetry: TelemetryLogger = budget.telemetry

--- a/src/energy_aware_scheduler.py
+++ b/src/energy_aware_scheduler.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable
+
+try:  # pragma: no cover - optional torch dependency
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - allow running without torch
+    class _DummyCuda:
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+        @staticmethod
+        def memory_allocated() -> int:
+            return 0
+
+        @staticmethod
+        def get_device_properties(_: int):
+            class _P:
+                total_memory = 1
+            return _P()
+
+    torch = type("torch", (), {"cuda": _DummyCuda})()  # type: ignore
+
+from .adaptive_scheduler import AdaptiveScheduler
+
+
+class EnergyAwareScheduler(AdaptiveScheduler):
+    """Pause or migrate jobs when carbon intensity is high."""
+
+    def __init__(
+        self,
+        budget,
+        run_id: str,
+        max_mem: float = 0.9,
+        check_interval: float = 1.0,
+        window: int = 3,
+        min_improvement: float = 0.01,
+        intensity_threshold: float = 0.5,
+    ) -> None:
+        super().__init__(
+            budget,
+            run_id,
+            max_mem=max_mem,
+            check_interval=check_interval,
+            window=window,
+            min_improvement=min_improvement,
+        )
+        self.intensity_threshold = intensity_threshold
+        self.queue: list[tuple[Callable[[], None], float, str | None]] = []
+
+    # --------------------------------------------------------------
+    def add(self, job: Callable[[], None], region: str | None = None) -> None:
+        cost = self.telemetry.get_carbon_intensity(region)
+        self.queue.append((job, cost, region))
+
+    # --------------------------------------------------------------
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            if not self.queue:
+                time.sleep(self.check_interval)
+                continue
+            if self._should_pause():
+                time.sleep(self.check_interval)
+                continue
+            mem = (
+                torch.cuda.memory_allocated() / torch.cuda.get_device_properties(0).total_memory
+                if torch.cuda.is_available()
+                else 0.0
+            )
+            if mem < self.max_mem:
+                idx = min(range(len(self.queue)), key=lambda i: self.queue[i][1])
+                job, _, region = self.queue.pop(idx)
+                intensity = self.telemetry.get_carbon_intensity(region)
+                if intensity > self.intensity_threshold:
+                    data = self.telemetry.carbon_data or {"default": intensity}
+                    best = min(data, key=lambda r: self.telemetry.get_carbon_intensity(r))
+                    best_cost = self.telemetry.get_carbon_intensity(best)
+                    self.queue.append((job, best_cost, best))
+                    time.sleep(self.check_interval)
+                    continue
+                res = job()
+                if isinstance(res, (int, float)):
+                    self.record_improvement(float(res))
+            else:
+                time.sleep(self.check_interval)
+        self.budget.stop()
+
+
+__all__ = ["EnergyAwareScheduler"]

--- a/tests/test_energy_aware_scheduler.py
+++ b/tests/test_energy_aware_scheduler.py
@@ -1,0 +1,70 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import time
+import unittest
+
+# stub torch
+torch_stub = types.SimpleNamespace(
+    cuda=types.SimpleNamespace(
+        utilization=lambda: 0.0,
+        is_available=lambda: False,
+        memory_allocated=lambda: 0,
+        get_device_properties=lambda _: types.SimpleNamespace(total_memory=1),
+    )
+)
+sys.modules['torch'] = torch_stub
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+TelemetryLogger = _load('asi.telemetry', 'src/telemetry.py').TelemetryLogger
+ComputeBudgetTracker = _load('asi.compute_budget_tracker', 'src/compute_budget_tracker.py').ComputeBudgetTracker
+EnergyAwareScheduler = _load('asi.energy_aware_scheduler', 'src/energy_aware_scheduler.py').EnergyAwareScheduler
+AdaptiveScheduler = _load('asi.adaptive_scheduler', 'src/adaptive_scheduler.py').AdaptiveScheduler
+
+
+class TestEnergyAwareScheduler(unittest.TestCase):
+    def test_delay(self):
+        logger = TelemetryLogger(interval=0.05, carbon_data={'default': 1.0})
+        tracker = ComputeBudgetTracker(1.0, telemetry=logger)
+        sched = EnergyAwareScheduler(tracker, 'run', check_interval=0.05, intensity_threshold=0.5)
+        ran = []
+
+        def job():
+            ran.append(1)
+
+        sched.add(job)
+        time.sleep(0.2)
+        sched.stop()
+        self.assertEqual(len(ran), 0)
+
+    def test_migrate_via_adaptive(self):
+        logger = TelemetryLogger(interval=0.05, carbon_data={'US': 1.0, 'EU': 0.1})
+        tracker = ComputeBudgetTracker(1.0, telemetry=logger)
+        sched = AdaptiveScheduler(tracker, 'run', check_interval=0.05, energy_scheduler=True, intensity_threshold=0.5)
+        self.assertIsInstance(sched, EnergyAwareScheduler)
+        ran = []
+
+        def job():
+            ran.append(1)
+
+        sched.add(job, region='US')
+        time.sleep(0.3)
+        sched.stop()
+        self.assertEqual(len(ran), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `EnergyAwareScheduler` for carbon-aware job control
- enable via `AdaptiveScheduler(..., energy_scheduler=True)`
- expose new scheduler in package
- document usage alongside budget scheduler
- test behaviour

## Testing
- `python -m unittest tests.test_memory_event_detector tests.test_carbon_tracker tests.test_compute_budget_tracker tests.test_adaptive_scheduler tests.test_budget_aware_scheduler tests.test_energy_aware_scheduler -v`

------
https://chatgpt.com/codex/tasks/task_e_686886ed59ac83318797363f5053bb6f