### PR TITLE
Add dataset lineage viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository experiments with algorithms needed for self-improving AI. The bi
 - `python -m src.autobench` runs each test file in isolation and reports a summary.
 - `meta-rl-refactor` parses action/reward logs and suggests the next refactoring step.
 - `scripts/dataset_summary.py` prints lineage and license info. Use `--content` to cluster dataset samples and store summaries under `docs/datasets/`.
+- `scripts/lineage_viewer.py <root>` serves an interactive graph of the dataset lineage.
 - `scripts/ar_robot_demo.py` streams predicted and actual robot trajectories to a WebSocket server for lightweight AR visualization. Pass `--show-graph` to also broadcast `GraphOfThought` nodes.
 
 Example:

--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -505,6 +505,7 @@ lineage = DatasetLineageManager("./data")
 
 triples = download_triples(text_urls, img_urls, aud_urls, "./data", lineage=lineage, runner=runner)
 paraphrase_multilingual([Path("./data/text/0.txt")], translator, None, inspector, lineage, runner=runner)
+Run `scripts/lineage_viewer.py ./data` to browse the recorded steps.
 ```
 
 ## L-6 Mechanistic Interpretability Tools

--- a/scripts/lineage_viewer.py
+++ b/scripts/lineage_viewer.py
@@ -1,0 +1,36 @@
+"""Start a web server to visualize dataset lineage."""
+from __future__ import annotations
+
+import argparse
+import time
+
+try:  # pragma: no cover - prefer package import
+    from asi.dataset_lineage_manager import DatasetLineageManager
+    from asi.lineage_visualizer import LineageVisualizer
+except Exception:  # pragma: no cover - fallback for tests
+    from src.dataset_lineage_manager import DatasetLineageManager  # type: ignore
+    from src.lineage_visualizer import LineageVisualizer  # type: ignore
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Dataset lineage viewer")
+    parser.add_argument("root", help="Dataset root directory")
+    parser.add_argument("--port", type=int, default=8010)
+    args = parser.parse_args(argv)
+
+    mgr = DatasetLineageManager(args.root)
+    mgr.load()
+    viz = LineageVisualizer(mgr)
+    viz.start(port=args.port)
+    print(f"Serving on http://localhost:{viz.port}")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:  # pragma: no cover - manual stop
+        pass
+    finally:
+        viz.stop()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/src/lineage_visualizer.py
+++ b/src/lineage_visualizer.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+from .dataset_lineage_manager import DatasetLineageManager
+
+
+class LineageVisualizer:
+    """Serve an interactive graph of dataset lineage."""
+
+    def __init__(self, manager: DatasetLineageManager) -> None:
+        self.manager = manager
+        self.httpd: HTTPServer | None = None
+        self.thread: threading.Thread | None = None
+        self.port: int | None = None
+
+    # --------------------------------------------------------------
+    def graph_json(self) -> dict[str, list]:
+        nodes: dict[str, dict[str, str]] = {}
+        links: list[dict[str, str]] = []
+        for step in self.manager.steps:
+            for inp in step.inputs:
+                nodes[inp] = {"id": inp}
+            for out in step.outputs.keys():
+                nodes[out] = {"id": out}
+                for inp in step.inputs:
+                    links.append({"source": inp, "target": out, "note": step.note})
+        return {"nodes": list(nodes.values()), "links": links}
+
+    # --------------------------------------------------------------
+    def to_html(self) -> str:
+        return (
+            "<html><body><h1>Dataset Lineage</h1>"
+            "<script src='https://cdn.jsdelivr.net/npm/d3@7'></script>"
+            "<svg width='800' height='600'></svg>"
+            "<script>"
+            "fetch('/graph').then(r=>r.json()).then(data=>{"
+            "const svg=d3.select('svg');"
+            "const width=+svg.attr('width'),height=+svg.attr('height');"
+            "const sim=d3.forceSimulation(data.nodes)"
+            ".force('link',d3.forceLink(data.links).id(d=>d.id).distance(40))"
+            ".force('charge',d3.forceManyBody().strength(-200))"
+            ".force('center',d3.forceCenter(width/2,height/2));"
+            "const link=svg.append('g').selectAll('line')"
+            ".data(data.links).enter().append('line').attr('stroke','#999');"
+            "const node=svg.append('g').selectAll('circle')"
+            ".data(data.nodes).enter().append('circle').attr('r',5)"
+            ".call(d3.drag()"
+            ".on('start',e=>{if(!e.active)sim.alphaTarget(0.3).restart();e.subject.fx=e.subject.x;e.subject.fy=e.subject.y;})"
+            ".on('drag',e=>{e.subject.fx=e.x;e.subject.fy=e.y;})"
+            ".on('end',e=>{if(!e.active)sim.alphaTarget(0);e.subject.fx=null;e.subject.fy=null;}));"
+            "const text=svg.append('g').selectAll('text')"
+            ".data(data.nodes).enter().append('text').text(d=>d.id.split('/').pop());"
+            "sim.on('tick',()=>{"
+            "link.attr('x1',d=>d.source.x).attr('y1',d=>d.source.y)"
+            ".attr('x2',d=>d.target.x).attr('y2',d=>d.target.y);"
+            "node.attr('cx',d=>d.x).attr('cy',d=>d.y);"
+            "text.attr('x',d=>d.x+6).attr('y',d=>d.y+4);"
+            "});"
+            "});"
+            "</script></body></html>"
+        )
+
+    # --------------------------------------------------------------
+    def start(self, port: int = 8000) -> None:
+        if self.httpd is not None:
+            return
+
+        visualizer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: D401
+                if self.path == "/graph":
+                    data = json.dumps(visualizer.graph_json()).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                else:
+                    html = visualizer.to_html().encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/html")
+                    self.end_headers()
+                    self.wfile.write(html)
+
+            def log_message(self, format: str, *args: Any) -> None:  # noqa: D401
+                return
+
+        self.httpd = HTTPServer(("localhost", port), Handler)
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    # --------------------------------------------------------------
+    def stop(self) -> None:
+        if self.httpd is None:
+            return
+        assert self.thread is not None
+        self.httpd.shutdown()
+        self.thread.join(timeout=1)
+        self.httpd.server_close()
+        self.httpd = None
+        self.thread = None
+        self.port = None
+
+
+__all__ = ["LineageVisualizer"]

--- a/tests/test_lineage_visualizer.py
+++ b/tests/test_lineage_visualizer.py
@@ -1,0 +1,43 @@
+import tempfile
+import unittest
+from pathlib import Path
+import importlib.machinery
+import importlib.util
+import sys
+
+
+def _load(name: str, path: str):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    return mod
+
+
+DatasetLineageManager = _load('src.dataset_lineage_manager', 'src/dataset_lineage_manager.py').DatasetLineageManager
+LineageVisualizer = _load('src.lineage_visualizer', 'src/lineage_visualizer.py').LineageVisualizer
+
+
+class TestLineageVisualizer(unittest.TestCase):
+    def test_graph_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            inp = root / 'in.txt'
+            outp = root / 'out.txt'
+            inp.write_text('a')
+            outp.write_text('b')
+            mgr = DatasetLineageManager(root)
+            mgr.record([inp], [outp], note='copy')
+            viz = LineageVisualizer(mgr)
+            data = viz.graph_json()
+            self.assertEqual(len(data['nodes']), 2)
+            self.assertEqual(len(data['links']), 1)
+            link = data['links'][0]
+            self.assertEqual(link['source'], str(inp))
+            self.assertEqual(link['target'], str(outp))
+            self.assertEqual(link['note'], 'copy')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- visualize dataset lineage as an interactive graph via `LineageVisualizer`
- add CLI `lineage_viewer.py` to serve the graph
- test JSON graph generation
- mention the viewer in README and dataset docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numerous packages)*

------
https://chatgpt.com/codex/tasks/task_e_686ae4175f508331b1f7c2d0afb61e68