### PR TITLE
Add adaptive translator module

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -122,6 +122,7 @@ from .data_ingest import (
     ActiveDataSelector,
     CrossLingualTranslator,
 )
+from .adaptive_translator import AdaptiveTranslator
 from .generative_data_augmentor import GenerativeDataAugmentor
 from .diffusion_world_model import DiffusionWorldModel
 from .causal_graph_learner import CausalGraphLearner

--- a/src/adaptive_translator.py
+++ b/src/adaptive_translator.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import random
+from typing import Dict
+
+from .data_ingest import CrossLingualTranslator
+
+
+class AdaptiveTranslator:
+    """Learn which language yields better translations using Q-values."""
+
+    def __init__(self, translator: CrossLingualTranslator, epsilon: float = 0.1, alpha: float = 0.5) -> None:
+        self.translator = translator
+        self.epsilon = float(epsilon)
+        self.alpha = float(alpha)
+        self.q: Dict[str, float] = {l: 0.0 for l in translator.languages}
+        self.last_lang: str | None = None
+
+    # ------------------------------------------------------------------
+    def choose_language(self) -> str:
+        """Return a language index using epsilon-greedy selection."""
+        if random.random() < self.epsilon:
+            return random.choice(self.translator.languages)
+        return max(self.translator.languages, key=lambda l: self.q.get(l, 0.0))
+
+    def translate(self, text: str, lang: str | None = None) -> str:
+        """Translate ``text`` using ``lang`` or a learned preference."""
+        if lang is None:
+            lang = self.choose_language()
+        self.last_lang = lang
+        return self.translator._basic_translate(text, lang)
+
+    def update(self, reward: float, lang: str | None = None) -> None:
+        """Update Q-value for ``lang`` (defaults to last)."""
+        l = lang or self.last_lang
+        if l is None:
+            return
+        if l not in self.translator.languages:
+            raise ValueError(f"unsupported language: {l}")
+        current = self.q.get(l, 0.0)
+        self.q[l] = current + self.alpha * (reward - current)
+
+
+__all__ = ["AdaptiveTranslator"]

--- a/src/data_ingest.py
+++ b/src/data_ingest.py
@@ -162,16 +162,29 @@ class ActiveDataSelector:
 class CrossLingualTranslator:
     """Translate text to multiple languages using simple placeholders."""
 
-    def __init__(self, languages: Iterable[str]) -> None:
+    def __init__(
+        self,
+        languages: Iterable[str],
+        adaptive: "AdaptiveTranslator | None" = None,
+    ) -> None:
         self.languages = list(languages)
+        self.adaptive = adaptive
 
-    def translate(self, text: str, lang: str) -> str:
+    # ------------------------------------------------------
+    def _basic_translate(self, text: str, lang: str) -> str:
         if lang not in self.languages:
             raise ValueError(f"unsupported language: {lang}")
         return f"[{lang}] {text}"
 
+    def translate(self, text: str, lang: str | None = None) -> str:
+        if lang is None and self.adaptive is not None:
+            return self.adaptive.translate(text)
+        if lang is None:
+            raise ValueError("language must be specified")
+        return self._basic_translate(text, lang)
+
     def translate_all(self, text: str) -> Dict[str, str]:
-        return {l: self.translate(text, l) for l in self.languages}
+        return {l: self._basic_translate(text, l) for l in self.languages}
 
 
 class CrossLingualSpeechTranslator:

--- a/tests/test_adaptive_translator.py
+++ b/tests/test_adaptive_translator.py
@@ -1,0 +1,49 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+
+sys.modules['torch'] = types.ModuleType('torch')
+sys.modules['requests'] = types.ModuleType('requests')
+sys.modules['aiohttp'] = types.ModuleType('aiohttp')
+sys.modules['PIL'] = types.ModuleType('PIL')
+sys.modules['PIL.Image'] = types.ModuleType('PIL.Image')
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+
+di = load('asi.data_ingest', 'src/data_ingest.py')
+at = load('asi.adaptive_translator', 'src/adaptive_translator.py')
+
+CrossLingualTranslator = di.CrossLingualTranslator
+AdaptiveTranslator = at.AdaptiveTranslator
+
+
+class TestAdaptiveTranslator(unittest.TestCase):
+    def test_reward_guides_translation(self):
+        tr = CrossLingualTranslator(['en', 'fr'])
+        adapt = AdaptiveTranslator(tr, epsilon=0.0, alpha=1.0)
+        tr.adaptive = adapt
+        first = tr.translate('hello')
+        self.assertEqual(first, '[en] hello')
+        adapt.update(-1.0, lang='en')
+        adapt.update(1.0, lang='fr')
+        second = tr.translate('world')
+        self.assertEqual(second, '[fr] world')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `AdaptiveTranslator` for reinforcement translation updates
- update `CrossLingualTranslator` to use optional `AdaptiveTranslator`
- export new class in `asi.__init__`
- test reward-driven language selection

## Testing
- `pytest tests/test_adaptive_translator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a91e36a548331a04dfb3a6ffcab10