### PR TITLE
Add reinforcement learning MoE router

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -11,6 +11,8 @@ This repository includes starter modules for the first two algorithms listed in 
   - `ElasticMoERouter` dynamically reduces the number of active experts when GPU
     memory utilization gets high. It inherits from `SwitchRouter` and exposes
     `active_experts` to track the current count.
+  - `RLMoERouter` learns routing probabilities with a REINFORCE update and
+    mirrors the `ElasticMoERouter` API for plug-and-play experiments.
 - `src/moe_layer.py` implements a small MoE feed-forward block using these routers. It accepts an optional
   `balance_weight` which multiplies the `balance_loss()` penalty derived from the router's assignments and
   returns it alongside the layer output.
@@ -583,6 +585,8 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   architecture search. **Implemented in `src/quantum_hpo.py` with unit tests.**
 - **Implemented** an `ElasticMoERouter` that scales the number of active experts
   according to real-time GPU utilization.
+- **Implemented** an `RLMoERouter` that trains routing weights via a simple
+  reinforcement learning loop for improved load balance.
 - Extend `HierarchicalMemory` with an `SSDCache` that prefetches high-frequency
   vectors for faster retrieval. *Implemented with a disk-backed cache and
   persistence helpers in `src/hierarchical_memory.py`.*

--- a/src/rl_moe_router.py
+++ b/src/rl_moe_router.py
@@ -1,0 +1,53 @@
+import torch
+from typing import Callable
+
+from .moe_router import SwitchRouter
+
+
+class RLMoERouter(SwitchRouter):
+    """Switch router that learns routing probabilities with REINFORCE."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_experts: int,
+        k: int = 2,
+        temperature: float = 1.0,
+        min_util: float = 0.5,
+        max_util: float = 0.9,
+        utilization_fn: Callable[[], float] | None = None,
+        lr: float = 0.1,
+    ) -> None:
+        super().__init__(dim=dim, num_experts=num_experts, k=k, temperature=temperature)
+        self.min_util = min_util
+        self.max_util = max_util
+        self.utilization_fn = utilization_fn
+        self.lr = lr
+        self.baseline = 0.0
+        self.prefs = torch.zeros(num_experts, dtype=torch.float32)
+
+    def forward(self, x: torch.Tensor):
+        probs = torch.softmax(self.prefs / self.temperature, dim=0)
+        batch, seq, _ = x.shape
+        flat_probs = probs.repeat(batch * seq, 1)
+        flat_assign = torch.multinomial(flat_probs, self.k, replacement=True)
+        assignments = flat_assign.view(batch, seq, self.k)
+        weights = probs[assignments]
+
+        reward = -self.load_balance_std(assignments)
+        adv = reward - self.baseline
+        self.baseline += self.lr * adv
+        counts = torch.bincount(assignments.view(-1), minlength=self.num_experts).float()
+        freq = counts / counts.sum()
+        for i in range(self.num_experts):
+            grad = adv * (freq[i] - probs[i])
+            self.prefs[i] += self.lr * grad
+
+        return assignments, weights
+
+    def load_balance_std(self, assignments: torch.Tensor) -> float:
+        counts = torch.bincount(assignments.view(-1), minlength=self.num_experts).float()
+        return (counts.std() / counts.mean()).item()
+
+
+__all__ = ["RLMoERouter"]

--- a/tests/test_rl_moe_router.py
+++ b/tests/test_rl_moe_router.py
@@ -1,0 +1,51 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+import unittest
+import torch
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+loader = importlib.machinery.SourceFileLoader('asi.moe_router', 'src/moe_router.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+moe_router = importlib.util.module_from_spec(spec)
+moe_router.__package__ = 'asi'
+sys.modules['asi.moe_router'] = moe_router
+loader.exec_module(moe_router)
+
+loader2 = importlib.machinery.SourceFileLoader('asi.rl_moe_router', 'src/rl_moe_router.py')
+spec2 = importlib.util.spec_from_loader(loader2.name, loader2)
+rl_mod = importlib.util.module_from_spec(spec2)
+rl_mod.__package__ = 'asi'
+sys.modules['asi.rl_moe_router'] = rl_mod
+loader2.exec_module(rl_mod)
+
+RLMoERouter = rl_mod.RLMoERouter
+
+
+class TestRLMoERouter(unittest.TestCase):
+    def test_balance_improves(self):
+        router = RLMoERouter(dim=8, num_experts=4, lr=0.5)
+        x = torch.randn(4, 4, 8)
+        assign, _ = router(x)
+        before = router.load_balance_std(assign)
+        for _ in range(100):
+            router(x)
+        assign, _ = router(x)
+        after = router.load_balance_std(assign)
+        self.assertLess(after, before)
+
+    def test_convergence(self):
+        router = RLMoERouter(dim=8, num_experts=4, lr=0.5)
+        x = torch.randn(4, 4, 8)
+        for _ in range(200):
+            router(x)
+        assign, _ = router(x)
+        std = router.load_balance_std(assign)
+        self.assertLess(std, 0.4)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `RLMoERouter` for REINFORCE-based expert routing
- test RL router load balance and convergence
- document RL router under S-1 section

## Testing
- `pytest tests/test_rl_moe_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686ae412c08c83318f3c35e778809121