### PR TITLE
Add optional Loihi backend

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -84,6 +84,14 @@ To build the kernel yourself:
 
 After installation, the wrapper will automatically call the optimized kernel.
 
+## Neuromorphic Execution
+
+`src/loihi_backend.py` wraps optional calls into Intel's Loihi SDK. When
+`_HAS_LOIHI` is `True`, `LIFNeuron` and `SpikingLinear` offload their
+computations via `loihi_backend`. Enable this by installing the NxSDK and
+setting `use_loihi=True` on those modules or via
+`MultiModalWorldModelConfig.use_spiking`.
+
 ## S-3 Scaling-law Breakpoint Model
 
 `src/scaling_law.py` defines ``BreakpointScalingLaw`` which fits a piecewise

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -155,7 +155,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
   inject them into existing models.
 - `src/spiking_layers.py` defines `LIFNeuron` and `SpikingLinear`. Set
   `use_spiking=True` in `MultiModalWorldModelConfig` to replace MLP blocks with
-  these energy-efficient neurons.
+  these energy-efficient neurons. When the optional Loihi SDK is installed,
+  enable `use_loihi=True` to run them on neuromorphic hardware via
+  `src/loihi_backend.py`.
 - `src/cross_modal_fusion.py` encodes text, images and audio in a shared space
   with a contrastive training helper.
 - `src/multimodal_world_model.py` unifies these embeddings with actions for

--- a/src/loihi_backend.py
+++ b/src/loihi_backend.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import torch
+
+try:
+    import nxsdk.api.n2a as nx  # type: ignore
+    _HAS_LOIHI = True
+except Exception:  # pragma: no cover - optional dependency
+    nx = None  # type: ignore
+    _HAS_LOIHI = False
+
+
+def lif_forward(
+    mem: torch.Tensor,
+    x: torch.Tensor,
+    decay: float,
+    threshold: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run an LIF step on Loihi if available."""
+    if _HAS_LOIHI and hasattr(nx, "lif_forward"):
+        return nx.lif_forward(mem, x, decay=decay, threshold=threshold)  # type: ignore
+    mem = mem * decay + x
+    spk = (mem >= threshold).to(x.dtype)
+    mem = mem - spk * threshold
+    return spk, mem
+
+
+def linear_forward(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Linear transform optionally executed on Loihi."""
+    if _HAS_LOIHI and hasattr(nx, "linear_forward"):
+        return nx.linear_forward(x, weight, bias=bias)  # type: ignore
+    return torch.nn.functional.linear(x, weight, bias)
+
+
+__all__ = ["_HAS_LOIHI", "lif_forward", "linear_forward"]
+

--- a/src/spiking_layers.py
+++ b/src/spiking_layers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import torch
 from torch import nn
 
+from . import loihi_backend
+
 
 class _SpikeFn(torch.autograd.Function):
     @staticmethod
@@ -20,15 +22,19 @@ class _SpikeFn(torch.autograd.Function):
 class LIFNeuron(nn.Module):
     """Simplified leaky integrate-and-fire neuron."""
 
-    def __init__(self, decay: float = 0.9, threshold: float = 1.0) -> None:
+    def __init__(self, decay: float = 0.9, threshold: float = 1.0, *, use_loihi: bool = False) -> None:
         super().__init__()
         self.decay = decay
         self.threshold = threshold
+        self.use_loihi = use_loihi
         self.register_buffer("mem", torch.tensor(0.0))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
         if self.mem.numel() != x.numel() or self.mem.shape != x.shape:
             self.mem = torch.zeros_like(x)
+        if self.use_loihi and loihi_backend._HAS_LOIHI:
+            spk, self.mem = loihi_backend.lif_forward(self.mem, x, self.decay, self.threshold)
+            return spk
         self.mem = self.mem * self.decay + x
         spk = _SpikeFn.apply(self.mem, self.threshold)
         self.mem = self.mem - spk * self.threshold
@@ -49,13 +55,19 @@ class SpikingLinear(nn.Module):
         *,
         decay: float = 0.9,
         threshold: float = 1.0,
+        use_loihi: bool = False,
     ) -> None:
         super().__init__()
         self.linear = nn.Linear(in_features, out_features, bias=bias)
-        self.neuron = LIFNeuron(decay=decay, threshold=threshold)
+        self.use_loihi = use_loihi
+        self.neuron = LIFNeuron(decay=decay, threshold=threshold, use_loihi=use_loihi)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        return self.neuron(self.linear(x))
+        if self.use_loihi and loihi_backend._HAS_LOIHI:
+            out = loihi_backend.linear_forward(x, self.linear.weight, self.linear.bias)
+        else:
+            out = self.linear(x)
+        return self.neuron(out)
 
     def reset_state(self) -> None:
         self.neuron.reset_state()

--- a/tests/test_loihi_backend.py
+++ b/tests/test_loihi_backend.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import patch
+import torch
+
+import asi.spiking_layers as sl
+import asi.loihi_backend as lb
+
+
+class TestLoihiBackend(unittest.TestCase):
+    def test_lif_offload_called(self):
+        with patch.object(lb, '_HAS_LOIHI', True), \
+             patch.object(lb, 'lif_forward', return_value=(torch.tensor([1.0]), torch.tensor([0.0]))) as lf:
+            neuron = sl.LIFNeuron(use_loihi=True)
+            x = torch.tensor([0.5])
+            init_mem = neuron.mem.clone()
+            out = neuron(x)
+            lf.assert_called_with(init_mem, x, neuron.decay, neuron.threshold)
+            self.assertTrue(torch.allclose(out, torch.tensor([1.0])))
+
+    def test_linear_offload_called(self):
+        with patch.object(lb, '_HAS_LOIHI', True), \
+             patch.object(lb, 'linear_forward', return_value=torch.ones(1, 2)) as lin, \
+             patch.object(lb, 'lif_forward', return_value=(torch.zeros(1, 2), torch.zeros(1, 2))):
+            layer = sl.SpikingLinear(2, 2, use_loihi=True)
+            x = torch.randn(1, 2)
+            layer(x)
+            lin.assert_called_with(x, layer.linear.weight, layer.linear.bias)
+
+    def test_fallback_cpu(self):
+        torch.manual_seed(0)
+        neuron1 = sl.LIFNeuron()
+        neuron2 = sl.LIFNeuron(use_loihi=True)
+        x = torch.randn(2, 3)
+        out1 = neuron1(x)
+        out2 = neuron2(x)
+        self.assertTrue(torch.allclose(out1, out2))
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- wrap Loihi SDK calls in `loihi_backend.py`
- allow `LIFNeuron` and `SpikingLinear` to offload to the Loihi backend
- document how to enable neuromorphic execution
- note Loihi option in `Plan.md`
- add mocked unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6868870118208331a779e8aa085d08ba