### PR TITLE
Add memory timeline viewer and endpoint

### DIFF
--- a/src/memory_dashboard.py
+++ b/src/memory_dashboard.py
@@ -10,6 +10,7 @@ import torch
 
 from .retrieval_explainer import RetrievalExplainer
 from .retrieval_visualizer import RetrievalVisualizer
+from .memory_timeline_viewer import MemoryTimelineViewer
 
 from .hierarchical_memory import MemoryServer
 
@@ -164,6 +165,15 @@ class MemoryDashboard:
                     self.send_header("Content-Type", "text/html")
                     self.end_headers()
                     self.wfile.write(html)
+                elif self.path == "/timeline":
+                    viewer = None
+                    if dashboard.servers and dashboard.servers[0].telemetry is not None:
+                        viewer = MemoryTimelineViewer(dashboard.servers[0].telemetry)
+                    data = viewer.to_json().encode() if viewer else b"{}"
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
                 elif self.path in ("/stats", "/json"):
                     data = json.dumps(dashboard.aggregate()).encode()
                     self.send_response(200)

--- a/src/memory_timeline_viewer.py
+++ b/src/memory_timeline_viewer.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, Any, List
+
+from .telemetry import TelemetryLogger
+from .memory_event_detector import MemoryEventDetector
+
+
+class MemoryTimelineViewer:
+    """Build a JSON timeline from telemetry history and events."""
+
+    def __init__(self, telemetry: TelemetryLogger) -> None:
+        self.telemetry = telemetry
+        # keep reference to the event detector for convenience
+        self.detector: MemoryEventDetector = telemetry.event_detector
+
+    # --------------------------------------------------------------
+    def build(self) -> Dict[str, Any]:
+        """Return timeline and events as a dictionary."""
+        timeline: List[Dict[str, float]] = []
+        hits = 0.0
+        misses = 0.0
+        for idx, snap in enumerate(self.telemetry.history):
+            hits += float(snap.get("hits", 0.0))
+            misses += float(snap.get("misses", 0.0))
+            total = hits + misses
+            hit_rate = hits / total if total else 0.0
+            latency = float(snap.get("latency", 0.0))
+            intensity = float(snap.get("carbon_intensity", 0.0))
+            ts = idx * float(getattr(self.telemetry, "interval", 1.0))
+            timeline.append(
+                {
+                    "timestamp": ts,
+                    "hit_rate": hit_rate,
+                    "latency": latency,
+                    "carbon_intensity": intensity,
+                }
+            )
+        return {"timeline": timeline, "events": list(self.telemetry.get_events())}
+
+    # --------------------------------------------------------------
+    def to_json(self) -> str:
+        """Return ``build()`` result encoded as JSON."""
+        return json.dumps(self.build())
+
+
+__all__ = ["MemoryTimelineViewer"]

--- a/tests/test_memory_timeline_viewer.py
+++ b/tests/test_memory_timeline_viewer.py
@@ -1,0 +1,62 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import json
+import http.client
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    return mod
+
+MemoryTimelineViewer = _load('asi.memory_timeline_viewer', 'src/memory_timeline_viewer.py').MemoryTimelineViewer
+TelemetryLogger = _load('asi.telemetry', 'src/telemetry.py').TelemetryLogger
+MemoryEventDetector = _load('asi.memory_event_detector', 'src/memory_event_detector.py').MemoryEventDetector
+HierarchicalMemory = _load('asi.hierarchical_memory', 'src/hierarchical_memory.py').HierarchicalMemory
+MemoryDashboard = _load('asi.memory_dashboard', 'src/memory_dashboard.py').MemoryDashboard
+serve = _load('asi.memory_service', 'src/memory_service.py').serve
+
+
+class TestMemoryTimelineViewer(unittest.TestCase):
+    def test_json_output(self):
+        tel = TelemetryLogger(interval=0.1)
+        entry = {"hits": 1, "misses": 1, "latency": 0.2, "carbon_intensity": 0.5}
+        tel.history.append(entry)
+        tel.event_detector.update(entry)
+        viewer = MemoryTimelineViewer(tel)
+        data = json.loads(viewer.to_json())
+        self.assertEqual(len(data["timeline"]), 1)
+        self.assertEqual(data["timeline"][0]["hit_rate"], 0.5)
+        self.assertTrue(data["events"])  # event recorded
+
+    def test_dashboard_integration(self):
+        mem = HierarchicalMemory(dim=2, compressed_dim=1, capacity=10)
+        tel = TelemetryLogger(interval=0.1)
+        entry = {"hits": 1, "misses": 0, "latency": 0.1, "carbon_intensity": 0.4}
+        tel.history.append(entry)
+        tel.event_detector.update(entry)
+        server = serve(mem, 'localhost:50920', telemetry=tel)
+        dash = MemoryDashboard([server])
+        dash.start(port=0)
+        port = dash.port
+        conn = http.client.HTTPConnection('localhost', port)
+        conn.request('GET', '/timeline')
+        resp = conn.getresponse()
+        data = json.loads(resp.read())
+        dash.stop()
+        server.stop(0)
+        self.assertEqual(len(data['timeline']), 1)
+        self.assertEqual(data['timeline'][0]['carbon_intensity'], 0.4)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `MemoryTimelineViewer` for streaming telemetry timelines
- expose `/timeline` on `MemoryDashboard`
- test JSON emission and dashboard integration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for many dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a91e118308331bfec6bbc23294eaf