### PR TITLE
Add WASM export utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ meta-rl-refactor sample_log.csv
 
 Run the scripts directly with `python` to see parameter and FLOP estimates.
 
+### Browser inference
+
+Use `scripts/export_wasm.py` to create WebAssembly bundles from the example
+models:
+
+```bash
+python scripts/export_wasm.py
+```
+
+Serve the generated files along with `onnxruntime-web` and load them in the
+browser:
+
+```html
+<script src="node_modules/onnxruntime-web/dist/ort.wasm.min.js"></script>
+<script type="module">
+  import * as ort from 'onnxruntime-web';
+  const session = await ort.InferenceSession.create('wasm_models/world_model.onnx');
+  const output = await session.run({/* inputs */});
+</script>
+```
+
 ## Telemetry
 
 `MemoryServer` can record resource usage via `TelemetryLogger`. Metrics start

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -391,6 +391,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     with top-k sparsification or quantized gradients and integrate it with
     `DistributedTrainer`.
 56. **ONNX export**: Provide `export_to_onnx()` and a script to save `MultiModalWorldModel` and `CrossModalFusion` as ONNX graphs.
+56a. **WASM export**: Add `export_to_wasm()` to turn the ONNX graphs into WebAssembly bundles for `onnxruntime-web`.
 57. **Memory profiling**: Instrument `HierarchicalMemory` with a lightweight profiler that records query counts, hit/miss ratios and latency.
 58. **Secure federated learner**: Train models across remote peers using encrypted gradient aggregation. Accuracy should stay within 2% of centralized training.
 59. **GPU-aware scheduler**: Monitor GPU memory and compute load to dispatch jobs dynamically. Combined with `ComputeBudgetTracker`, the new `AdaptiveScheduler` automatically pauses or resumes runs based on remaining GPU hours and historical improvement. *Carbon-intensity data now guide the scheduler to prefer lower-emission nodes, reducing the environmental footprint.*

--- a/scripts/export_wasm.py
+++ b/scripts/export_wasm.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Export models to WebAssembly format using onnxruntime-web."""
+
+from pathlib import Path
+
+from asi.multimodal_world_model import MultiModalWorldModel, MultiModalWorldModelConfig
+from asi.cross_modal_fusion import CrossModalFusion, CrossModalFusionConfig
+from asi.onnx_utils import export_to_onnx, export_to_wasm
+
+
+def main() -> None:
+    out_dir = Path("wasm_models")
+    out_dir.mkdir(exist_ok=True)
+
+    world_cfg = MultiModalWorldModelConfig(vocab_size=10, img_channels=3, action_dim=4)
+    fusion_cfg = CrossModalFusionConfig(
+        vocab_size=10, text_dim=32, img_channels=3, audio_channels=2, latent_dim=16
+    )
+
+    world_model = MultiModalWorldModel(world_cfg)
+    fusion_model = CrossModalFusion(fusion_cfg)
+
+    world_onnx = out_dir / "world_model.onnx"
+    fusion_onnx = out_dir / "fusion.onnx"
+
+    export_to_onnx(world_model, str(world_onnx))
+    export_to_onnx(fusion_model, str(fusion_onnx))
+
+    export_to_wasm(world_onnx, out_dir / "world_model")
+    export_to_wasm(fusion_onnx, out_dir / "fusion")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/onnx_utils.py
+++ b/src/onnx_utils.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 import torch
 from torch import nn
 
@@ -42,4 +45,26 @@ def export_to_onnx(model: nn.Module, path: str) -> None:
         )
 
 
-__all__ = ["export_to_onnx"]
+def export_to_wasm(onnx_path: str | Path, output_dir: str | Path) -> None:
+    """Convert an ONNX model into a WebAssembly bundle via ``onnxruntime-web``."""
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "npx",
+        "onnxruntime-web",
+        "build",
+        "--input",
+        str(onnx_path),
+        "--output",
+        str(out),
+    ]
+    try:
+        subprocess.check_call(cmd)
+    except FileNotFoundError as exc:  # pragma: no cover - env dependent
+        raise RuntimeError(
+            "Node.js with the onnxruntime-web package is required for WASM export"
+        ) from exc
+
+
+__all__ = ["export_to_onnx", "export_to_wasm"]


### PR DESCRIPTION
## Summary
- enable WebAssembly export with `export_to_wasm()`
- provide `scripts/export_wasm.py` to export demo models
- document browser inference workflow
- mention WASM export in the roadmap

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a91be3210833187f9cf78ae8e54db