### PR TITLE
Add interactive GraphUI

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -688,6 +688,10 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Add `self_reflect()` to `GraphOfThought` which outputs a concise summary of
   reasoning steps. `ReasoningHistoryLogger` stores these summaries with
   timestamps for later inspection.
+- `GraphUI` exposes `/graph/node`, `/graph/edge`, `/graph/remove_*` and
+  `/graph/recompute` so reasoning graphs can be edited interactively. Each edit
+  records a new summary via `ReasoningHistoryLogger`. The script
+  `scripts/graph_playground.py` launches this playground.
 - Provide a `ResourceBroker` module coordinating multiple clusters and a demo
   script `scripts/resource_broker_demo.py`. The broker now reports per-accelerator
   utilisation via `get_load()` and allows allocating jobs to specific

--- a/scripts/graph_playground.py
+++ b/scripts/graph_playground.py
@@ -1,0 +1,29 @@
+import argparse
+import time
+from asi.graph_of_thought import GraphOfThought
+from asi.reasoning_history import ReasoningHistoryLogger
+from asi.graph_ui import GraphUI
+
+
+def main(port: int) -> None:
+    graph = GraphOfThought()
+    a = graph.add_step("start")
+    b = graph.add_step("finish")
+    graph.connect(a, b)
+    logger = ReasoningHistoryLogger()
+    ui = GraphUI(graph, logger)
+    ui.start(port=port)
+    print(f"Graph UI running at http://localhost:{ui.port}/graph")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    ui.stop()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Launch editable graph UI")
+    parser.add_argument("--port", type=int, default=8070)
+    args = parser.parse_args()
+    main(args.port)


### PR DESCRIPTION
## Summary
- extend GraphUI with POST routes to add/remove nodes and edges
- trigger recomputation through `/graph/recompute`
- update tests for new endpoints
- provide demo script `graph_playground.py`
- document editable reasoning graphs in Implementation notes

## Testing
- `pytest tests/test_graph_ui.py -q`
- `pytest -q` *(fails: ModuleNotFoundError and missing heavy deps)*

------
https://chatgpt.com/codex/tasks/task_e_686886f650a48331b95362d7ae160798