### PR TITLE
Add translation of reasoning summaries

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -400,7 +400,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 73. **Versioned model lineage**: Record hashed checkpoints and link them to dataset versions via `ModelVersionManager` for reproducible experiments. *Implemented in `src/model_version_manager.py` with tests.*
 74. **Dataset anonymization**: Sanitize text, image and audio files during ingestion using `DatasetAnonymizer`. The `download_triples()` helper now scrubs PII and logs a summary via `DatasetLineageManager`.
 75. **Dataset summarization**: `scripts/dataset_summary.py --content` clusters text samples with `dataset_summarizer.summarize_dataset()` and writes the result to `docs/datasets/`.
-76. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps to aid debugging.
+76. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps to aid debugging. When initialised with a `CrossLingualTranslator` the logger records translated summaries for multilingual inspection.
 77. **User preference modeling**: `UserPreferences` maintains per-user vectors and feedback counts so `PromptOptimizer` can personalise prompts. Aggregate stats expose fairness gaps across demographics.
 
 76. **Trusted execution inference**: `EnclaveRunner` launches model inference inside a trusted enclave. `DistributedTrainer` can route its steps through the enclave to keep weights in a protected address space. This guards intermediate activations but does not eliminate side-channel risk.
@@ -409,7 +409,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 78. **Cluster carbon dashboard**: `TelemetryLogger` now publishes per-node carbon metrics to a central `ClusterCarbonDashboard`. `RiskDashboard` links to the dashboard so operators can track environmental impact across nodes.
 79. **Federated knowledge graph memory**: Replicate triples across nodes via `FederatedKGMemoryServer` so that after network partitions all servers agree on the same graph. Success is 100% retrieval consistency across two peers after concurrent updates.
 80. **Federated RL self-play**: `FederatedRLTrainer` wraps self-play loops and shares gradients via `SecureFederatedLearner`. Reward should match single-node training within 2% using two peers.
-81. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps. The logger now provides `analyze()` to cluster repeated steps and flag inconsistencies. Use `python -m asi.self_reflection` to print a report from saved histories.
+81. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps. The logger now provides `analyze()` to cluster repeated steps and flag inconsistencies, and can translate summaries when a `CrossLingualTranslator` is supplied. Use `python -m asi.self_reflection` to print a report from saved histories.
 82. **Graph-of-thought visualizer**: Use `src/got_visualizer.py` and the CLI
     `scripts/got_visualizer.py trace.json --out graph.html` to render reasoning
     traces for collaborative editing sessions.

--- a/src/graph_ui.py
+++ b/src/graph_ui.py
@@ -22,6 +22,7 @@ _HTML = """
 </head>
 <body>
 <h1>Reasoning Graph</h1>
+<p>Languages: {languages}</p>
 <svg width="600" height="400"></svg>
 <script>
 async function load() {
@@ -81,7 +82,10 @@ class GraphUI:
     def _setup_routes(self) -> None:
         @self.app.get('/graph', response_class=HTMLResponse)
         async def graph_page() -> Any:
-            return HTMLResponse(_HTML)
+            langs = ''
+            if self.logger.translator is not None:
+                langs = ', '.join(self.logger.translator.languages)
+            return HTMLResponse(_HTML.replace('{languages}', langs))
 
         async def _record() -> None:
             summary = self.graph.self_reflect()
@@ -94,6 +98,11 @@ class GraphUI:
         @self.app.get('/history')
         async def history() -> Any:
             return JSONResponse(self.logger.get_history())
+
+        @self.app.get('/languages')
+        async def languages() -> Any:
+            langs = self.logger.translator.languages if self.logger.translator else []
+            return JSONResponse(langs)
 
         @self.app.post('/graph/node')
         async def add_node(req: Request) -> Any:

--- a/tests/test_self_reflection_translation.py
+++ b/tests/test_self_reflection_translation.py
@@ -1,0 +1,62 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+import types
+import json
+
+from asi.reasoning_history import ReasoningHistoryLogger
+
+
+class CrossLingualTranslator:
+    def __init__(self, languages):
+        self.languages = list(languages)
+
+    def translate(self, text, lang):
+        if lang not in self.languages:
+            raise ValueError('unsupported language')
+        return f'[{lang}] {text}'
+
+    def translate_all(self, text):
+        return {l: self.translate(text, l) for l in self.languages}
+
+
+dummy = types.ModuleType('asi.data_ingest')
+dummy.CrossLingualTranslator = CrossLingualTranslator
+sys.modules['asi.data_ingest'] = dummy
+
+
+class TestHistoryTranslation(unittest.TestCase):
+    def test_logger_translates(self):
+        tr = CrossLingualTranslator(["es"])
+        logger = ReasoningHistoryLogger(translator=tr)
+        logger.log("start -> end")
+        entries = logger.get_history()
+        self.assertIsInstance(entries[0][1], dict)
+        self.assertEqual(entries[0][1]["translations"]["es"], "[es] start -> end")
+
+
+class TestSelfReflectionCLITranslations(unittest.TestCase):
+    def test_cli_with_translations(self):
+        tr = CrossLingualTranslator(["es"])
+        logger = ReasoningHistoryLogger(translator=tr)
+        logger.log("start -> not start")
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            json.dump(logger.entries, f)
+            fname = f.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-m", "asi.self_reflection", fname],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0)
+            self.assertIn("Inconsistencies", proc.stdout)
+        finally:
+            os.unlink(fname)
+
+
+if __name__ == "__main__":  # pragma: no cover - test helper
+    unittest.main()


### PR DESCRIPTION
## Summary
- support storing translated self-reflection summaries
- expose available languages via `GraphUI` and `MultiAgentDashboard`
- document multilingual self-reflection logger
- test translated history logging and CLI

## Testing
- `pip install numpy`
- `pip install -e .`
- `python -m unittest tests.test_self_reflection_analyzer tests.test_self_reflection_translation`
- `pytest -q` *(fails: 141 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68695dd14bc8833182acff11a0d2836e