### PR TITLE
Implement blockchain-based provenance logging

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -698,6 +698,7 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   **Implemented in `src/dataset_versioner.py` and wired through `data_ingest`.**
 - Add a `DatasetLineageManager` that records transformation steps and resulting file hashes for reproducible pipelines.
   **Implemented in `src/dataset_lineage_manager.py` with tests.**
+- Introduce a `BlockchainProvenanceLedger` that links each record to the previous hash. Ingestion helpers append their lineage to this ledger and `scripts/check_blockchain_provenance.py` verifies the chain.
 - Implement a `ContextWindowProfiler` that measures memory footprint and wall-clock time at various sequence lengths. **Implemented as `src/context_profiler.py` and integrated with `eval_harness.py`.**
 - Extend `HierarchicalMemory` with an adaptive eviction policy that prunes rarely used vectors and emit statistics on hit/miss ratios.
   **Implemented** via `adaptive_evict` in `HierarchicalMemory` with `get_stats()` to report usage metrics.

--- a/scripts/check_blockchain_provenance.py
+++ b/scripts/check_blockchain_provenance.py
@@ -1,0 +1,20 @@
+import argparse
+import json
+from pathlib import Path
+from asi.dataset_lineage_manager import DatasetLineageManager
+from asi.blockchain_provenance_ledger import BlockchainProvenanceLedger
+
+
+def main(root: str) -> None:
+    mgr = DatasetLineageManager(root)
+    ledger = BlockchainProvenanceLedger(root)
+    records = [json.dumps(step.__dict__, sort_keys=True) for step in mgr.steps]
+    ok = ledger.verify(records)
+    print("OK" if ok else "CORRUPTED")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description="Verify blockchain provenance ledger")
+    p.add_argument("root", help="Dataset root")
+    args = p.parse_args()
+    main(args.root)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -226,6 +226,7 @@ from .quantum_multimodal_retrieval import quantum_crossmodal_search
 from .risk_scoreboard import RiskScoreboard
 from .semantic_drift_detector import SemanticDriftDetector
 from .data_provenance_ledger import DataProvenanceLedger
+from .blockchain_provenance_ledger import BlockchainProvenanceLedger
 from .fairness_evaluator import FairnessEvaluator
 from .cross_lingual_fairness import CrossLingualFairnessEvaluator
 from .risk_dashboard import RiskDashboard

--- a/src/blockchain_provenance_ledger.py
+++ b/src/blockchain_provenance_ledger.py
@@ -1,0 +1,44 @@
+import json
+import hashlib
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .data_provenance_ledger import DataProvenanceLedger
+
+
+class BlockchainProvenanceLedger(DataProvenanceLedger):
+    """Provenance ledger implemented as a simple hash-linked blockchain."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.path = Path(root) / "provenance_chain.jsonl"
+        self.entries: list[dict[str, str]] = []
+        if self.path.exists():
+            for line in self.path.read_text().splitlines():
+                self.entries.append(json.loads(line))
+
+    # --------------------------------------------------------------
+    def append(self, record: str, signature: Optional[str] = None) -> None:
+        prev = self.entries[-1]["hash"] if self.entries else ""
+        h = hashlib.sha256((prev + record).encode()).hexdigest()
+        entry = {"hash": h, "prev": prev}
+        if signature is not None:
+            entry["sig"] = signature
+        self.entries.append(entry)
+        with open(self.path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+
+    # --------------------------------------------------------------
+    def verify(self, records: Iterable[str]) -> bool:
+        rec_list = list(records)
+        if len(rec_list) != len(self.entries):
+            return False
+        prev = ""
+        for entry, rec in zip(self.entries, rec_list):
+            h = hashlib.sha256((prev + rec).encode()).hexdigest()
+            if h != entry.get("hash") or entry.get("prev") != prev:
+                return False
+            prev = entry["hash"]
+        return True
+
+
+__all__ = ["BlockchainProvenanceLedger"]

--- a/tests/test_blockchain_provenance.py
+++ b/tests/test_blockchain_provenance.py
@@ -1,0 +1,37 @@
+import tempfile
+import json
+import unittest
+import importlib.machinery
+import importlib.util
+import sys
+import types
+
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+src_pkg.__path__ = ['src']
+src_pkg.__spec__ = importlib.machinery.ModuleSpec('src', None, is_package=True)
+loader = importlib.machinery.SourceFileLoader('src.blockchain_provenance_ledger', 'src/blockchain_provenance_ledger.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+mod.__package__ = 'src'
+sys.modules['src.blockchain_provenance_ledger'] = mod
+sys.modules['asi.blockchain_provenance_ledger'] = mod
+loader.exec_module(mod)
+BlockchainProvenanceLedger = mod.BlockchainProvenanceLedger
+
+
+class TestBlockchainProvenance(unittest.TestCase):
+    def test_append_and_verify(self):
+        with tempfile.TemporaryDirectory() as root:
+            ledger = BlockchainProvenanceLedger(root)
+            recs = [json.dumps({'i': i}) for i in range(3)]
+            for r in recs:
+                ledger.append(r)
+            self.assertTrue(ledger.verify(recs))
+            # tamper with a record
+            recs[1] = json.dumps({'i': 99})
+            self.assertFalse(ledger.verify(recs))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `BlockchainProvenanceLedger` for hash-linked provenance
- let data ingestion optionally record provenance to this chain
- provide `check_blockchain_provenance.py` helper
- document the workflow and stub versioner for tests
- test blockchain ledger verification

## Testing
- `pytest -q tests/test_blockchain_provenance.py`
- `pytest -q tests/test_data_ingest.py::TestDataIngest::test_download_triples_version tests/test_data_ingest.py::TestDataIngest::test_offline_synthesizer_version`
- `pytest -q tests/test_data_ingest.py::TestDataIngest::test_download_triples tests/test_data_ingest.py::TestDataIngest::test_download_triples_anonymizer tests/test_data_ingest.py::TestDataIngest::test_offline_synthesizer tests/test_data_ingest.py::TestDataIngest::test_paraphrase_multilingual`


------
https://chatgpt.com/codex/tasks/task_e_686ae4155eb48331ad1cba1a09e57736