### PR TITLE
Add RL carbon scheduler

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -459,6 +459,12 @@ drops below a threshold, while `submit_at_optimal_time()` waits for the lowest
 forecast in the next 24 h.  Both helpers call `submit_job()` once conditions are
 favourable, reducing cluster emissions without manual tuning.
 
+`rl_carbon_scheduler.RLCarbonScheduler` goes a step further by learning when to
+launch jobs from historical intensity and job-duration traces.  It employs a
+Q-learning policy to trade off energy consumption against queueing delay.  The
+scheduler plugs into `DistributedTrainer` like the rule-based versions and
+records estimated energy usage and wait time via `TelemetryLogger`.
+
 
 
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -250,6 +250,7 @@ from .hpc_scheduler import submit_job, monitor_job, cancel_job
 from .carbon_aware_scheduler import CarbonAwareScheduler
 
 from .carbon_hpc_scheduler import CarbonAwareScheduler
+from .rl_carbon_scheduler import RLCarbonScheduler
 
 from .collaboration_portal import CollaborationPortal
 from .cluster_carbon_dashboard import ClusterCarbonDashboard

--- a/src/distributed_trainer.py
+++ b/src/distributed_trainer.py
@@ -124,7 +124,10 @@ class DistributedTrainer:
                 ]
                 if self.grad_compression is not None:
                     cmd += ["--comp-cfg", json.dumps(self.grad_compression)]
-                submit_job(cmd, backend=self.hpc_backend)
+                if self.scheduler is not None and hasattr(self.scheduler, "submit_job"):
+                    self.scheduler.submit_job(cmd, backend=self.hpc_backend)
+                else:
+                    submit_job(cmd, backend=self.hpc_backend)
                 self.step += 1
                 continue
 

--- a/src/rl_carbon_scheduler.py
+++ b/src/rl_carbon_scheduler.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+"""Reinforcement learning based carbon-aware scheduler."""
+
+import random
+import time
+from typing import Iterable, Tuple, List, Dict, Union, Optional
+
+from .telemetry import TelemetryLogger
+from .hpc_scheduler import submit_job
+
+
+class RLCarbonScheduler:
+    """Schedule jobs using a Q-learning policy trained on historical data."""
+
+    def __init__(
+        self,
+        history: Iterable[Tuple[float, float]],
+        *,
+        bins: int = 10,
+        epsilon: float = 0.1,
+        alpha: float = 0.5,
+        gamma: float = 0.9,
+        check_interval: float = 60.0,
+        telemetry: Optional[TelemetryLogger] = None,
+        region: Optional[str] = None,
+    ) -> None:
+        self.history = list(history)
+        self.bins = bins
+        self.epsilon = epsilon
+        self.alpha = alpha
+        self.gamma = gamma
+        self.check_interval = check_interval
+        self.telemetry = telemetry or TelemetryLogger(interval=check_interval)
+        self.region = region
+        if self.history:
+            self.min_i = min(i for i, _ in self.history)
+            self.max_i = max(i for i, _ in self.history)
+        else:
+            self.min_i = 0.0
+            self.max_i = 1.0
+        self.q: Dict[Tuple[int, int], float] = {}
+        if self.history:
+            self._train(10)
+
+    # --------------------------------------------------------------
+    def _bucket(self, intensity: float) -> int:
+        if self.max_i == self.min_i:
+            return 0
+        ratio = (intensity - self.min_i) / (self.max_i - self.min_i)
+        return max(0, min(self.bins - 1, int(ratio * (self.bins - 1))))
+
+    # --------------------------------------------------------------
+    def _train(self, cycles: int = 1) -> None:
+        for _ in range(cycles):
+            for idx in range(len(self.history) - 1):
+                i, dur = self.history[idx]
+                j, _ = self.history[idx + 1]
+                s = self._bucket(i)
+                sp = self._bucket(j)
+                for action, reward in ((0, -i * dur), (1, -0.1)):
+                    cur = self.q.get((s, action), 0.0)
+                    next_max = max(
+                        self.q.get((sp, a), 0.0) for a in (0, 1)
+                    )
+                    target = reward + self.gamma * next_max
+                    self.q[(s, action)] = cur + self.alpha * (target - cur)
+
+    # --------------------------------------------------------------
+    def _policy(self, intensity: float) -> int:
+        s = self._bucket(intensity)
+        if random.random() < self.epsilon:
+            return random.randint(0, 1)
+        run_q = self.q.get((s, 0), 0.0)
+        wait_q = self.q.get((s, 1), 0.0)
+        return 0 if run_q >= wait_q else 1
+
+    # --------------------------------------------------------------
+    def submit_job(
+        self,
+        command: Union[str, List[str]],
+        *,
+        backend: str = "slurm",
+        expected_duration: float = 1.0,
+    ) -> str:
+        """Submit ``command`` when the RL policy decides to run."""
+        start = time.time()
+        while True:
+            intensity = self.telemetry.get_carbon_intensity(self.region)
+            action = self._policy(intensity)
+            if action == 0:
+                job_id = submit_job(
+                    command,
+                    backend=backend,
+                    telemetry=self.telemetry,
+                    region=self.region,
+                )
+                wait = time.time() - start
+                energy = intensity * expected_duration
+                self.telemetry.metrics["energy_usage"] = (
+                    self.telemetry.metrics.get("energy_usage", 0.0) + energy
+                )
+                self.telemetry.metrics["wait_time"] = (
+                    self.telemetry.metrics.get("wait_time", 0.0) + wait
+                )
+                return job_id
+            time.sleep(self.check_interval)
+
+
+__all__ = ["RLCarbonScheduler"]
+

--- a/tests/test_rl_carbon_scheduler.py
+++ b/tests/test_rl_carbon_scheduler.py
@@ -1,0 +1,120 @@
+import importlib.util
+import types
+import sys
+import time
+import threading
+import unittest
+from unittest.mock import patch
+
+psutil_stub = types.SimpleNamespace(
+    cpu_percent=lambda interval=None: 50.0,
+    virtual_memory=lambda: types.SimpleNamespace(percent=10.0),
+    net_io_counters=lambda: types.SimpleNamespace(bytes_sent=0, bytes_recv=0),
+)
+sys.modules['psutil'] = psutil_stub
+
+torch_stub = types.SimpleNamespace(
+    cuda=types.SimpleNamespace(
+        is_available=lambda: False,
+        memory_allocated=lambda: 0,
+        get_device_properties=lambda _: types.SimpleNamespace(total_memory=1),
+    )
+)
+sys.modules['torch'] = torch_stub
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+_load('asi.carbon_tracker', 'src/carbon_tracker.py')
+_load('asi.memory_event_detector', 'src/memory_event_detector.py')
+TelemetryLogger = _load('asi.telemetry', 'src/telemetry.py').TelemetryLogger
+_load('asi.hpc_scheduler', 'src/hpc_scheduler.py')
+gc_stub = types.ModuleType('asi.gradient_compression')
+class _GCfg:
+    def __init__(self, topk=None, bits=None):
+        self.topk = topk
+        self.bits = bits
+
+class _GComp:
+    def __init__(self, cfg):
+        self.cfg = cfg
+    def compress(self, g):
+        return g
+
+gc_stub.GradientCompressionConfig = _GCfg
+gc_stub.GradientCompressor = _GComp
+sys.modules['asi.gradient_compression'] = gc_stub
+_load('asi.adaptive_micro_batcher', 'src/adaptive_micro_batcher.py')
+gpu_sched_stub = types.ModuleType('asi.gpu_aware_scheduler')
+gpu_sched_stub.GPUAwareScheduler = object
+sys.modules['asi.gpu_aware_scheduler'] = gpu_sched_stub
+accel_stub = types.ModuleType('asi.accelerator_scheduler')
+accel_stub.AcceleratorScheduler = object
+sys.modules['asi.accelerator_scheduler'] = accel_stub
+_load('asi.enclave_runner', 'src/enclave_runner.py')
+dm_stub = types.ModuleType('asi.distributed_memory')
+class _DM:
+    def __init__(self, *a, **kw):
+        pass
+    def save(self, *a, **k):
+        pass
+    def add(self, *a, **k):
+        pass
+
+dm_stub.DistributedMemory = _DM
+sys.modules['asi.distributed_memory'] = dm_stub
+RLCarbonScheduler = _load('asi.rl_carbon_scheduler', 'src/rl_carbon_scheduler.py').RLCarbonScheduler
+hpc_mod = _load('asi.hpc_scheduler', 'src/hpc_scheduler.py')
+submit_job = hpc_mod.submit_job
+dt_mod = _load('asi.distributed_trainer', 'src/distributed_trainer.py')
+DistributedTrainer = dt_mod.DistributedTrainer
+MemoryConfig = dt_mod.MemoryConfig
+
+
+class TestRLCarbonScheduler(unittest.TestCase):
+    def test_wait_and_run(self):
+        logger = TelemetryLogger(interval=0.05, carbon_data={'default': 0.8})
+        hist = [(0.8, 1.0), (0.2, 1.0)]
+        sched = RLCarbonScheduler(hist, telemetry=logger, check_interval=0.05)
+        job_id = []
+
+        def run():
+            job_id.append(sched.submit_job(['job.sh'], backend='slurm'))
+
+        with patch('asi.rl_carbon_scheduler.submit_job', return_value='ok') as sj:
+            t = threading.Thread(target=run)
+            t.start()
+            time.sleep(0.1)
+            logger.carbon_data['default'] = 0.2
+            t.join(timeout=0.3)
+            self.assertEqual(job_id[0], 'ok')
+            self.assertGreaterEqual(sj.call_count, 1)
+            self.assertGreater(sched.telemetry.metrics['wait_time'], 0.0)
+
+    def test_trainer_integration(self):
+        logger = TelemetryLogger(interval=0.05)
+        sched = RLCarbonScheduler([], telemetry=logger)
+
+        def dummy(mem, step, comp=None):
+            pass
+
+        cfg = MemoryConfig(dim=2, compressed_dim=1, capacity=2)
+        with patch.object(sched, 'submit_job', return_value='jid') as sj:
+            trainer = DistributedTrainer(dummy, cfg, '/tmp', hpc_backend='slurm', scheduler=sched)
+            trainer.run(steps=1)
+            sj.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- implement RL-based carbon scheduler for HPC queues
- integrate with `DistributedTrainer`
- document RL scheduler in Plan
- test RL scheduler behaviour and trainer integration

## Testing
- `pytest -q` *(fails: 137 errors during collection)*
- `pytest tests/test_rl_carbon_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68695de5bef48331a621b50554a3a928