### PR TITLE
Add distributed anomaly monitor

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -346,6 +346,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 47. **Adaptive streaming compression**: Add `AdaptiveCompressor` to adjust the compression ratio in `StreamingCompressor` based on retrieval frequency.
 48. **Prompt optimization**: Build a `PromptOptimizer` that learns prompt revisions via reinforcement learning and measure evaluation gains.
 49. **Training anomaly detection**: Extend `SelfHealingTrainer` with a `TrainingAnomalyDetector` to roll back or restart runs when metrics diverge.
+49a. **Distributed anomaly monitoring**: `DistributedAnomalyMonitor` collects per-node anomaly metrics and flags cross-run spikes through `RiskDashboard`.
 50. **Parameter-efficient adaptation**: Explore low-rank fine-tuning across tasks; success is matching baseline accuracy with ≤10% extra parameters.
 51. **Context summarization memory**: Store compressed summaries for distant tokens and re-expand them on demand; success is >95% retrieval accuracy at 100× token length. *Implemented in `src/context_summary_memory.py` with tests.*
 52. **Dataset lineage manager**: Automatically track dataset versions and transformations, enabling reproducible training pipelines. *Implemented in `src/dataset_lineage_manager.py`.*

--- a/scripts/distributed_anomaly_demo.py
+++ b/scripts/distributed_anomaly_demo.py
@@ -1,0 +1,31 @@
+"""Demo of DistributedAnomalyMonitor."""
+
+from __future__ import annotations
+
+import random
+
+from asi.training_anomaly_detector import TrainingAnomalyDetector
+from asi.risk_scoreboard import RiskScoreboard
+from asi.risk_dashboard import RiskDashboard
+from asi.distributed_anomaly_monitor import DistributedAnomalyMonitor
+
+
+def main() -> None:
+    board = RiskScoreboard()
+    dash = RiskDashboard(board, [])
+    detectors = {
+        "node1": TrainingAnomalyDetector(window=2, threshold=1.5),
+        "node2": TrainingAnomalyDetector(window=2, threshold=1.5),
+    }
+    monitor = DistributedAnomalyMonitor(dash, detectors)
+
+    for step in range(5):
+        for node in ("node1", "node2"):
+            loss = random.uniform(0.5, 3.0)
+            monitor.record(node, step, loss)
+
+    print("Aggregated", monitor.aggregate())
+
+
+if __name__ == "__main__":  # pragma: no cover - demo
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -237,6 +237,7 @@ from .doc_summarizer import summarize_module
 from .hpc_scheduler import submit_job, monitor_job, cancel_job
 from .collaboration_portal import CollaborationPortal
 from .cluster_carbon_dashboard import ClusterCarbonDashboard
+from .distributed_anomaly_monitor import DistributedAnomalyMonitor
 from .spiking_layers import LIFNeuron, SpikingLinear
 
 

--- a/src/distributed_anomaly_monitor.py
+++ b/src/distributed_anomaly_monitor.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Any, List
+
+from .training_anomaly_detector import TrainingAnomalyDetector
+from .risk_dashboard import RiskDashboard
+
+
+@dataclass
+class DistributedAnomalyMonitor:
+    """Collect anomaly metrics across training nodes."""
+
+    risk_dashboard: RiskDashboard | None = None
+    detectors: Dict[str, TrainingAnomalyDetector] = field(default_factory=dict)
+    anomaly_counts: Dict[str, int] = field(default_factory=dict)
+    step_events: Dict[int, List[str]] = field(default_factory=dict)
+    cross_run_events: List[Dict[str, Any]] = field(default_factory=list)
+
+    def record(self, node_id: str, step: int, loss: float) -> bool:
+        """Record ``loss`` for ``node_id`` and return ``True`` if anomalous."""
+        det = self.detectors.setdefault(node_id, TrainingAnomalyDetector())
+        anomalous = det.record(loss)
+        if anomalous:
+            self.anomaly_counts[node_id] = self.anomaly_counts.get(node_id, 0) + 1
+            nodes = self.step_events.setdefault(step, [])
+            nodes.append(node_id)
+            if len(nodes) >= 2 and all(e.get("step") != step for e in self.cross_run_events):
+                event = {"step": step, "nodes": list(nodes)}
+                self.cross_run_events.append(event)
+                if self.risk_dashboard is not None:
+                    self.risk_dashboard.scoreboard.metrics["cross_run_anomalies"] = float(
+                        len(self.cross_run_events)
+                    )
+        return anomalous
+
+    def aggregate(self) -> Dict[str, Any]:
+        """Return combined anomaly statistics."""
+        return {
+            "total_anomalies": float(sum(self.anomaly_counts.values())),
+            "per_node": {k: float(v) for k, v in self.anomaly_counts.items()},
+            "cross_run_events": list(self.cross_run_events),
+        }
+
+
+__all__ = ["DistributedAnomalyMonitor"]

--- a/tests/test_distributed_anomaly_monitor.py
+++ b/tests/test_distributed_anomaly_monitor.py
@@ -1,0 +1,56 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+
+stub_hm = types.ModuleType('src.hierarchical_memory')
+class _Mem:
+    def get_stats(self):
+        return {'hit_rate': 0.0}
+stub_hm.MemoryServer = type('MS', (), {'__init__': lambda self,*a,**k: None, 'memory': _Mem(), 'telemetry': None})
+stub_hm.HierarchicalMemory = type('HM', (), {})
+sys.modules['src.hierarchical_memory'] = stub_hm
+
+mods = ['risk_dashboard', 'risk_scoreboard', 'distributed_anomaly_monitor', 'training_anomaly_detector', 'memory_dashboard', 'telemetry', 'memory_service']
+for name in mods:
+    loader = importlib.machinery.SourceFileLoader(f'src.{name}', f'src/{name}.py')
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'src'
+    sys.modules[f'src.{name}'] = mod
+    loader.exec_module(mod)
+
+DistributedAnomalyMonitor = sys.modules['src.distributed_anomaly_monitor'].DistributedAnomalyMonitor
+RiskDashboard = sys.modules['src.risk_dashboard'].RiskDashboard
+RiskScoreboard = sys.modules['src.risk_scoreboard'].RiskScoreboard
+TrainingAnomalyDetector = sys.modules['src.training_anomaly_detector'].TrainingAnomalyDetector
+TelemetryLogger = sys.modules['src.telemetry'].TelemetryLogger
+
+
+class TestDistributedAnomalyMonitor(unittest.TestCase):
+    def test_aggregate_cross_run(self):
+        board = RiskScoreboard()
+        server = type('Stub', (), {'memory': _Mem(), 'telemetry': TelemetryLogger(interval=0.1)})()
+        dash = RiskDashboard(board, [server])
+        detectors = {
+            'n1': TrainingAnomalyDetector(window=2, threshold=1.1),
+            'n2': TrainingAnomalyDetector(window=2, threshold=1.1),
+        }
+        mon = DistributedAnomalyMonitor(dash, detectors)
+        mon.record('n1', 0, 1.0)
+        mon.record('n1', 1, 2.0)
+        mon.record('n2', 0, 1.0)
+        mon.record('n2', 1, 2.0)
+        agg = mon.aggregate()
+        self.assertEqual(agg['per_node']['n1'], 1.0)
+        self.assertEqual(agg['per_node']['n2'], 1.0)
+        self.assertEqual(len(agg['cross_run_events']), 1)
+        self.assertEqual(board.metrics.get('cross_run_anomalies'), 1.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `DistributedAnomalyMonitor` to gather per-node anomalies
- expose cross-run anomalies on the `RiskDashboard`
- add demo script showing usage
- document distributed anomaly monitoring in the plan
- include tests for aggregation logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686886fa555c8331b1676d1cbc2664b9