### PR TITLE
Add AR Graph overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository experiments with algorithms needed for self-improving AI. The bi
 - `python -m src.autobench` runs each test file in isolation and reports a summary.
 - `meta-rl-refactor` parses action/reward logs and suggests the next refactoring step.
 - `scripts/dataset_summary.py` prints lineage and license info. Use `--content` to cluster dataset samples and store summaries under `docs/datasets/`.
-- `scripts/ar_robot_demo.py` streams predicted and actual robot trajectories to a WebSocket server for lightweight AR visualization.
+- `scripts/ar_robot_demo.py` streams predicted and actual robot trajectories to a WebSocket server for lightweight AR visualization. Pass `--show-graph` to also broadcast `GraphOfThought` nodes.
 
 Example:
 
@@ -28,7 +28,7 @@ meta-rl-refactor sample_log.csv
 4. Optional: `pip install faiss-cpu` to enable disk-backed vector storage in `src/vector_store.py`.
 5. Run `pip install -e .` to enable imports from the `asi` package.
 6. The project runs without these optional packages, but FlashAttention-3 and persistent storage will be disabled.
-7. Launch the AR demo with `python scripts/ar_robot_demo.py` and connect your AR client to `ws://localhost:8765/ws`.
+7. Launch the AR demo with `python scripts/ar_robot_demo.py` (add `--show-graph` to stream the reasoning graph) and connect your AR client to `ws://localhost:8765/ws`.
 
 Run the scripts directly with `python` to see parameter and FLOP estimates.
 

--- a/scripts/ar_robot_demo.py
+++ b/scripts/ar_robot_demo.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Demo streaming robot state to an AR client."""
 
+import argparse
+
 from __future__ import annotations
 
 import time
@@ -8,6 +10,8 @@ import torch
 
 try:  # pragma: no cover - prefer package imports
     from asi.ar_debugger import ARDebugger
+    from asi.ar_got_overlay import ARGOTOverlay
+    from asi.graph_of_thought import GraphOfThought
     from asi.self_play_env import SimpleEnv
     from asi.world_model_rl import (
         RLBridgeConfig,
@@ -16,6 +20,8 @@ try:  # pragma: no cover - prefer package imports
     )
 except Exception:  # pragma: no cover - fallback for tests
     from src.ar_debugger import ARDebugger  # type: ignore
+    from src.ar_got_overlay import ARGOTOverlay  # type: ignore
+    from src.graph_of_thought import GraphOfThought  # type: ignore
     from src.self_play_env import SimpleEnv  # type: ignore
     from src.world_model_rl import (  # type: ignore
         RLBridgeConfig,
@@ -24,7 +30,11 @@ except Exception:  # pragma: no cover - fallback for tests
     )
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="AR robot demo")
+    parser.add_argument("--show-graph", action="store_true", help="Stream reasoning graph")
+    args = parser.parse_args(argv)
+
     env = SimpleEnv(2)
     transitions: list[tuple[torch.Tensor, int, torch.Tensor, float]] = []
     obs = env.reset()
@@ -41,16 +51,33 @@ def main() -> None:
     dbg.start(port=8765)
     print(f"AR debugger running on ws://localhost:{dbg.port}/ws")
 
+    overlay: ARGOTOverlay | None = None
+    graph: GraphOfThought | None = None
+    last_node: int | None = None
+    if args.show_graph:
+        graph = GraphOfThought()
+        last_node = graph.add_step("start")
+        overlay = ARGOTOverlay(graph)
+        overlay.start(port=8766)
+        print(f"Graph overlay running on ws://localhost:{overlay.port}/ws")
+
     obs = env.reset()
-    for _ in range(10):
+    for i in range(10):
         action = torch.ones(2)
         step = env.step(action)
         pred, _ = wm(obs, action)
         dbg.stream_state(pred, step.observation)
+        if args.show_graph and overlay is not None and graph is not None and last_node is not None:
+            node = graph.add_step(f"step {i}")
+            graph.connect(last_node, node)
+            last_node = node
+            overlay.send_graph()
         obs = step.observation
         time.sleep(0.1)
 
     dbg.stop()
+    if overlay is not None:
+        overlay.stop()
 
 
 if __name__ == "__main__":  # pragma: no cover - demo

--- a/src/ar_got_overlay.py
+++ b/src/ar_got_overlay.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import threading
+from aiohttp import web
+
+try:  # pragma: no cover - prefer package imports
+    from asi.graph_of_thought import GraphOfThought
+except Exception:  # pragma: no cover - fallback for tests
+    from src.graph_of_thought import GraphOfThought  # type: ignore
+
+
+class ARGOTOverlay:
+    """Stream ``GraphOfThought`` data for AR overlays via WebSockets."""
+
+    def __init__(self, graph: GraphOfThought) -> None:
+        self.graph = graph
+        self.app = web.Application()
+        self.app.router.add_get('/ws', self._ws_handler)
+        self.clients: list[web.WebSocketResponse] = []
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.runner: web.AppRunner | None = None
+        self.thread: threading.Thread | None = None
+        self.port: int | None = None
+
+    async def _ws_handler(self, request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        self.clients.append(ws)
+        try:
+            async for _ in ws:
+                pass
+        finally:
+            if ws in self.clients:
+                self.clients.remove(ws)
+        return ws
+
+    async def _broadcast(self, data: dict) -> None:
+        msg = json.dumps(data)
+        for ws in list(self.clients):
+            try:
+                await ws.send_str(msg)
+            except Exception:
+                self.clients.remove(ws)
+
+    def send_graph(self) -> None:
+        """Broadcast the current graph to all connected clients."""
+        if self.loop is None:
+            return
+        data = self.graph.to_json()
+        asyncio.run_coroutine_threadsafe(self._broadcast(data), self.loop)
+
+    def _run(self, host: str, port: int) -> None:
+        assert self.loop is not None
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_until_complete(self.runner.setup())
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind((host, port))
+        _, real_port = sock.getsockname()
+        self.port = real_port
+        site = web.SockSite(self.runner, sock)
+        self.loop.run_until_complete(site.start())
+        try:
+            self.loop.run_forever()
+        finally:
+            self.loop.run_until_complete(self.runner.cleanup())
+
+    def start(self, host: str = 'localhost', port: int = 8766) -> None:
+        if self.thread is not None:
+            return
+        self.loop = asyncio.new_event_loop()
+        self.runner = web.AppRunner(self.app)
+        self.thread = threading.Thread(target=self._run, args=(host, port), daemon=True)
+        self.thread.start()
+        import time
+        time.sleep(0.1)
+
+    def stop(self) -> None:
+        if self.thread is None or self.loop is None:
+            return
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join(timeout=1.0)
+        self.thread = None
+        self.loop = None
+        self.runner = None
+        self.port = None
+
+__all__ = ['ARGOTOverlay']

--- a/tests/test_ar_got_overlay.py
+++ b/tests/test_ar_got_overlay.py
@@ -1,0 +1,46 @@
+import unittest
+import asyncio
+import importlib
+import types
+import sys
+import json
+from pathlib import Path
+
+pkg = types.ModuleType('asi')
+sys.modules.setdefault('asi', pkg)
+src_pkg = types.ModuleType('src')
+src_pkg.__path__ = [str(Path('src'))]
+sys.modules.setdefault('src', src_pkg)
+
+ARGOTOverlay = importlib.import_module('src.ar_got_overlay').ARGOTOverlay
+GraphOfThought = importlib.import_module('src.graph_of_thought').GraphOfThought
+
+from aiohttp import ClientSession
+
+
+class TestARGOTOverlay(unittest.TestCase):
+    def test_stream(self):
+        graph = GraphOfThought()
+        a = graph.add_step('start')
+        b = graph.add_step('end')
+        graph.connect(a, b)
+        overlay = ARGOTOverlay(graph)
+        overlay.start(port=0)
+        port = overlay.port
+
+        async def run_client() -> dict:
+            assert port is not None
+            async with ClientSession() as session:
+                async with session.ws_connect(f'http://localhost:{port}/ws') as ws:
+                    overlay.send_graph()
+                    msg = await ws.receive()
+                    return json.loads(msg.data)
+
+        data = asyncio.get_event_loop().run_until_complete(run_client())
+        overlay.stop()
+        self.assertIn('nodes', data)
+        self.assertIn('edges', data)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement ARGOTOverlay for GraphOfThought AR streams
- allow `--show-graph` in `ar_robot_demo.py`
- document graph overlay in README
- test streaming of graph overlay

## Testing
- `pytest -q` *(fails: missing packages)*
- `pytest tests/test_ar_got_overlay.py::TestARGOTOverlay::test_stream -q` *(fails: blocked network when installing torch)*

------
https://chatgpt.com/codex/tasks/task_e_686a91ba81e08331bb4e2f92dc32335b