### PR TITLE
Add quantum memory server with gRPC API

### DIFF
--- a/asi/__init__.py
+++ b/asi/__init__.py
@@ -27,6 +27,10 @@ for _m in [
     "quantum_retrieval",
     "quantum_sampler",
     "quantum_hpo",
+    "memory_pb2",
+    "memory_pb2_grpc",
+    "quantum_memory_server",
+    "quantum_memory_client",
 ]:
     _import(_m)
 

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -338,6 +338,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
      accepts language tags from `CrossLingualMemory`; running
      `scripts/quantum_crosslingual_benchmark.py` shows parity across languages
      with ~1.5× latency.
+37b. **Quantum memory server**: `quantum_memory_server` exposes gRPC APIs
+     for vector search using `quantum_retrieval.amplify_search`. The accompanying
+     `QuantumMemoryClient` lets peers push embeddings and query the server over
+     the network.
 38. **Duplicate data filter**: Use CLIP embeddings with locality-sensitive
     hashing to drop near-duplicate samples during ingestion and connect it to
     `AutoDatasetFilter`.

--- a/src/quantum_memory_client.py
+++ b/src/quantum_memory_client.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import numpy as np
+
+try:
+    import grpc  # type: ignore
+    from . import memory_pb2, memory_pb2_grpc
+    _HAS_GRPC = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAS_GRPC = False
+
+
+class QuantumMemoryClient:
+    """Thin client for :class:`QuantumMemoryServer`."""
+
+    def __init__(self, address: str) -> None:
+        if not _HAS_GRPC:
+            raise ImportError("grpcio is required for QuantumMemoryClient")
+        self.address = address
+        self.channel = grpc.insecure_channel(address)
+        self.stub = memory_pb2_grpc.MemoryServiceStub(self.channel)
+
+    def add(self, vector: np.ndarray, metadata: any | None = None) -> None:
+        arr = np.asarray(vector, dtype=np.float32).reshape(-1).tolist()
+        meta = "" if metadata is None else str(metadata)
+        req = memory_pb2.PushRequest(vector=arr, metadata=meta)
+        self.stub.Push(req)
+
+    def search(self, vector: np.ndarray, k: int = 5):
+        arr = np.asarray(vector, dtype=np.float32).reshape(-1).tolist()
+        req = memory_pb2.QueryRequest(vector=arr, k=k)
+        reply = self.stub.Query(req)
+        dim = len(arr)
+        vecs = np.array(reply.vectors, dtype=np.float32).reshape(-1, dim)
+        return vecs, list(reply.metadata)
+
+    def close(self) -> None:
+        self.channel.close()
+
+
+__all__ = ["QuantumMemoryClient"]

--- a/tests/test_quantum_memory_server.py
+++ b/tests/test_quantum_memory_server.py
@@ -1,0 +1,33 @@
+import unittest
+import numpy as np
+
+from asi.vector_store import VectorStore
+from asi.quantum_memory_server import QuantumMemoryServer
+from asi.quantum_memory_client import QuantumMemoryClient
+
+
+class TestQuantumMemoryServer(unittest.TestCase):
+    def test_add_and_query(self):
+        try:
+            import grpc  # noqa: F401
+        except Exception:
+            self.skipTest("grpcio not available")
+
+        store = VectorStore(dim=4)
+        server = QuantumMemoryServer(store, "localhost:50800")
+        server.start()
+
+        client = QuantumMemoryClient("localhost:50800")
+        vec = np.random.randn(4).astype(np.float32)
+        client.add(vec, metadata="a")
+        out, meta = client.search(vec, k=1)
+
+        server.stop(0)
+        client.close()
+
+        np.testing.assert_allclose(out, vec.reshape(1, -1), atol=1e-5)
+        self.assertEqual(meta, ["a"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `QuantumMemoryServer` exposing a VectorStore over gRPC
- add `QuantumMemoryClient` helper
- document the new server in the plan
- test gRPC vector search

## Testing
- `python -m pytest -q tests/test_quantum_memory_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686a91bb47c08331b5b0062b414203f1