### PR TITLE
Add preference-weighted search

### DIFF
--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -20,6 +20,7 @@ from .async_vector_store import AsyncFaissVectorStore
 from .hopfield_memory import HopfieldMemory
 from .data_ingest import CrossLingualTranslator
 from .retrieval_rl import RetrievalPolicy
+from .user_preferences import UserPreferences
 
 
 class SSDCache:
@@ -221,10 +222,14 @@ class HierarchicalMemory:
         self.add_modalities(text, images, audio, metadata)
 
     def search_by_modality(
-        self, query: torch.Tensor, k: int = 5, modality: str | None = None
+        self,
+        query: torch.Tensor,
+        k: int = 5,
+        modality: str | None = None,
+        preferences: "UserPreferences | None" = None,
     ) -> Tuple[torch.Tensor, List[Any]]:
         """Retrieve vectors filtered by modality."""
-        vecs, metas = self.search(query, k=max(k, len(self)))
+        vecs, metas = self.search(query, k=max(k, len(self)), preferences=preferences)
         if modality is None:
             return vecs[:k], metas[:k]
         target_id = None
@@ -402,6 +407,7 @@ class HierarchicalMemory:
         mode: str = "standard",
         offset: torch.Tensor | None = None,
         language: str | None = None,
+        preferences: "UserPreferences | None" = None,
     ) -> Tuple[torch.Tensor, List[Any]] | Tuple[torch.Tensor, List[Any], List[float], List[Any]]:
         """Retrieve top-k decoded vectors and their metadata.
 
@@ -419,9 +425,9 @@ class HierarchicalMemory:
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:
-                return asyncio.run(self.asearch(query, k))
+                return asyncio.run(self.asearch(query, k, preferences=preferences))
             else:
-                return loop.create_task(self.asearch(query, k))
+                return loop.create_task(self.asearch(query, k, preferences=preferences))
         if self.cache is not None:
             c_vecs, c_meta = self.cache.search(query.detach().cpu().numpy(), k)
         else:
@@ -456,9 +462,20 @@ class HierarchicalMemory:
             self.last_trace = None
             return empty, []
         vec = torch.cat(out_vecs, dim=0)
-        scores = torch.nn.functional.cosine_similarity(
+        base_scores = torch.nn.functional.cosine_similarity(
             vec, query.expand_as(vec), dim=1
-        ).tolist()
+        )
+        if preferences is not None and preferences.vectors:
+            pref_arr = next(iter(preferences.vectors.values()))
+            pref = torch.as_tensor(pref_arr, dtype=vec.dtype, device=vec.device)
+            if pref.numel() < vec.size(1):
+                pref = torch.nn.functional.pad(pref, (0, vec.size(1) - pref.numel()))
+            elif pref.numel() > vec.size(1):
+                pref = pref[: vec.size(1)]
+            weight = vec @ pref
+            scores = (base_scores * weight).tolist()
+        else:
+            scores = base_scores.tolist()
         if self.retrieval_policy is not None:
             order = self.retrieval_policy.rank(out_meta, scores)
             if order:
@@ -491,10 +508,10 @@ class HierarchicalMemory:
         return vec, out_meta
 
     def search_with_kg(
-        self, query: torch.Tensor, k: int = 5
+        self, query: torch.Tensor, k: int = 5, preferences: "UserPreferences | None" = None
     ) -> Tuple[torch.Tensor, List[Any], List[TimedTriple]]:
         """Retrieve vectors and matching knowledge graph triples."""
-        vecs, meta = self.search(query, k)
+        vecs, meta = self.search(query, k, preferences=preferences)
         triples: list[TimedTriple] = []
         if self.kg is not None:
             for m in meta:
@@ -509,6 +526,7 @@ class HierarchicalMemory:
         return_provenance: bool = False,
         *,
         language: str | None = None,
+        preferences: "UserPreferences | None" = None,
     ) -> Tuple[torch.Tensor, List[Any]] | Tuple[torch.Tensor, List[Any], List[float], List[Any]]:
         """Asynchronously retrieve vectors and metadata."""
         if self.cache is not None:
@@ -548,9 +566,20 @@ class HierarchicalMemory:
             self.last_trace = None
             return empty, []
         vec = torch.cat(out_vecs, dim=0)
-        scores = torch.nn.functional.cosine_similarity(
+        base_scores = torch.nn.functional.cosine_similarity(
             vec, query.expand_as(vec), dim=1
-        ).tolist()
+        )
+        if preferences is not None and preferences.vectors:
+            pref_arr = next(iter(preferences.vectors.values()))
+            pref = torch.as_tensor(pref_arr, dtype=vec.dtype, device=vec.device)
+            if pref.numel() < vec.size(1):
+                pref = torch.nn.functional.pad(pref, (0, vec.size(1) - pref.numel()))
+            elif pref.numel() > vec.size(1):
+                pref = pref[: vec.size(1)]
+            weight = vec @ pref
+            scores = (base_scores * weight).tolist()
+        else:
+            scores = base_scores.tolist()
         if self.retrieval_policy is not None:
             order = self.retrieval_policy.rank(out_meta, scores)
             if order:

--- a/tests/test_preference_memory.py
+++ b/tests/test_preference_memory.py
@@ -1,0 +1,24 @@
+import unittest
+import numpy as np
+import torch
+from asi.hierarchical_memory import HierarchicalMemory
+from asi.user_preferences import UserPreferences
+
+class TestPreferenceMemory(unittest.TestCase):
+    def test_preference_ranking(self):
+        mem = HierarchicalMemory(dim=2, compressed_dim=2, capacity=10)
+        vecs = torch.tensor([[1.0, 0.0], [0.0, 1.0]], dtype=torch.float32)
+        mem.add(vecs, metadata=["a", "b"])
+
+        prefs = UserPreferences(dim=2)
+        prefs.update("u", np.array([0.0, 1.0], dtype=np.float32))
+
+        q = torch.tensor([0.8, 0.6], dtype=torch.float32)
+        _, meta_default = mem.search(q, k=2)
+        self.assertEqual(meta_default[0], "a")
+
+        _, meta_pref = mem.search(q, k=2, preferences=prefs)
+        self.assertEqual(meta_pref[0], "b")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support optional `UserPreferences` in `HierarchicalMemory.search`
- weight similarity scores by preference vectors
- propagate preferences through modality and KG search helpers
- add unit test for preference-based ranking

## Testing
- `pytest tests/test_preference_memory.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a91bc42d48331a1dadc08ff7d6f07