### PR TITLE
Add carbon aware HPC scheduler

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -418,6 +418,13 @@ The `hpc_scheduler` module wraps `sbatch`, `srun` and `kubectl` so jobs can be l
 `hpc_backend="slurm"` or `"kubernetes"` to `DistributedTrainer` to dispatch workers through the scheduler.  Use `submit_job()` to start a
 task, `monitor_job()` to poll its status, and `cancel_job()` to terminate it.
 
+`carbon_hpc_scheduler.CarbonAwareScheduler` builds on this by querying an external
+carbon-intensity API and tracking energy via `CarbonFootprintTracker`.  Its
+`submit_when_green()` method delays a job until the forecast for the chosen region
+drops below a threshold, while `submit_at_optimal_time()` waits for the lowest
+forecast in the next 24 h.  Both helpers call `submit_job()` once conditions are
+favourable, reducing cluster emissions without manual tuning.
+
 
 
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -235,6 +235,7 @@ from .budget_aware_scheduler import BudgetAwareScheduler
 from .doc_summarizer import summarize_module
 
 from .hpc_scheduler import submit_job, monitor_job, cancel_job
+from .carbon_hpc_scheduler import CarbonAwareScheduler
 from .collaboration_portal import CollaborationPortal
 from .cluster_carbon_dashboard import ClusterCarbonDashboard
 from .spiking_layers import LIFNeuron, SpikingLinear

--- a/src/carbon_hpc_scheduler.py
+++ b/src/carbon_hpc_scheduler.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""Carbon-aware HPC job scheduling utilities."""
+
+from dataclasses import dataclass, field
+import time
+from typing import List, Union
+
+import requests
+
+from .hpc_scheduler import submit_job
+from .carbon_tracker import CarbonFootprintTracker
+
+
+def get_carbon_intensity(region: str | None = None) -> float:
+    """Return current carbon intensity (gCO2/kWh) for ``region``."""
+    url = "https://api.carbonintensity.org.uk/intensity"
+    if region:
+        url = f"https://api.carbonintensity.org.uk/regional/{region}"
+    try:
+        resp = requests.get(url, timeout=2)
+        resp.raise_for_status()
+        data = resp.json()
+        if region:
+            return float(data["data"][0]["data"][0]["intensity"]["forecast"])
+        return float(data["data"][0]["intensity"]["forecast"])
+    except Exception:
+        return 400.0
+
+
+def get_hourly_forecast(region: str | None = None) -> List[float]:
+    """Return a 24h carbon intensity forecast."""
+    url = "https://api.carbonintensity.org.uk/intensity/fw24h"
+    if region:
+        url = f"https://api.carbonintensity.org.uk/regional/{region}/fw24h"
+    try:
+        resp = requests.get(url, timeout=2)
+        resp.raise_for_status()
+        data = resp.json()
+        if region:
+            records = data["data"][0]["data"]
+            return [float(r["intensity"]["forecast"]) for r in records]
+        return [float(r["intensity"]["forecast"]) for r in data["data"]]
+    except Exception:
+        return []
+
+
+@dataclass
+class CarbonAwareScheduler:
+    """Schedule jobs when carbon intensity is low."""
+
+    backend: str = "slurm"
+    region: str | None = None
+    threshold: float = 300.0
+    check_interval: float = 600.0
+    tracker: CarbonFootprintTracker = field(
+        default_factory=lambda: CarbonFootprintTracker(interval=1.0)
+    )
+
+    # --------------------------------------------------
+    def submit_when_green(self, command: Union[str, List[str]]) -> str:
+        """Submit ``command`` once intensity drops below ``threshold``."""
+        self.tracker.start()
+        try:
+            while True:
+                intensity = get_carbon_intensity(self.region)
+                if intensity <= self.threshold:
+                    break
+                time.sleep(self.check_interval)
+            job_id = submit_job(command, backend=self.backend)
+        finally:
+            self.tracker.stop()
+        return job_id
+
+    # --------------------------------------------------
+    def submit_at_optimal_time(
+        self, command: Union[str, List[str]], max_delay: float = 21600.0
+    ) -> str:
+        """Submit at the forecasted lowest-intensity slot within ``max_delay``."""
+        self.tracker.start()
+        try:
+            forecast = get_hourly_forecast(self.region)
+            delay = 0.0
+            if forecast:
+                min_idx = int(min(range(len(forecast)), key=lambda i: forecast[i]))
+                delay = min_idx * 3600.0
+            if delay and delay <= max_delay:
+                time.sleep(delay)
+            job_id = submit_job(command, backend=self.backend)
+        finally:
+            self.tracker.stop()
+        return job_id
+
+
+__all__ = [
+    "get_carbon_intensity",
+    "get_hourly_forecast",
+    "CarbonAwareScheduler",
+]

--- a/src/hpc_scheduler.py
+++ b/src/hpc_scheduler.py
@@ -13,7 +13,10 @@ def submit_job(command: Union[str, List[str]], backend: str = "slurm") -> str:
     else:
         raise ValueError(f"Unknown backend {backend}")
     proc = subprocess.run(cmd, capture_output=True, text=True)
-    proc.check_returncode()
+    if hasattr(proc, "check_returncode"):
+        proc.check_returncode()
+    elif proc.returncode:
+        raise subprocess.CalledProcessError(proc.returncode, cmd, proc.stdout, proc.stderr)
     return proc.stdout.strip()
 
 
@@ -26,7 +29,10 @@ def monitor_job(job_id: str, backend: str = "slurm") -> str:
     else:
         raise ValueError(f"Unknown backend {backend}")
     proc = subprocess.run(cmd, capture_output=True, text=True)
-    proc.check_returncode()
+    if hasattr(proc, "check_returncode"):
+        proc.check_returncode()
+    elif proc.returncode:
+        raise subprocess.CalledProcessError(proc.returncode, cmd, proc.stdout, proc.stderr)
     return proc.stdout.strip()
 
 
@@ -39,7 +45,10 @@ def cancel_job(job_id: str, backend: str = "slurm") -> str:
     else:
         raise ValueError(f"Unknown backend {backend}")
     proc = subprocess.run(cmd, capture_output=True, text=True)
-    proc.check_returncode()
+    if hasattr(proc, "check_returncode"):
+        proc.check_returncode()
+    elif proc.returncode:
+        raise subprocess.CalledProcessError(proc.returncode, cmd, proc.stdout, proc.stderr)
     return proc.stdout.strip()
 
 


### PR DESCRIPTION
## Summary
- implement `carbon_hpc_scheduler` for carbon-aware job submission
- expose `CarbonAwareScheduler` in `asi` package
- update `hpc_scheduler` to handle patched subprocess objects
- document new scheduler in Plan
- test carbon-aware scheduler

## Testing
- `pytest tests/test_carbon_hpc_scheduler.py tests/test_hpc_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686886fdab408331ac4047aac732f97e