### PR TITLE
Add cross-lingual analogy search

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -593,6 +593,7 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Implement a `ContextSummaryMemory` that replaces far-past vectors with text summaries and re-expands them when retrieved. Unit test `tests/test_context_summary_memory.py` verifies summarization and expansion.
   **Implemented in `src/context_summary_memory.py` with tests.**
 - Extend `ContextSummaryMemory` with a `translator` argument so summaries are stored in multiple languages and returned in the query language. Tested in `tests/test_cross_lingual_summary_memory.py`.
+- Extend `analogical_retrieval.analogy_search` with a `language` argument and update `HierarchicalMemory.search(mode="analogy")` so `ContextSummaryMemory` can return translated vectors. Tested in `tests/test_cross_lingual_analogy.py`.
 - Implement a `KnowledgeGraphMemory` that stores `(subject, predicate, object)` triples and hooks into `HierarchicalMemory` via `use_kg=True`. Unit tests cover insertion and retrieval.
   **Implemented in `src/knowledge_graph_memory.py` with `tests/test_knowledge_graph_memory.py`.**
 - Implement a `FederatedKGMemoryServer` that replicates `KnowledgeGraphMemory` across peers using CRDT-based updates. Endpoints `Push`, `PushBatch`, `Query` and `Sync` ensure replicas converge after partitions.

--- a/src/analogical_retrieval.py
+++ b/src/analogical_retrieval.py
@@ -1,5 +1,32 @@
 import torch
-from typing import Tuple
+from typing import Tuple, List, Any, TYPE_CHECKING
+
+from .data_ingest import CrossLingualTranslator
+from .cross_lingual_memory import _embed_text
+
+if TYPE_CHECKING:  # pragma: no cover - import for type hints
+    from .hierarchical_memory import HierarchicalMemory
+
+
+def _to_vec(
+    item: torch.Tensor | str | Tuple[str, str],
+    memory: "HierarchicalMemory",
+    translator: CrossLingualTranslator | None,
+    default_lang: str | None,
+) -> torch.Tensor:
+    """Return embedding for ``item`` using ``translator`` if needed."""
+    if isinstance(item, torch.Tensor):
+        return item
+    text: str
+    lang: str | None = default_lang
+    if isinstance(item, tuple):
+        text, lang = item
+    else:
+        text = item
+    if translator is not None and lang is not None:
+        text = translator.translate(text, lang)
+    dim = memory.compressor.encoder.in_features
+    return _embed_text(text, dim)
 
 
 def analogy_offset(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
@@ -16,24 +43,40 @@ def apply_analogy(query: torch.Tensor, offset: torch.Tensor) -> torch.Tensor:
     return query + offset
 
 
-def analogy_vector(query: torch.Tensor, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+def analogy_vector(
+    query: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+) -> torch.Tensor:
     """Return the vector for ``query : a :: ? : b`` using ``b - a``."""
     return apply_analogy(query, analogy_offset(a, b))
 
 
 def analogy_search(
     memory: "HierarchicalMemory",
-    query: torch.Tensor,
-    a: torch.Tensor,
-    b: torch.Tensor,
+    query: torch.Tensor | str | Tuple[str, str],
+    a: torch.Tensor | str | Tuple[str, str],
+    b: torch.Tensor | str | Tuple[str, str],
     k: int = 5,
-    **kwargs,
-):
-    """Shortcut for analogy retrieval through ``HierarchicalMemory``."""
-    from .hierarchical_memory import HierarchicalMemory  # circular import
+    *,
+    language: str | None = None,
+    **kwargs: Any,
+) -> Tuple[torch.Tensor, List[Any]]:
+    """Shortcut for analogy retrieval through ``HierarchicalMemory``.
 
-    offset = analogy_offset(a, b)
-    return memory.search(query, k=k, mode="analogy", offset=offset, **kwargs)
+    ``query``, ``a`` and ``b`` may be strings or ``(text, lang)`` tuples.
+    If a ``CrossLingualTranslator`` is attached to ``memory`` the strings are
+    translated before embedding.
+    """
+
+    translator = getattr(memory, "translator", None)
+    q_vec = _to_vec(query, memory, translator, language)
+    a_vec = _to_vec(a, memory, translator, language)
+    b_vec = _to_vec(b, memory, translator, language)
+    offset = analogy_offset(a_vec, b_vec)
+    return memory.search(
+        q_vec, k=k, mode="analogy", offset=offset, language=language, **kwargs
+    )
 
 
 __all__ = [

--- a/src/context_summary_memory.py
+++ b/src/context_summary_memory.py
@@ -48,7 +48,7 @@ class ContextSummaryMemory(HierarchicalMemory):
     def search(
         self, query: torch.Tensor, k: int = 5, language: str | None = None
     ) -> Tuple[torch.Tensor, List[Any]]:  # type: ignore[override]
-        vecs, meta = super().search(query, k)
+        vecs, meta = super().search(query, k, language=language)
         new_vecs = []
         out_meta: List[Any] = []
         for v, m in zip(vecs, meta):

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -401,6 +401,7 @@ class HierarchicalMemory:
         *,
         mode: str = "standard",
         offset: torch.Tensor | None = None,
+        language: str | None = None,
     ) -> Tuple[torch.Tensor, List[Any]] | Tuple[torch.Tensor, List[Any], List[float], List[Any]]:
         """Retrieve top-k decoded vectors and their metadata.
 
@@ -499,7 +500,13 @@ class HierarchicalMemory:
         return vecs, meta, triples
 
     async def asearch(
-        self, query: torch.Tensor, k: int = 5, return_scores: bool = False, return_provenance: bool = False
+        self,
+        query: torch.Tensor,
+        k: int = 5,
+        return_scores: bool = False,
+        return_provenance: bool = False,
+        *,
+        language: str | None = None,
     ) -> Tuple[torch.Tensor, List[Any]] | Tuple[torch.Tensor, List[Any], List[float], List[Any]]:
         """Asynchronously retrieve vectors and metadata."""
         if self.cache is not None:

--- a/tests/test_cross_lingual_analogy.py
+++ b/tests/test_cross_lingual_analogy.py
@@ -1,0 +1,49 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import unittest
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+
+di = load('asi.data_ingest', 'src/data_ingest.py')
+clm = load('asi.cross_lingual_memory', 'src/cross_lingual_memory.py')
+ar = load('asi.analogical_retrieval', 'src/analogical_retrieval.py')
+
+CrossLingualTranslator = di.CrossLingualTranslator
+CrossLingualMemory = clm.CrossLingualMemory
+analogy_search = ar.analogy_search
+
+
+class TestCrossLingualAnalogy(unittest.TestCase):
+    def test_retrieval_across_languages(self):
+        tr = CrossLingualTranslator(['es'])
+        mem = CrossLingualMemory(dim=4, compressed_dim=2, capacity=10, translator=tr)
+        words = ['man', 'woman', 'king', 'queen']
+        mem.add_texts(words, metadata=words)
+        vecs, meta = analogy_search(
+            mem,
+            ('king', 'en'),
+            ('man', 'en'),
+            ('woman', 'es'),
+            k=1
+        )
+        self.assertEqual(len(meta), 1)
+        self.assertIn(meta[0], ['queen', '[es] queen'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enable analogy_search to translate textual queries
- allow HierarchicalMemory.search to accept a language option
- propagate language to ContextSummaryMemory
- test cross-lingual analogies
- document cross-lingual analogy capability

## Testing
- `pytest -q tests/test_cross_lingual_analogy.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest -q` *(fails: 124 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686886f0ac3c8331afe93ff091592ec4