### PR TITLE
Add FHE federated trainer

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -460,6 +460,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     `ZKGradientProof` for each encrypted gradient. `FederatedWorldModelTrainer`
     verifies these proofs before applying updates so compromised peers cannot
     inject arbitrary gradients.
+85a. **FHE gradient aggregation**: `FHEFederatedTrainer` wraps the secure learner
+     and uses `run_fhe` to decrypt TenSEAL-encrypted gradients. Reward on the RL
+     benchmark should drop less than 5% versus plaintext training.
 86. **Offline memory replay**: `run_nightly_replay()` schedules daily sessions
     where embeddings from `HierarchicalMemory` and `ContextSummaryMemory` are
     reconstructed and passed through the model for consolidation. Integrated

--- a/scripts/federated_world_model_train.py
+++ b/scripts/federated_world_model_train.py
@@ -1,12 +1,18 @@
 import argparse
 import torch
 from asi.world_model_rl import RLBridgeConfig, TransitionDataset
-from asi.federated_world_model_trainer import FederatedWorldModelTrainer, FederatedTrainerConfig
+from asi.federated_world_model_trainer import (
+    FederatedWorldModelTrainer,
+    FederatedTrainerConfig,
+)
+from asi.fhe_federated_trainer import FHEFederatedTrainer, FHEFederatedTrainerConfig
+import tenseal as ts
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Federated world model training")
     parser.add_argument("--rounds", type=int, default=1)
     parser.add_argument("--local-epochs", type=int, default=1, dest="local_epochs")
+    parser.add_argument("--use-fhe", action="store_true", help="train with FHE-encrypted gradients")
     args = parser.parse_args()
 
     cfg = RLBridgeConfig(state_dim=4, action_dim=2)
@@ -21,7 +27,20 @@ def main() -> None:
     ds1 = TransitionDataset(data1)
     ds2 = TransitionDataset(data2)
     tcfg = FederatedTrainerConfig(rounds=args.rounds, local_epochs=args.local_epochs)
-    trainer = FederatedWorldModelTrainer(cfg, [ds1, ds2], trainer_cfg=tcfg)
+    if args.use_fhe:
+        ctx = ts.context(
+            ts.SCHEME_TYPE.CKKS,
+            poly_modulus_degree=8192,
+            coeff_mod_bit_sizes=[60, 40, 40, 60],
+        )
+        ctx.generate_galois_keys()
+        ctx.global_scale = 2**40
+        ftcfg = FHEFederatedTrainerConfig(
+            rounds=args.rounds, local_epochs=args.local_epochs, lr=tcfg.lr
+        )
+        trainer = FHEFederatedTrainer(cfg, [ds1, ds2], ctx, trainer_cfg=ftcfg)
+    else:
+        trainer = FederatedWorldModelTrainer(cfg, [ds1, ds2], trainer_cfg=tcfg)
     model = trainer.train()
     torch.save(model.state_dict(), "federated_model.pt")
     print("saved model to federated_model.pt")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -202,6 +202,7 @@ from .federated_world_model_trainer import (
     FederatedWorldModelTrainer,
     FederatedTrainerConfig,
 )
+from .fhe_federated_trainer import FHEFederatedTrainer, FHEFederatedTrainerConfig
 from .adversarial_robustness import AdversarialRobustnessSuite
 from .graph_of_thought import ReasoningDebugger
 from .multi_stage_oversight import MultiStageOversight

--- a/src/fhe_federated_trainer.py
+++ b/src/fhe_federated_trainer.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+import torch
+
+try:
+    import tenseal as ts  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    ts = None
+
+from .secure_federated_learner import SecureFederatedLearner
+from .zk_gradient_proof import ZKGradientProof
+from .world_model_rl import RLBridgeConfig, WorldModel, TransitionDataset
+from .fhe_runner import run_fhe
+
+
+@dataclass
+class FHEFederatedTrainerConfig:
+    rounds: int = 1
+    local_epochs: int = 1
+    lr: float = 1e-4
+
+
+class FHEFederatedTrainer:
+    """Federated trainer that encrypts gradients via TenSEAL."""
+
+    def __init__(
+        self,
+        cfg: RLBridgeConfig,
+        datasets: Iterable[TransitionDataset],
+        ctx: "ts.Context",
+        learner: SecureFederatedLearner | None = None,
+        trainer_cfg: FHEFederatedTrainerConfig | None = None,
+    ) -> None:
+        if ts is None:
+            raise ImportError("tenseal is required for FHEFederatedTrainer")
+        self.cfg = cfg
+        self.datasets = list(datasets)
+        self.ctx = ctx
+        self.learner = learner or SecureFederatedLearner()
+        self.tcfg = trainer_cfg or FHEFederatedTrainerConfig()
+        self.model = WorldModel(cfg)
+
+    # --------------------------------------------------
+    def _local_gradients(self, dataset: TransitionDataset) -> List[torch.Tensor]:
+        loader = torch.utils.data.DataLoader(
+            dataset, batch_size=self.cfg.batch_size, shuffle=True
+        )
+        params = [p for p in self.model.parameters() if p.requires_grad]
+        grads = [torch.zeros_like(p) for p in params]
+        opt = torch.optim.SGD(params, lr=self.tcfg.lr)
+        loss_fn = torch.nn.MSELoss()
+        for _ in range(self.tcfg.local_epochs):
+            for s, a, ns, r in loader:
+                pred_s, pred_r = self.model(s, a)
+                loss = loss_fn(pred_s, ns) + loss_fn(pred_r, r)
+                opt.zero_grad()
+                loss.backward()
+                for g, p in zip(grads, params):
+                    g += p.grad.detach().clone()
+                opt.step()
+        return [g / len(loader) for g in grads]
+
+    def _decrypt_fhe(self, enc: "ts.CKKSVector") -> torch.Tensor:
+        """Decrypt an encrypted vector using ``run_fhe``."""
+
+        def _model(_: "ts.CKKSVector", vec: "ts.CKKSVector" = enc) -> "ts.CKKSVector":
+            return vec
+
+        dummy = torch.zeros(enc.size())
+        return run_fhe(_model, dummy, self.ctx)
+
+    def train(self) -> WorldModel:
+        params = [p for p in self.model.parameters() if p.requires_grad]
+        for _ in range(self.tcfg.rounds):
+            enc_grads: List[Tuple["ts.CKKSVector", ZKGradientProof]] = []
+            for ds in self.datasets:
+                grads = self._local_gradients(ds)
+                flat = torch.cat([g.view(-1) for g in grads])
+                enc, proof = self.learner.encrypt(flat, with_proof=True)
+                enc_vec = ts.ckks_vector(self.ctx, enc.tolist())
+                enc_grads.append((enc_vec, proof))
+            dec_grads = [
+                self.learner.decrypt(self._decrypt_fhe(g), proof)
+                for g, proof in enc_grads
+            ]
+            agg = self.learner.aggregate(dec_grads)
+            start = 0
+            for p in params:
+                num = p.numel()
+                g = agg[start : start + num].view_as(p)
+                p.data -= self.tcfg.lr * g
+                start += num
+        return self.model
+
+
+__all__ = ["FHEFederatedTrainer", "FHEFederatedTrainerConfig"]


### PR DESCRIPTION
## Summary
- support federated training with FHE encrypted gradients
- allow `scripts/federated_world_model_train.py` to enable FHE with `--use-fhe`
- export new trainer via the package init
- document FHE gradient aggregation in the plan

## Testing
- `pytest tests/test_fhe_runner.py tests/test_federated_world_model_trainer.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a91cd93e8833181692efcb00d40d6