### PR TITLE
Introduce FHE runner

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -724,6 +724,12 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 
 `src/edge_rl_trainer.py` trains world models under a compute budget. It checks `ComputeBudgetTracker.remaining()` each step and stops when resources run low. See `scripts/train_edge_rl.py` for a usage example.
 
+`src/fhe_runner.py` provides `run_fhe()` to execute small models with fully
+homomorphic encryption. It relies on the open‑source TenSEAL library and
+supports only 1‑D tensors. Expect substantial overhead (often 100× slower) from
+ciphertext operations and memory usage, so this mode is suitable for toy
+examples rather than large‑scale training.
+
 ### Resource-aware scheduling
 
 `MultiAgentCoordinator` accepts a `ComputeBudgetTracker` instance which tracks GPU hours per agent. `RLNegotiator` considers `tracker.remaining()` when assigning tasks and each action logs usage via `tracker.consume()`. This ensures repositories are processed by agents with sufficient budget.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ pyyaml
 fastapi
 uvicorn
 cryptography
+tenseal
 

--- a/scripts/secure_inference_example.py
+++ b/scripts/secure_inference_example.py
@@ -5,16 +5,34 @@ from __future__ import annotations
 
 import torch
 from asi.enclave_runner import EnclaveRunner
+from asi.fhe_runner import run_fhe
+
+import tenseal as ts
+import argparse
 
 
 def model(x: torch.Tensor) -> torch.Tensor:
     return x + 1
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Enclave inference demo")
+    parser.add_argument("--fhe", action="store_true", help="run model under FHE")
+    args = parser.parse_args(argv)
+
     runner = EnclaveRunner()
     inp = torch.tensor([3.0, 4.0])
-    out = runner.run(model, inp)
+    if args.fhe:
+        ctx = ts.context(
+            ts.SCHEME_TYPE.CKKS,
+            poly_modulus_degree=8192,
+            coeff_mod_bit_sizes=[60, 40, 40, 60],
+        )
+        ctx.generate_galois_keys()
+        ctx.global_scale = 2**40
+        out = runner.run(run_fhe, model, inp, ctx)
+    else:
+        out = runner.run(model, inp)
     print("output", out)
 
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -240,3 +240,4 @@ from .cluster_carbon_dashboard import ClusterCarbonDashboard
 from .spiking_layers import LIFNeuron, SpikingLinear
 
 
+from .fhe_runner import run_fhe

--- a/src/fhe_runner.py
+++ b/src/fhe_runner.py
@@ -1,0 +1,33 @@
+"""Utility to execute simple models using fully homomorphic encryption."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import torch
+
+try:
+    import tenseal as ts  # type: ignore
+    _HAS_TENSEAL = True
+except Exception:  # pragma: no cover - optional dependency
+    ts = None
+    _HAS_TENSEAL = False
+
+
+def run_fhe(model: Callable[[any], any], inputs: torch.Tensor, key: "ts.Context") -> torch.Tensor:
+    """Encrypt ``inputs``, run ``model`` under FHE and decrypt the result."""
+    if not _HAS_TENSEAL:
+        raise ImportError("tenseal is required for run_fhe")
+
+    if inputs.ndim != 1:
+        raise ValueError("only 1D tensors supported")
+
+    enc = ts.ckks_vector(key, inputs.tolist())
+    out_enc = model(enc)
+    if not isinstance(out_enc, ts.CKKSVector):
+        raise TypeError("model must return a CKKSVector")
+    out = torch.tensor(out_enc.decrypt())
+    return out
+
+
+__all__ = ["run_fhe"]

--- a/tests/test_fhe_runner.py
+++ b/tests/test_fhe_runner.py
@@ -1,0 +1,28 @@
+import unittest
+import torch
+import tenseal as ts
+
+from asi.fhe_runner import run_fhe
+
+
+def add_one(x):
+    return x + 1
+
+
+class TestFHERunner(unittest.TestCase):
+    def test_run_fhe(self):
+        ctx = ts.context(
+            ts.SCHEME_TYPE.CKKS,
+            poly_modulus_degree=8192,
+            coeff_mod_bit_sizes=[60, 40, 40, 60],
+        )
+        ctx.generate_galois_keys()
+        ctx.global_scale = 2**40
+        inp = torch.tensor([1.0, 2.0])
+        out = run_fhe(add_one, inp, ctx)
+        exp = torch.tensor([2.0, 3.0])
+        self.assertTrue(torch.allclose(out, exp, atol=1e-3))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `run_fhe` helper built on TenSEAL
- expose it via the package init
- allow encrypted inference via a new flag in the secure inference example
- document overhead of FHE and list `tenseal` in requirements
- test simple encrypted execution

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686886ff04148331adb404be110c7f78