### PR TITLE
Add RL dataset ranking agent

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -422,6 +422,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     lightweight SQLite database. `license_inspector.py` loads the database to
     flag incompatible licenses. The plan is to crowd‑source additional data hub
     scrapers so community members can contribute new sources via pull requests.
+    Discovered entries are now scored by `rl_dataset_discovery.DatasetQualityAgent`
+    which weights datasets based on license compatibility, diversity metrics and
+    novelty. `store_datasets()` saves this weight for downstream ranking.
  
 83. **Analogy-based retrieval evaluation**: Use `analogical_retrieval.analogy_search()`
     on a small word-analogy dataset. For each tuple `(A, B, Q)` compute the

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -159,6 +159,7 @@ from .dataset_discovery import (
     discover_kaggle,
     store_datasets,
 )
+from .rl_dataset_discovery import DatasetQualityAgent
 from .streaming_compression import AdaptiveCompressor, TemporalVectorCompressor
 from .context_profiler import profile_model, ContextWindowProfiler
 from .accelerator_scheduler import AcceleratorScheduler

--- a/src/rl_dataset_discovery.py
+++ b/src/rl_dataset_discovery.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import torch
+from typing import Iterable, Set
+
+from .dataset_discovery import DiscoveredDataset
+
+
+class DatasetQualityAgent:
+    """Simple RL agent to score discovered datasets."""
+
+    def __init__(self, allowed_licenses: Iterable[str] | None = None, lr: float = 0.1) -> None:
+        self.allowed = {l.lower() for l in (allowed_licenses or ["mit", "apache", "cc-by"])}
+        self.lr = lr
+        self.weights = torch.zeros(3, dtype=torch.float32)
+        self.baseline = 0.0
+        self.seen: Set[str] = set()
+
+    # --------------------------------------------------------------
+    def _signals(self, d: DiscoveredDataset) -> torch.Tensor:
+        lic_text = (d.license + " " + d.license_text).lower()
+        license_ok = 1.0 if any(a in lic_text for a in self.allowed) else 0.0
+        tokens = d.name.split()
+        diversity = len(set(tokens)) / max(len(tokens), 1)
+        novelty = 0.0 if d.name in self.seen else 1.0
+        return torch.tensor([license_ok, diversity, novelty], dtype=torch.float32)
+
+    # --------------------------------------------------------------
+    def evaluate(self, d: DiscoveredDataset) -> float:
+        """Return weight for ``d`` and update the agent."""
+        x = self._signals(d)
+        prob = torch.sigmoid((self.weights * x).sum())
+        reward = x.mean()
+        self.baseline += self.lr * (reward - self.baseline)
+        adv = reward - self.baseline
+        self.weights += self.lr * adv * x
+        self.seen.add(d.name)
+        return float(prob.item())
+
+
+__all__ = ["DatasetQualityAgent"]

--- a/tests/test_rl_dataset_discovery.py
+++ b/tests/test_rl_dataset_discovery.py
@@ -1,0 +1,51 @@
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+import importlib.machinery
+import importlib.util
+import sys
+import types
+
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+
+loader = importlib.machinery.SourceFileLoader('src.dataset_discovery', 'src/dataset_discovery.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+dd = importlib.util.module_from_spec(spec)
+dd.__package__ = 'src'
+sys.modules['src.dataset_discovery'] = dd
+loader.exec_module(dd)
+
+loader2 = importlib.machinery.SourceFileLoader('src.rl_dataset_discovery', 'src/rl_dataset_discovery.py')
+spec2 = importlib.util.spec_from_loader(loader2.name, loader2)
+rl = importlib.util.module_from_spec(spec2)
+rl.__package__ = 'src'
+sys.modules['src.rl_dataset_discovery'] = rl
+loader2.exec_module(rl)
+
+DiscoveredDataset = dd.DiscoveredDataset
+store_datasets = dd.store_datasets
+DatasetQualityAgent = rl.DatasetQualityAgent
+
+
+class TestRLDatasetDiscovery(unittest.TestCase):
+    def test_weight_assignment(self):
+        rss = """<rss><channel>
+        <item><title>unique ds</title><link>http://x/ds1</link><license>MIT</license></item>
+        <item><title>dup dup</title><link>http://x/ds2</link><license>Unknown</license></item>
+        </channel></rss>"""
+        dsets = dd._parse_rss(rss, 'hf')
+        agent = DatasetQualityAgent(['mit'])
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / 'db.sqlite'
+            store_datasets(dsets, db, agent=agent)
+            conn = sqlite3.connect(db)
+            cur = conn.execute('SELECT weight FROM datasets ORDER BY name')
+            w1, w2 = [r[0] for r in cur.fetchall()]
+            conn.close()
+            self.assertGreater(w1, w2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `DatasetQualityAgent` for RL-based dataset scoring
- support weighting inside `dataset_discovery.store_datasets`
- document RL ranking in dataset discovery section of `Plan.md`
- expose agent via package init and add tests

## Testing
- `python - <<'PY' ...` (see output)

------
https://chatgpt.com/codex/tasks/task_e_68695dceb73883319f3e60f093c0dc9e