### PR TITLE
Integrate carbon-aware scheduling

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -706,6 +706,26 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   counters and reports kWh and CO₂ emissions. `TelemetryLogger` can start this
   tracker and `ComputeBudgetTracker` now exposes per-run carbon usage.
   **Implemented in `src/carbon_tracker.py` with tests.**
+
+Short example using the carbon-aware scheduler:
+
+```python
+from asi.telemetry import TelemetryLogger
+from asi.compute_budget_tracker import ComputeBudgetTracker
+from asi.adaptive_scheduler import AdaptiveScheduler
+
+tel = TelemetryLogger(interval=1.0, carbon_tracker=True)
+budget = ComputeBudgetTracker(2.0, telemetry=tel)
+sched = AdaptiveScheduler(budget, "demo")
+
+sched.add(train_step, region="US-east")
+sched.add(eval_step, region="EU-west")
+time.sleep(10)
+sched.stop()
+```
+
+`TelemetryLogger` publishes energy stats to a running
+`ClusterCarbonDashboard` so operators can monitor cluster-wide impact.
 - Add an `AdaptiveMicroBatcher` that monitors GPU memory via `TelemetryLogger`
   and adjusts micro-batch sizes automatically. `DistributedTrainer` and
   `EdgeRLTrainer` accept it through the optional `micro_batcher` argument.

--- a/src/adaptive_scheduler.py
+++ b/src/adaptive_scheduler.py
@@ -49,7 +49,7 @@ class AdaptiveScheduler:
         self.min_improvement = min_improvement
         self.max_mem = max_mem
         self.check_interval = check_interval
-        self.queue: list[tuple[Callable[[], None], float]] = []
+        self.queue: list[tuple[Callable[[], None], str | None]] = []
         self._stop = threading.Event()
         self.thread = threading.Thread(target=self._loop, daemon=True)
         self.budget.start(run_id)
@@ -57,8 +57,8 @@ class AdaptiveScheduler:
 
     # --------------------------------------------------------------
     def add(self, job: Callable[[], None], region: str | None = None) -> None:
-        cost = self.telemetry.get_carbon_intensity(region)
-        self.queue.append((job, cost))
+        """Queue a job with an optional region hint."""
+        self.queue.append((job, region))
 
     # --------------------------------------------------------------
     def record_improvement(self, val: float) -> None:
@@ -90,7 +90,10 @@ class AdaptiveScheduler:
                 else 0.0
             )
             if mem < self.max_mem:
-                idx = min(range(len(self.queue)), key=lambda i: self.queue[i][1])
+                idx = min(
+                    range(len(self.queue)),
+                    key=lambda i: self.telemetry.get_cost_index(self.queue[i][1]),
+                )
                 job, _ = self.queue.pop(idx)
                 res = job()
                 if isinstance(res, (int, float)):

--- a/tests/test_carbon_tracker.py
+++ b/tests/test_carbon_tracker.py
@@ -68,6 +68,15 @@ class TestCarbonTracker(unittest.TestCase):
         self.assertIn('carbon', usage)
         self.assertGreaterEqual(usage['carbon'], 0)
 
+    def test_live_carbon_intensity(self):
+        cft = CarbonFootprintTracker(interval=0.1, co2_per_kwh=50.0)
+        logger = TelemetryLogger(interval=0.1, carbon_tracker=cft)
+        logger.start()
+        time.sleep(0.2)
+        intensity = logger.get_live_carbon_intensity()
+        logger.stop()
+        self.assertAlmostEqual(intensity, 50.0, delta=1e-3)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cluster_carbon_dashboard.py
+++ b/tests/test_cluster_carbon_dashboard.py
@@ -27,10 +27,10 @@ class TestClusterCarbonDashboard(unittest.TestCase):
         dash.start(port=0)
         port = dash.port
         conn = http.client.HTTPConnection('localhost', port)
-        data1 = json.dumps({'node_id': 'n1', 'energy_kwh': 1.0, 'carbon_g': 2.0})
+        data1 = json.dumps({'node_id': 'n1', 'energy_kwh': 1.0, 'carbon_g': 2.0, 'carbon_intensity': 2.0, 'energy_cost': 0.2})
         conn.request('POST', '/update', body=data1)
         conn.getresponse().read()
-        data2 = json.dumps({'node_id': 'n2', 'energy_kwh': 0.5, 'carbon_g': 1.0})
+        data2 = json.dumps({'node_id': 'n2', 'energy_kwh': 0.5, 'carbon_g': 1.0, 'carbon_intensity': 1.0, 'energy_cost': 0.1})
         conn.request('POST', '/update', body=data2)
         conn.getresponse().read()
         conn.request('GET', '/stats')
@@ -39,6 +39,7 @@ class TestClusterCarbonDashboard(unittest.TestCase):
         dash.stop()
         self.assertEqual(stats['total']['energy_kwh'], 1.5)
         self.assertEqual(stats['nodes']['n1']['carbon_g'], 2.0)
+        self.assertIn('energy_cost', stats['total'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- enhance `TelemetryLogger` with live carbon metrics and cost estimation
- update `ClusterCarbonDashboard` to show cost and intensity
- read per-node carbon data in `AdaptiveScheduler`
- document carbon-aware scheduling usage
- add regression tests for carbon tracker and dashboard

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_686886f58cf483319fe40a4bcaf97ea9