### PR TITLE
Enhance bio memory replay and consolidation

### DIFF
--- a/src/bio_memory_replay.py
+++ b/src/bio_memory_replay.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import torch
 
 from .hierarchical_memory import HierarchicalMemory
@@ -17,29 +19,38 @@ class BioMemoryReplayer:
         self.memory = memory
         self.batch_size = batch_size
 
-    def reconstruct_sequences(self) -> torch.Tensor:
-        """Return reconstructed embeddings from the memory."""
+    def reconstruct_sequences(self) -> tuple[torch.Tensor, list[Any]]:
+        """Return reconstructed embeddings and their metadata."""
         data = []
+        out_meta: list[Any] = []
         metas = getattr(self.memory.store, "_meta", [])
         for vec, meta in zip(self.memory.compressor.buffer.data, metas):
-            if isinstance(self.memory, ContextSummaryMemory) and isinstance(meta, dict) and "ctxsum" in meta:
+            if (
+                isinstance(self.memory, ContextSummaryMemory)
+                and isinstance(meta, dict)
+                and "ctxsum" in meta
+            ):
                 text = meta["ctxsum"]["summary"]
                 vec = self.memory.summarizer.expand(text)
             data.append(vec.detach().clone())
+            out_meta.append(meta)
         if data:
-            return torch.stack(data)
-        return torch.empty(0, self.memory.compressor.encoder.in_features)
+            return torch.stack(data), out_meta
+        dim = self.memory.compressor.encoder.in_features
+        return torch.empty(0, dim), []
 
     def replay(self) -> None:
         """Feed reconstructed embeddings through the model."""
-        seqs = self.reconstruct_sequences()
+        seqs, metas = self.reconstruct_sequences()
         if seqs.numel() == 0:
             return
         device = next(self.model.parameters()).device
         with torch.no_grad():
             for i in range(0, len(seqs), self.batch_size):
                 batch = seqs[i : i + self.batch_size].to(device)
-                self.model(batch)
+                out = self.model(batch)
+                comp = self.memory.compressor.encoder(out).cpu()
+                self.memory.add_compressed(comp, metas[i : i + self.batch_size])
 
 
 def run_nightly_replay(trainer: DistributedTrainer, model: torch.nn.Module, memory: HierarchicalMemory | ContextSummaryMemory, batch_size: int = 32) -> None:

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -284,6 +284,56 @@ class HierarchicalMemory:
                     self.kg.add_triples(triples)
             self._evict_if_needed()
 
+    def add_compressed(
+        self, comp: torch.Tensor, metadata: Iterable[Any] | None = None
+    ) -> None:
+        """Store already-compressed vectors directly in the vector store."""
+        if isinstance(self.store, AsyncFaissVectorStore):
+            import asyncio
+
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(self.aadd_compressed(comp, metadata))
+            else:
+                return loop.create_task(self.aadd_compressed(comp, metadata))
+        arr = comp.detach().cpu().numpy()
+        metas = list(metadata) if metadata is not None else []
+        if not metas:
+            metas = [self._next_id + i for i in range(arr.shape[0])]
+            self._next_id += arr.shape[0]
+        self.store.add(arr, metas)
+        for m in metas:
+            self._usage[m] = 0
+        if self.kg is not None:
+            triples = [t for t in metas if isinstance(t, tuple) and len(t) == 3]
+            if triples:
+                self.kg.add_triples(triples)
+        self._evict_if_needed()
+
+    async def aadd_compressed(
+        self, comp: torch.Tensor, metadata: Iterable[Any] | None = None
+    ) -> None:
+        """Asynchronously store already-compressed vectors."""
+        import asyncio
+        arr = comp.detach().cpu().numpy()
+        metas = list(metadata) if metadata is not None else []
+        if not metas:
+            metas = [self._next_id + i for i in range(arr.shape[0])]
+            self._next_id += arr.shape[0]
+        if isinstance(self.store, AsyncFaissVectorStore):
+            await self.store.aadd(arr, metas)
+        else:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self.store.add, arr, metas)
+        for m in metas:
+            self._usage[m] = 0
+        if self.kg is not None:
+            triples = [t for t in metas if isinstance(t, tuple) and len(t) == 3]
+            if triples:
+                self.kg.add_triples(triples)
+        self._evict_if_needed()
+
     def add_multimodal(
         self,
         text: torch.Tensor,


### PR DESCRIPTION
## Summary
- compress replayed sequences before inserting back into memory
- support adding already-compressed vectors to HierarchicalMemory
- allow nightly consolidation hooks in DistributedTrainer
- cover new functionality with tests

## Testing
- `pytest tests/test_bio_memory_replay.py tests/test_bio_consolidation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a91c1d8b08331bd855db270e88f37