### PR TITLE
Add 3D training utilities

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -696,6 +696,9 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   under `research_logs/`.
 - Expand `GenerativeDataAugmentor` with `synthesize_3d()` for basic 3D asset
   synthesis.
+- Extend `world_model_rl.train_world_model()` to accept 3D data from this
+  augmentor, introduce a `VoxelEnv` wrapper emitting voxel observations and add
+  a `voxel_rollout` evaluator in `eval_harness.py` for 3D rollouts.
 - Implement a mocked `quantum_sampler.sample_actions_qae()` and integrate it as
   an optional sampler in `train_with_self_play`.
 - Compute an overall risk metric via the new `RiskScoreboard` module.

--- a/src/eval_harness.py
+++ b/src/eval_harness.py
@@ -320,6 +320,19 @@ def _eval_context_profiler() -> Tuple[bool, str]:
     return ok, f"runs={len(stats)}"
 
 
+def _eval_voxel_rollout() -> Tuple[bool, str]:
+    """Run a tiny rollout in the 3D voxel environment."""
+    from asi.self_play_env import VoxelEnv, rollout_env
+    env = VoxelEnv((2, 2, 2))
+
+    def policy(obs: torch.Tensor) -> torch.Tensor:  # returns same shape
+        return torch.ones_like(obs)
+
+    obs, _ = rollout_env(env, policy, steps=2)
+    ok = all(o.shape == torch.Size([2, 2, 2]) for o in obs)
+    return ok, f"steps={len(obs)}"
+
+
 EVALUATORS: Dict[str, Callable[[], Tuple[bool, str]]] = {
     "moe_router": _eval_moe_router,
     "flash_attention3": _eval_flash_attention3,
@@ -342,6 +355,7 @@ EVALUATORS: Dict[str, Callable[[], Tuple[bool, str]]] = {
     "fairness_evaluator": _eval_fairness_evaluator,
     "cross_lingual_fairness": _eval_cross_lingual_fairness,
     "context_profiler": _eval_context_profiler,
+    "voxel_rollout": _eval_voxel_rollout,
 }
 
 

--- a/src/self_play_env.py
+++ b/src/self_play_env.py
@@ -31,6 +31,22 @@ class SimpleEnv:
         return EnvStep(self.state.clone(), reward, done)
 
 
+class VoxelEnv(SimpleEnv):
+    """Wrapper that exposes the underlying state as a 3D volume."""
+
+    def __init__(self, dims: tuple[int, int, int], device: torch.device | None = None) -> None:
+        self.dims = dims
+        super().__init__(int(torch.prod(torch.tensor(dims)).item()), device=device)
+
+    def reset(self) -> torch.Tensor:  # noqa: D401 - override
+        obs = super().reset()
+        return obs.view(self.dims)
+
+    def step(self, action: torch.Tensor) -> EnvStep:  # noqa: D401 - override
+        step = super().step(action.view(-1))
+        return EnvStep(step.observation.view(self.dims), step.reward, step.done)
+
+
 class PrioritizedReplayBuffer:
     """Replay buffer that samples transitions according to reward."""
 
@@ -101,4 +117,4 @@ def rollout_env(
     return observations, rewards
 
 
-__all__ = ["EnvStep", "SimpleEnv", "PrioritizedReplayBuffer", "rollout_env"]
+__all__ = ["EnvStep", "SimpleEnv", "VoxelEnv", "PrioritizedReplayBuffer", "rollout_env"]

--- a/tests/test_voxel_env.py
+++ b/tests/test_voxel_env.py
@@ -1,0 +1,23 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import sys
+import torch
+
+loader = importlib.machinery.SourceFileLoader('spe', 'src/self_play_env.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+spe = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = spe
+loader.exec_module(spe)
+VoxelEnv = spe.VoxelEnv
+rollout_env = spe.rollout_env
+
+class TestVoxelEnv(unittest.TestCase):
+    def test_voxel_observation_shape(self):
+        env = VoxelEnv((2,2,2))
+        policy = lambda obs: torch.ones_like(obs)
+        obs, rewards = rollout_env(env, policy, steps=1)
+        self.assertEqual(obs[0].shape, torch.Size([2,2,2]))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_world_model_3d.py
+++ b/tests/test_world_model_3d.py
@@ -1,0 +1,50 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import numpy as np
+import torch
+
+# load modules dynamically to avoid package deps
+loader = importlib.machinery.SourceFileLoader('wmrl', 'src/world_model_rl.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+wmrl = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = wmrl
+loader.exec_module(wmrl)
+RLBridgeConfig = wmrl.RLBridgeConfig
+TransitionDataset = wmrl.TransitionDataset
+train_world_model = wmrl.train_world_model
+
+loader = importlib.machinery.SourceFileLoader('gda', 'src/generative_data_augmentor.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+gda = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = gda
+loader.exec_module(gda)
+GenerativeDataAugmentor = gda.GenerativeDataAugmentor
+
+loader = importlib.machinery.SourceFileLoader('mmw', 'src/multimodal_world_model.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mmw = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mmw
+loader.exec_module(mmw)
+MultiModalWorldModelConfig = mmw.MultiModalWorldModelConfig
+MultiModalWorldModel = mmw.MultiModalWorldModel
+
+
+class TestWorldModel3DTrain(unittest.TestCase):
+    def test_train_world_model_with_3d(self):
+        cfg = RLBridgeConfig(state_dim=8, action_dim=1, epochs=1, batch_size=1)
+        dataset = TransitionDataset([(torch.zeros(8), 0, torch.zeros(8), 0.0)])
+        mm_cfg = MultiModalWorldModelConfig(vocab_size=5, img_channels=1, action_dim=1)
+        mm = MultiModalWorldModel(mm_cfg)
+        augmentor = GenerativeDataAugmentor(mm)
+        vol = np.zeros((1, 2, 2, 2), dtype=np.float32)
+        policy = lambda s: torch.zeros(1, dtype=torch.long)
+        synth = augmentor.synthesize_3d('x', vol, policy, steps=1)
+        model = train_world_model(cfg, dataset, synth_3d=synth)
+        self.assertIsInstance(model, torch.nn.Module)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `world_model_rl.train_world_model` for 3D synthesized data
- add `VoxelEnv` for voxel observations
- expose voxel rollout evaluator in `eval_harness`
- document new 3D training pathway
- add unit tests for voxel env and 3D training

## Testing
- `pytest -q tests/test_world_model_rl.py tests/test_world_model_3d.py tests/test_voxel_env.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68688709d0ec83319b2977df64493895