### PR TITLE
Add retrieval summary to dashboard

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -333,6 +333,7 @@ To reproduce the toy run step by step:
 
 - `src/hierarchical_memory.py` and `src/link_slot_attention.py` provide a two-tier memory backed by FAISS.
 - The store compresses vectors before writing them to disk and loads the nearest neighbours on demand.
+- `RetrievalExplainer.summarize()` distills query results into a brief text used by `MemoryDashboard` to show context for each retrieval.
 
 ## C-8 Distributed Hierarchical Memory Backend
 

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -475,6 +475,8 @@ class HierarchicalMemory:
         ):
             self._update_eviction()
         self.last_trace = {
+            "query": query.detach().cpu().tolist(),
+            "results": vec.detach().cpu().tolist(),
             "scores": scores,
             "provenance": list(out_meta),
         }
@@ -558,7 +560,12 @@ class HierarchicalMemory:
             and self.query_count % self.evict_check_interval == 0
         ):
             self._update_eviction()
-        self.last_trace = {"scores": scores, "provenance": list(out_meta)}
+        self.last_trace = {
+            "query": query.detach().cpu().tolist(),
+            "results": vec.detach().cpu().tolist(),
+            "scores": scores,
+            "provenance": list(out_meta),
+        }
         if return_scores or return_provenance:
             extras = []
             if return_scores:

--- a/src/memory_dashboard.py
+++ b/src/memory_dashboard.py
@@ -117,21 +117,18 @@ class MemoryDashboard:
                     if trace is None:
                         data = b"{}"
                     else:
-                        vecs, meta, scores = (
-                            None,
-                            trace.get("provenance", []),
-                            trace.get("scores", []),
-                        )
-                        data = json.dumps(
-                            RetrievalExplainer.format(
-                                torch.tensor([]), torch.tensor([]), scores, meta
-                            )
-                        ).encode()
-                        self.send_response(200)
-                        self.send_header("Content-Type", "application/json")
-                        self.end_headers()
-                        self.wfile.write(data)
-                        return
+                        q = torch.tensor(trace.get("query", []))
+                        r = torch.tensor(trace.get("results", []))
+                        meta = trace.get("provenance", [])
+                        scores = trace.get("scores", [])
+                        items = RetrievalExplainer.format(q, r, scores, meta)
+                        summary = RetrievalExplainer.summarize(q, r, scores, meta)
+                        data = json.dumps({"items": items, "summary": summary}).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                    return
                 elif self.path.startswith("/entries"):
                     q = parse_qs(urlparse(self.path).query)
                     start = int(q.get("start", [0])[0])

--- a/src/retrieval_explainer.py
+++ b/src/retrieval_explainer.py
@@ -13,4 +13,17 @@ class RetrievalExplainer:
             items.append({"provenance": p, "score": float(s), "vector": r.tolist()})
         return items
 
+    @staticmethod
+    def summarize(
+        query: torch.Tensor,
+        results: torch.Tensor,
+        scores: List[float],
+        provenance: List[Any],
+    ) -> str:
+        """Return a short textual summary of retrieval output."""
+        parts = []
+        for i, (score, src) in enumerate(zip(scores, provenance), start=1):
+            parts.append(f"{i}. {src} (score={score:.3f})")
+        return " | ".join(parts)
+
 __all__ = ["RetrievalExplainer"]

--- a/tests/test_retrieval_explainer.py
+++ b/tests/test_retrieval_explainer.py
@@ -27,5 +27,14 @@ class TestRetrievalExplainer(unittest.TestCase):
         self.assertEqual(len(items), 2)
         self.assertEqual(items[0]['provenance'], 'a')
 
+    def test_summarize(self):
+        q = torch.zeros(1, 2)
+        r = torch.ones(2, 2)
+        scores = [0.9, 0.8]
+        prov = ['a', 'b']
+        summary = RetrievalExplainer.summarize(q, r, scores, prov)
+        self.assertIn('a', summary)
+        self.assertIn('0.9', summary)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `RetrievalExplainer.summarize` helper
- persist query and result vectors in `HierarchicalMemory` traces
- show summary of retrievals in `MemoryDashboard`
- document summarization in Implementation guide
- test summarization helper

## Testing
- `pytest tests/test_retrieval_explainer.py tests/test_memory_dashboard.py tests/test_hierarchical_memory.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install --extra-index-url https://download.pytorch.org/whl/cpu torch==2.2.1+cpu` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6868870788bc8331af7f0cf0556fa12d