### PR TITLE
Add multi-provider scheduler and region config

### DIFF
--- a/configs/region_providers.yaml
+++ b/configs/region_providers.yaml
@@ -1,0 +1,4 @@
+us-east-1: aws
+us-central1: gcp
+eastus: azure
+default: aws

--- a/scripts/resource_broker_demo.py
+++ b/scripts/resource_broker_demo.py
@@ -5,17 +5,22 @@ from __future__ import annotations
 
 import random
 from asi.resource_broker import ResourceBroker
+from asi.cost_aware_scheduler import MultiProviderScheduler
 
 
 def main() -> None:
     broker = ResourceBroker()
     broker.register_cluster("cloud", 4)
     broker.register_cluster("on_prem", 2)
+    sched = MultiProviderScheduler(region="us-east-1")
     for i in range(3):
         metrics = {"cpu": random.randint(20, 90), "gpu": random.randint(20, 90)}
         decision = broker.scale_decision(metrics)
         cluster = broker.allocate(f"job{i}")
-        print(f"job{i} -> {cluster}, decision={decision}, metrics={metrics}")
+        job_id = sched.submit_at_optimal_time(["echo", f"running {cluster}"])
+        print(
+            f"job{i} -> {cluster}, decision={decision}, metrics={metrics}, job_id={job_id}"
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover - demo


### PR DESCRIPTION
## Summary
- extend cost-aware scheduler with Azure support and add `MultiProviderScheduler`
- select provider based on combined carbon and price forecast
- let AdaptiveScheduler load region provider map
- demo provider selection in `resource_broker_demo.py`
- add `configs/region_providers.yaml`

## Testing
- `pytest tests/test_cost_aware_scheduler.py tests/test_adaptive_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a91d1b15083319d51e9e04e917a8e