### PR TITLE
Secure ingestion via EnclaveRunner

### DIFF
--- a/asi/__init__.py
+++ b/asi/__init__.py
@@ -27,6 +27,7 @@ for _m in [
     "quantum_retrieval",
     "quantum_sampler",
     "quantum_hpo",
+    "enclave_runner",
 ]:
     _import(_m)
 

--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -490,6 +490,23 @@ def tokenizer(t: str):
 triples = offline_synthesizer(wm, tokenizer, "hello", np.zeros((1, 4, 4)), policy, steps=2)
 ```
 
+Sensitive ingestion steps can be isolated using `EnclaveRunner`:
+
+```python
+from asi.enclave_runner import EnclaveRunner
+from asi.license_inspector import LicenseInspector
+from asi.dataset_lineage_manager import DatasetLineageManager
+from asi.data_ingest import download_triples, paraphrase_multilingual
+from pathlib import Path
+
+runner = EnclaveRunner()
+inspector = LicenseInspector()
+lineage = DatasetLineageManager("./data")
+
+triples = download_triples(text_urls, img_urls, aud_urls, "./data", lineage=lineage, runner=runner)
+paraphrase_multilingual([Path("./data/text/0.txt")], translator, None, inspector, lineage, runner=runner)
+```
+
 ## L-6 Mechanistic Interpretability Tools
 
 - `src/transformer_circuits.py` provides utilities to record attention weights

--- a/tests/test_data_ingest.py
+++ b/tests/test_data_ingest.py
@@ -59,12 +59,18 @@ import numpy as np
 import asyncio
 from unittest.mock import patch
 
-mm = types.SimpleNamespace(
-    MultiModalWorldModel=object,
-    MultiModalWorldModelConfig=object,
-)
-MultiModalWorldModel = mm.MultiModalWorldModel
-MultiModalWorldModelConfig = mm.MultiModalWorldModelConfig
+class DummyWM:
+    def __init__(self, *a, **kw):
+        pass
+
+
+class DummyCfg:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+MultiModalWorldModel = DummyWM
+MultiModalWorldModelConfig = DummyCfg
 
 
 class TestDataIngest(unittest.TestCase):

--- a/tests/test_enclave_ingest.py
+++ b/tests/test_enclave_ingest.py
@@ -1,0 +1,69 @@
+import unittest
+import tempfile
+import os
+from pathlib import Path
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from asi.enclave_runner import EnclaveRunner
+
+# Load data_ingest module similar to other tests
+torch = types.SimpleNamespace(tensor=lambda *a, **kw: None,
+                              zeros=lambda *a, **kw: None,
+                              long=lambda: None)
+sys.modules['torch'] = torch
+
+loader = importlib.machinery.SourceFileLoader('src.data_ingest', 'src/data_ingest.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+di = importlib.util.module_from_spec(spec)
+di.__package__ = 'src'
+sys.modules['src.data_ingest'] = di
+sys.modules['asi.data_ingest'] = di
+loader.exec_module(di)
+
+class TestEnclaveIngest(unittest.TestCase):
+    def test_download_triples_enclave(self):
+        async def fake_download(session, url, dest):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(os.environ.get('IN_ENCLAVE', '0'))
+
+        di._HAS_AIOHTTP = True
+        class DummySession:
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+        di.aiohttp = types.SimpleNamespace(ClientSession=DummySession)
+
+        with tempfile.TemporaryDirectory() as root:
+            with unittest.mock.patch.object(di, '_download_file_async', fake_download):
+                runner = EnclaveRunner()
+                triples = di.download_triples(['u'], ['u'], ['u'], root, runner=runner)
+            t, _, _ = triples[0]
+            self.assertEqual(Path(t).read_text(), '1')
+
+    def test_paraphrase_multilingual_enclave(self):
+        class Insp:
+            def inspect(self, meta):
+                Path(meta).with_name('flag.txt').write_text(os.environ.get('IN_ENCLAVE','0'))
+                return True
+        class Lin:
+            def record(self, *a, **k):
+                Path(a[0][0]).with_name('lin.txt').write_text(os.environ.get('IN_ENCLAVE','0'))
+        with tempfile.TemporaryDirectory() as root:
+            src = Path(root)/'x.txt'
+            src.write_text('hi')
+            meta = src.with_suffix('.json')
+            meta.write_text('{}')
+            insp = Insp()
+            lin = Lin()
+            trans = di.CrossLingualTranslator(['es'])
+            runner = EnclaveRunner()
+            out = di.paraphrase_multilingual([src], trans, None, insp, lin, runner=runner)
+            self.assertTrue(out)
+            self.assertEqual((src.with_name('flag.txt')).read_text(), '1')
+            self.assertEqual((src.with_name('lin.txt')).read_text(), '1')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- run ingestion helpers inside a secure enclave
- expose enclave-aware ingestion usage in docs
- ensure LicenseInspector and DatasetLineageManager run in enclaves
- add enclave ingestion tests

## Testing
- `python -m pytest tests/test_enclave_runner.py tests/test_data_ingest.py tests/test_enclave_ingest.py tests/test_dataset_lineage_manager.py tests/test_license_inspector.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a91bd6f108331a08cd649bc1d7546