### PR TITLE
Add counterfactual simulation helper

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -556,6 +556,10 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Implement a `FederatedMemoryExchange` service that synchronizes vectors across multiple `MemoryServer` nodes. Provide a `scripts/federated_memory_sync.py` utility to benchmark cross-node synchronization throughput. **Implemented in `src/federated_memory_exchange.py` with the benchmarking script `scripts/federated_memory_sync.py`.**
 - Create a `CausalGraphLearner` module that infers directed relations from `world_model_rl` transitions and logs the resulting edges for planning. **Implemented in `src/causal_graph_learner.py`.**
 - Develop a `CausalReasoner` that combines `CausalGraphLearner` with `NeuroSymbolicExecutor` to plan actions along learned cause–effect chains. **Implemented in `src/causal_reasoner.py` with tests.**
+- Extend `world_model_rl` with `simulate_counterfactual()` which consults the
+  learned graph to adjust predicted transitions for hypothetical interventions.
+  This improves planning accuracy by allowing the reasoner to explore "what-if"
+  scenarios. See `scripts/causal_sim.py` for an example.
 - Add a `SelfAlignmentEvaluator` to `eval_harness.py` that runs `deliberative_alignment.check_alignment()` on generated outputs and reports the metrics alongside existing benchmarks. **Implemented as `_eval_self_alignment()` in `src/eval_harness.py`.**
 - Add an `ActiveDataSelector` to `data_ingest.py` that scores incoming triples by predictive entropy and filters out low-information samples before storage. **Implemented in `data_ingest.ActiveDataSelector`.**
 - Implement a `FederatedMemoryServer` variant that replicates vector stores across peers using gRPC streaming consensus for decentralized retrieval. The server now includes a `Sync` RPC implementing CRDT merge semantics so replicas converge after partitions. **Implemented in `src/federated_memory_server.py`.**

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -280,6 +280,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 28. **Causal graph learner**: Train `CausalGraphLearner` on `world_model_rl`
     transitions and report planning gains from the inferred edges.
     *Implemented in `src/causal_graph_learner.py`.*
+29. **Counterfactual simulation**: Use `world_model_rl.simulate_counterfactual()`
+    with edges from `CausalGraphLearner` to evaluate hypothetical actions and
+    refine plans. *Implemented in `src/world_model_rl.py` with
+    `scripts/causal_sim.py`.*
 29. **Structured knowledge graph memory**: Store facts as triples in a `KnowledgeGraphMemory` and retrieve them through `HierarchicalMemory` for better planning context.
     The new `GraphNeuralReasoner` loads these triples and predicts missing relations so `HierarchicalPlanner.query_relation()` can infer edges not explicitly stored.
     `KnowledgeGraphMemory` now records optional timestamps per triple and supports temporal range queries for time-sensitive reasoning.

--- a/scripts/causal_sim.py
+++ b/scripts/causal_sim.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Example demonstrating counterfactual planning."""
+
+from __future__ import annotations
+
+import argparse
+import torch
+
+from asi.world_model_rl import (
+    RLBridgeConfig,
+    TransitionDataset,
+    train_world_model,
+    simulate_counterfactual,
+)
+from asi.causal_graph_learner import CausalGraphLearner
+
+
+def build_dataset() -> TransitionDataset:
+    data = []
+    for i in range(5):
+        s = torch.tensor([float(i), float(i)])
+        a = 0
+        ns = s + torch.tensor([1.0, 0.5])
+        r = float(i)
+        data.append((s, a, ns, r))
+    return TransitionDataset(data)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Counterfactual simulation example")
+    parser.parse_args(argv)
+
+    cfg = RLBridgeConfig(state_dim=2, action_dim=1, epochs=1, batch_size=2)
+    dataset = build_dataset()
+    learner = CausalGraphLearner()
+    model = train_world_model(cfg, dataset, learner=learner)
+
+    state = torch.tensor([0.0, 0.0])
+    action = torch.tensor(0)
+    next_state, _ = simulate_counterfactual(model, learner, state, action, {0: 2.0})
+    print("Predicted next state with intervention:", next_state.tolist())
+    print("Learned edges:", learner.edges())
+
+
+if __name__ == "__main__":  # pragma: no cover - example CLI
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -90,6 +90,7 @@ from .world_model_rl import (
     train_world_model as train_rl_world_model,
     train_with_self_play,
     rollout_policy,
+    simulate_counterfactual,
 )
 from .embodied_calibration import (
     CalibrationConfig,

--- a/src/world_model_rl.py
+++ b/src/world_model_rl.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Iterable, Any
+from typing import Callable, Iterable, Any, Dict
 
 try:
     from .self_play_env import SimpleEnv
@@ -45,6 +45,7 @@ from torch import nn
 from torch.utils.data import DataLoader, Dataset
 
 from .compute_budget_tracker import ComputeBudgetTracker
+from .causal_graph_learner import CausalGraphLearner
 try:
     from .budget_aware_scheduler import BudgetAwareScheduler
 except Exception:  # pragma: no cover - for tests
@@ -104,6 +105,7 @@ def train_world_model(
     pbm: "PrivacyBudgetManager | None" = None,
     run_id: str = "default",
     budget: ComputeBudgetTracker | None = None,
+    learner: CausalGraphLearner | None = None,
 ) -> WorldModel:
     model = WorldModel(cfg)
     scheduler = (
@@ -140,6 +142,12 @@ def train_world_model(
     if pbm is not None and dp_cfg is not None:
         eps = dp_cfg.noise_std * len(dataset) / cfg.batch_size
         pbm.consume(run_id, eps, 0.0)
+    if learner is not None:
+        transitions = [
+            (s.numpy(), int(a), ns.numpy())
+            for s, a, ns, _r in dataset
+        ]
+        learner.fit(transitions)
     return model
 
 
@@ -156,6 +164,43 @@ def rollout_policy(model: WorldModel, policy: Callable[[torch.Tensor], torch.Ten
             rewards.append(float(reward.item()))
             state = next_state
     return states, rewards
+
+
+def simulate_counterfactual(
+    model: WorldModel,
+    learner: CausalGraphLearner,
+    state: torch.Tensor,
+    action: torch.Tensor,
+    interventions: Dict[int, float],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Predict ``next_state`` and ``reward`` after intervening on ``state``.
+
+    ``interventions`` maps state dimension indices to new values. The effect on
+    other dimensions is approximated using the causal edges learned by
+    ``learner``.
+    """
+
+    device = next(model.parameters()).device
+    state = state.to(device)
+    action = action.to(device)
+    with torch.no_grad():
+        base_next, reward = model(state, action)
+        if learner.adj is None:
+            return base_next, reward
+        delta = torch.zeros_like(base_next)
+        for src, val in interventions.items():
+            if src >= learner.adj.shape[0]:
+                continue
+            diff = val - state[src]
+            for dst in range(learner.adj.shape[1]):
+                w = float(learner.adj[src, dst])
+                if w != 0.0:
+                    delta[dst] += diff * w
+        counter_next = base_next + delta
+        for idx, val in interventions.items():
+            if idx < counter_next.shape[0]:
+                counter_next[idx] = val
+        return counter_next, reward
 
 
 def train_with_self_play(
@@ -224,4 +269,5 @@ __all__ = [
     "train_world_model",
     "train_with_self_play",
     "rollout_policy",
+    "simulate_counterfactual",
 ]

--- a/tests/test_simulate_counterfactual.py
+++ b/tests/test_simulate_counterfactual.py
@@ -1,0 +1,47 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import torch
+
+# prepare asi package
+pkg = types.ModuleType('asi')
+sys.modules.setdefault('asi', pkg)
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    return mod
+
+CausalGraphLearner = _load('asi.causal_graph_learner', 'src/causal_graph_learner.py').CausalGraphLearner
+wm_mod = _load('asi.world_model_rl', 'src/world_model_rl.py')
+RLBridgeConfig = wm_mod.RLBridgeConfig
+TransitionDataset = wm_mod.TransitionDataset
+train_world_model = wm_mod.train_world_model
+simulate_counterfactual = wm_mod.simulate_counterfactual
+
+
+class TestSimulateCounterfactual(unittest.TestCase):
+    def test_counterfactual(self):
+        cfg = RLBridgeConfig(state_dim=2, action_dim=1, epochs=1, batch_size=1)
+        data = []
+        for i in range(2):
+            s = torch.tensor([float(i), float(i)])
+            ns = s + 1
+            data.append((s, 0, ns, 0.0))
+        ds = TransitionDataset(data)
+        learner = CausalGraphLearner()
+        model = train_world_model(cfg, ds, learner=learner)
+        s = torch.tensor([0.0, 0.0])
+        a = torch.tensor(0)
+        ns, r = simulate_counterfactual(model, learner, s, a, {0: 1.0})
+        self.assertEqual(ns.shape[0], 2)
+        self.assertIsInstance(r.item(), float)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `world_model_rl.train_world_model` with causal graph logging
- add `simulate_counterfactual` helper
- expose new helper in package init
- provide `scripts/causal_sim.py` example
- document counterfactual reasoning improvements
- add unit test for counterfactual simulation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686886efda788331bc4ec1d592912e31