### PR TITLE
Add weight-based data selector

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -297,9 +297,11 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     decentralized retrieval. The service now exposes a `Sync` RPC and uses
     CRDT update rules so that multiple servers converge on identical vector
     stores after exchanging updates.
-31. **Active data selection**: Add an `ActiveDataSelector` to score incoming
-    triples by predictive entropy and keep only high-information samples.
-    *Implemented in `data_ingest.ActiveDataSelector`.*
+31. **Active data selection**: `ActiveDataSelector` now outputs continuous
+    sample weights based on predictive entropy and down-weights biased
+    examples using `dataset_bias_detector`. A new `SampleWeightRL` loop
+    updates the weights online during training. *Implemented in
+    `data_ingest.ActiveDataSelector` and `adaptive_curriculum.SampleWeightRL`.*
 32. **Hierarchical graph planner**: Combine `GraphOfThought` with
     `world_model_rl.rollout_policy` to generate multi-stage plans for
     refactoring and exploration.

--- a/src/adaptive_curriculum.py
+++ b/src/adaptive_curriculum.py
@@ -54,4 +54,24 @@ class AdaptiveCurriculum:
             self.prefs[i] += self.cfg.lr * grad
 
 
-__all__ = ["CurriculumConfig", "AdaptiveCurriculum"]
+class SampleWeightRL:
+    """REINFORCE loop to adapt sample weights during training."""
+
+    def __init__(self, num_samples: int, lr: float = 0.1) -> None:
+        self.prefs = torch.zeros(num_samples, dtype=torch.float32)
+        self.lr = lr
+        self.baseline = 0.0
+
+    def weights(self) -> torch.Tensor:
+        return torch.softmax(self.prefs, dim=0)
+
+    def update(self, idx: int, reward: float) -> None:
+        probs = self.weights()
+        self.baseline += self.lr * (reward - self.baseline)
+        adv = reward - self.baseline
+        for i in range(len(self.prefs)):
+            grad = adv * ((1 if i == idx else 0) - probs[i])
+            self.prefs[i] += self.lr * grad
+
+
+__all__ = ["CurriculumConfig", "AdaptiveCurriculum", "SampleWeightRL"]

--- a/tests/test_active_data_selector.py
+++ b/tests/test_active_data_selector.py
@@ -1,17 +1,43 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
 import unittest
 import numpy as np
-from asi.data_ingest import ActiveDataSelector
+import tempfile
+from pathlib import Path
 
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+loader_bias = importlib.machinery.SourceFileLoader(
+    'asi.dataset_bias_detector', 'src/dataset_bias_detector.py'
+)
+spec_bias = importlib.util.spec_from_loader(loader_bias.name, loader_bias)
+bias_mod = importlib.util.module_from_spec(spec_bias)
+sys.modules['asi.dataset_bias_detector'] = bias_mod
+loader_bias.exec_module(bias_mod)
+
+loader = importlib.machinery.SourceFileLoader('asi.data_ingest', 'src/data_ingest.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+data_ingest = importlib.util.module_from_spec(spec)
+sys.modules['asi.data_ingest'] = data_ingest
+loader.exec_module(data_ingest)
+ActiveDataSelector = data_ingest.ActiveDataSelector
 
 class TestActiveDataSelector(unittest.TestCase):
-    def test_select(self):
-        selector = ActiveDataSelector(threshold=0.5)
-        triples = [("t", "i", "a"), ("t2", "i2", "a2")]
-        probs = [np.array([0.5, 0.5]), np.array([0.9, 0.1])]
-        kept = selector.select(triples, probs)
-        self.assertEqual(len(kept), 1)
-        self.assertEqual(kept[0][0], "t")
+    def test_select_weights(self):
+        selector = ActiveDataSelector(threshold=1.0)
+        with tempfile.TemporaryDirectory() as d:
+            p1 = Path(d) / 'a.txt'
+            p2 = Path(d) / 'b.txt'
+            p1.write_text('alpha beta gamma delta')
+            p2.write_text('hello hello hello hello')
+            triples = [(p1, 'i', 'a'), (p2, 'i2', 'a2')]
+            probs = [np.array([0.5, 0.5]), np.array([0.5, 0.5])]
+            weights = selector.select(triples, probs)
+            self.assertEqual(len(weights), 2)
+            self.assertGreater(weights[0][1], weights[1][1])
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sample_weight_rl.py
+++ b/tests/test_sample_weight_rl.py
@@ -1,0 +1,28 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+import unittest
+import torch
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+loader = importlib.machinery.SourceFileLoader('asi.adaptive_curriculum', 'src/adaptive_curriculum.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+adaptive_curriculum = importlib.util.module_from_spec(spec)
+sys.modules['asi.adaptive_curriculum'] = adaptive_curriculum
+loader.exec_module(adaptive_curriculum)
+SampleWeightRL = adaptive_curriculum.SampleWeightRL
+
+class TestSampleWeightRL(unittest.TestCase):
+    def test_update_weights(self):
+        rl = SampleWeightRL(2, lr=0.5)
+        before = rl.weights().clone()
+        rl.update(0, 1.0)
+        rl.update(1, -1.0)
+        after = rl.weights()
+        self.assertGreater(after[0].item(), before[0].item())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `ActiveDataSelector` to return weighted samples and factor in dataset bias
- add `SampleWeightRL` reinforcement learner
- test new weighting behaviour and RL update
- document continuous weighting in the plan

## Testing
- `pytest -q tests/test_active_data_selector.py tests/test_adaptive_curriculum.py tests/test_sample_weight_rl.py`

------
https://chatgpt.com/codex/tasks/task_e_686886f1c2848331af59dd695ccd10a5