### PR TITLE
Add natural-language graph editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ portal.start(port=8090)
 
 Visit `http://localhost:8090` to inspect progress.
 
+### Graph UI Editing
+
+`GraphUI` visualizes reasoning graphs. With `NLGraphEditor` you can type plain
+English commands into the text box at `/graph` to modify the graph. Examples:
+
+```text
+add node analysis
+add edge from start to analysis
+merge nodes analysis and finish
+```
+
+Each command triggers a recomputation of the concise summary stored in
+`ReasoningHistoryLogger`. See [docs/Plan.md](docs/Plan.md) for the roadmap.
+
 ## Testing
 
 1. Install requirements: `pip install -r requirements.txt` (or run

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -416,7 +416,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 83. **Graph UI**: `GraphUI` serves interactive D3 graphs via FastAPI. Visit `http://localhost:8070/graph` while the server is running to explore reasoning steps. `http://localhost:8070/history` shows stored summaries.
 
 
-84. **Temporal telemetry monitoring**: `MemoryEventDetector` parses logged hardware metrics and flags change points. `TelemetryLogger` stores these events so the memory dashboard exposes them via `/events`.
+84. **Natural-language graph editor**: `nl_graph_editor.py` interprets commands like "merge nodes A and B" or "add edge from X to Y". `GraphUI` exposes `/graph/nl_edit` so the web UI accepts these instructions.
+
+85. **Temporal telemetry monitoring**: `MemoryEventDetector` parses logged hardware metrics and flags change points. `TelemetryLogger` stores these events so the memory dashboard exposes them via `/events`.
 82. **Dataset discovery pipeline**: `dataset_discovery.py` scans RSS feeds from
     HuggingFace and Kaggle, storing dataset names, URLs and license text in a
     lightweight SQLite database. `license_inspector.py` loads the database to

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -238,6 +238,7 @@ from .retrieval_explainer import RetrievalExplainer
 from .retrieval_rl import RetrievalPolicy, train_policy
 from .interpretability_dashboard import InterpretabilityDashboard
 from .graph_ui import GraphUI
+from .nl_graph_editor import NLGraphEditor
 from .collaborative_healing import CollaborativeHealingLoop
 from .compute_budget_tracker import ComputeBudgetTracker
 from .budget_aware_scheduler import BudgetAwareScheduler

--- a/src/nl_graph_editor.py
+++ b/src/nl_graph_editor.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+from .graph_of_thought import GraphOfThought
+
+
+class NLGraphEditor:
+    """Apply simple natural-language edit commands to a ``GraphOfThought``."""
+
+    def __init__(self, graph: GraphOfThought) -> None:
+        self.graph = graph
+
+    # --------------------------------------------------------------
+    def _find_node(self, token: str) -> int:
+        token = token.strip()
+        if token.isdigit() and int(token) in self.graph.nodes:
+            return int(token)
+        for nid, node in self.graph.nodes.items():
+            if node.text.lower() == token.lower():
+                return nid
+        raise KeyError(f"unknown node {token}")
+
+    # --------------------------------------------------------------
+    def apply(self, command: str) -> Dict[str, Any]:
+        cmd = command.lower().strip()
+        if m := re.search(r"add edge from (.+?) to (.+)", cmd):
+            src = self._find_node(m.group(1))
+            dst = self._find_node(m.group(2))
+            self.graph.connect(src, dst)
+            return {"status": "ok", "action": "add_edge", "src": src, "dst": dst}
+        if m := re.search(r"remove edge from (.+?) to (.+)", cmd):
+            src = self._find_node(m.group(1))
+            dst = self._find_node(m.group(2))
+            if src in self.graph.edges:
+                self.graph.edges[src] = [d for d in self.graph.edges[src] if d != dst]
+            return {"status": "ok", "action": "remove_edge", "src": src, "dst": dst}
+        if m := re.search(r"merge nodes (.+?) and (.+)", cmd):
+            a = self._find_node(m.group(1))
+            b = self._find_node(m.group(2))
+            new_text = f"{self.graph.nodes[a].text} {self.graph.nodes[b].text}"
+            new_id = self.graph.add_step(new_text)
+            outgoing = list({*self.graph.edges.get(a, []), *self.graph.edges.get(b, [])})
+            for tgt in outgoing:
+                self.graph.connect(new_id, tgt)
+            for src, dsts in list(self.graph.edges.items()):
+                self.graph.edges[src] = [new_id if d in (a, b) else d for d in dsts]
+            for nid in (a, b):
+                self.graph.nodes.pop(nid, None)
+                self.graph.edges.pop(nid, None)
+            return {"status": "ok", "action": "merge", "new_id": new_id}
+        if m := re.search(r"add node (.+)", cmd):
+            text = command[ m.start(1) : ].strip() if m.lastindex else command
+            node_id = self.graph.add_step(text)
+            return {"status": "ok", "action": "add_node", "id": node_id}
+        if m := re.search(r"remove node (.+)", cmd):
+            nid = self._find_node(m.group(1))
+            self.graph.nodes.pop(nid, None)
+            self.graph.edges.pop(nid, None)
+            for src, dsts in list(self.graph.edges.items()):
+                self.graph.edges[src] = [d for d in dsts if d != nid]
+            return {"status": "ok", "action": "remove_node", "id": nid}
+        raise ValueError("unrecognized command")
+
+
+__all__ = ["NLGraphEditor"]

--- a/tests/test_graph_ui.py
+++ b/tests/test_graph_ui.py
@@ -20,6 +20,7 @@ def _load(name, path):
 
 GraphOfThought = _load('asi.graph_of_thought', 'src/graph_of_thought.py').GraphOfThought
 ReasoningHistoryLogger = _load('asi.reasoning_history', 'src/reasoning_history.py').ReasoningHistoryLogger
+_load('asi.nl_graph_editor', 'src/nl_graph_editor.py')
 GraphUI = _load('asi.graph_ui', 'src/graph_ui.py').GraphUI
 
 
@@ -42,13 +43,16 @@ class TestGraphUI(unittest.TestCase):
         conn.request('POST', '/graph/edge', json.dumps({'src': a, 'dst': node_id}),
                      {'Content-Type': 'application/json'})
         conn.getresponse().read()
+        conn.request('POST', '/graph/nl_edit', json.dumps({'command': 'add node extra'}),
+                     {'Content-Type': 'application/json'})
+        conn.getresponse().read()
         conn.request('POST', '/graph/recompute')
         summary = json.loads(conn.getresponse().read())['summary']
         self.assertIn('start', summary)
         conn.request('GET', '/graph/data')
         resp = conn.getresponse()
         data = json.loads(resp.read())
-        self.assertEqual(len(data['nodes']), 3)
+        self.assertEqual(len(data['nodes']), 4)
         conn.request('GET', '/history')
         resp = conn.getresponse()
         hist = json.loads(resp.read())

--- a/tests/test_nl_graph_editor.py
+++ b/tests/test_nl_graph_editor.py
@@ -1,0 +1,41 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+loader = importlib.machinery.SourceFileLoader('asi.graph_of_thought', 'src/graph_of_thought.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mod
+loader.exec_module(mod)
+GraphOfThought = mod.GraphOfThought
+
+editor_loader = importlib.machinery.SourceFileLoader('asi.nl_graph_editor', 'src/nl_graph_editor.py')
+editor_spec = importlib.util.spec_from_loader(editor_loader.name, editor_loader)
+editor_mod = importlib.util.module_from_spec(editor_spec)
+sys.modules[editor_loader.name] = editor_mod
+editor_loader.exec_module(editor_mod)
+NLGraphEditor = editor_mod.NLGraphEditor
+
+
+class TestNLGraphEditor(unittest.TestCase):
+    def test_commands(self):
+        g = GraphOfThought()
+        e = NLGraphEditor(g)
+        e.apply('add node A')
+        e.apply('add node B')
+        e.apply('add edge from A to B')
+        self.assertIn(1, g.edges.get(0, []))
+        e.apply('merge nodes A and B')
+        self.assertEqual(len(g.nodes), 1)
+        nid = next(iter(g.nodes))
+        self.assertIn('A', g.nodes[nid].text)
+        self.assertIn('B', g.nodes[nid].text)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `NLGraphEditor` for plain-English graph edits
- integrate editor in `GraphUI` and expose `/graph/nl_edit`
- document graph editing workflow and update roadmap
- test editor functionality and UI endpoint

## Testing
- `pip install fastapi uvicorn`
- `pytest tests/test_graph_of_thought.py tests/test_graph_ui.py tests/test_nl_graph_editor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68695de709f48331aca74297d7d54392