### PR TITLE
Add carbon-aware job scheduling

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -416,7 +416,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 
 The `hpc_scheduler` module wraps `sbatch`, `srun` and `kubectl` so jobs can be launched on an HPC cluster or a Kubernetes grid.  Pass
 `hpc_backend="slurm"` or `"kubernetes"` to `DistributedTrainer` to dispatch workers through the scheduler.  Use `submit_job()` to start a
-task, `monitor_job()` to poll its status, and `cancel_job()` to terminate it.
+task, `monitor_job()` to poll its status, and `cancel_job()` to terminate it.  A
+`CarbonAwareScheduler` can now queue jobs until the current carbon intensity
+drops below a configured threshold, using `CarbonFootprintTracker` or an
+external API for the measurements.
 
 
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -235,6 +235,7 @@ from .budget_aware_scheduler import BudgetAwareScheduler
 from .doc_summarizer import summarize_module
 
 from .hpc_scheduler import submit_job, monitor_job, cancel_job
+from .carbon_aware_scheduler import CarbonAwareScheduler
 from .collaboration_portal import CollaborationPortal
 from .cluster_carbon_dashboard import ClusterCarbonDashboard
 from .spiking_layers import LIFNeuron, SpikingLinear

--- a/src/carbon_aware_scheduler.py
+++ b/src/carbon_aware_scheduler.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+"""Queue HPC jobs based on regional carbon intensity."""
+
+import threading
+import time
+import json
+import urllib.request
+from collections import deque
+from typing import Deque, List, Union, Optional, Tuple
+
+from .telemetry import TelemetryLogger
+from .hpc_scheduler import submit_job, monitor_job, cancel_job
+
+
+class CarbonAwareScheduler:
+    """Dispatch jobs when carbon intensity drops below a threshold."""
+
+    def __init__(
+        self,
+        max_intensity: float,
+        *,
+        region: Optional[str] = None,
+        telemetry: Optional[TelemetryLogger] = None,
+        check_interval: float = 60.0,
+        carbon_api: Optional[str] = None,
+    ) -> None:
+        self.max_intensity = max_intensity
+        self.region = region
+        self.carbon_api = carbon_api
+        self.telemetry = telemetry or TelemetryLogger(interval=check_interval)
+        self.check_interval = check_interval
+        self.queue: Deque[Tuple[Union[str, List[str]], str]] = deque()
+        self._stop = threading.Event()
+        self.thread = threading.Thread(target=self._loop, daemon=True)
+        self.thread.start()
+
+    # --------------------------------------------------------------
+    def _fetch_intensity(self) -> float:
+        if self.carbon_api:
+            try:
+                with urllib.request.urlopen(self.carbon_api, timeout=1) as r:
+                    data = json.loads(r.read().decode() or "{}")
+                    return float(data.get("carbon_intensity", 0.0))
+            except Exception:
+                pass
+        return self.telemetry.get_carbon_intensity(self.region)
+
+    # --------------------------------------------------------------
+    def submit_job(self, command: Union[str, List[str]], backend: str = "slurm") -> str:
+        intensity = self._fetch_intensity()
+        if intensity <= self.max_intensity:
+            return submit_job(
+                command,
+                backend=backend,
+                telemetry=self.telemetry,
+                region=self.region,
+                max_intensity=self.max_intensity,
+                carbon_api=self.carbon_api,
+            )
+        self.queue.append((command, backend))
+        return "QUEUED"
+
+    # --------------------------------------------------------------
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            if self.queue and self._fetch_intensity() <= self.max_intensity:
+                command, backend = self.queue.popleft()
+                submit_job(
+                    command,
+                    backend=backend,
+                    telemetry=self.telemetry,
+                    region=self.region,
+                    max_intensity=self.max_intensity,
+                    carbon_api=self.carbon_api,
+                )
+            else:
+                time.sleep(self.check_interval)
+
+    # --------------------------------------------------------------
+    def monitor_job(self, job_id: str, backend: str = "slurm") -> str:
+        return monitor_job(job_id, backend=backend)
+
+    def cancel_job(self, job_id: str, backend: str = "slurm") -> str:
+        return cancel_job(job_id, backend=backend)
+
+    # --------------------------------------------------------------
+    def stop(self) -> None:
+        self._stop.set()
+        if self.thread.is_alive():
+            self.thread.join(timeout=1.0)
+
+
+__all__ = ["CarbonAwareScheduler"]

--- a/tests/test_carbon_aware_scheduler.py
+++ b/tests/test_carbon_aware_scheduler.py
@@ -1,0 +1,52 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import time
+from unittest.mock import patch
+import unittest
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+TelemetryLogger = _load('asi.telemetry', 'src/telemetry.py').TelemetryLogger
+CarbonAwareScheduler = _load('asi.carbon_aware_scheduler', 'src/carbon_aware_scheduler.py').CarbonAwareScheduler
+hpc_mod = _load('asi.hpc_scheduler', 'src/hpc_scheduler.py')
+submit_job = hpc_mod.submit_job
+
+
+class TestCarbonAwareScheduler(unittest.TestCase):
+    def test_immediate_run(self):
+        logger = TelemetryLogger(interval=0.05, carbon_data={'default': 0.3})
+        sched = CarbonAwareScheduler(0.5, telemetry=logger, check_interval=0.05)
+        with patch.object(hpc_mod, 'submit_job', return_value='id') as run:
+            jid = sched.submit_job(['job.sh'])
+            self.assertEqual(jid, 'id')
+            run.assert_called_once()
+        sched.stop()
+
+    def test_queue_and_release(self):
+        logger = TelemetryLogger(interval=0.05, carbon_data={'default': 0.7})
+        sched = CarbonAwareScheduler(0.5, telemetry=logger, check_interval=0.05)
+        with patch.object(hpc_mod, 'submit_job', return_value='ok') as run:
+            res = sched.submit_job(['job.sh'])
+            self.assertEqual(res, 'QUEUED')
+            self.assertEqual(run.call_count, 0)
+            logger.carbon_data['default'] = 0.3
+            time.sleep(0.1)
+            sched.stop()
+            self.assertGreaterEqual(run.call_count, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `hpc_scheduler.submit_job` with carbon intensity checks
- add `CarbonAwareScheduler` for queueing jobs until emissions drop
- export the new scheduler
- document carbon-aware scheduling in the Scalability section
- test carbon-aware scheduling behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68688706acec8331ac7412c67e86f913