### PR TITLE
Add A/B evaluation tool

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -178,6 +178,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 - `src/eval_harness.py` aggregates metrics from all modules and prints a pass/fail scoreboard. The CLI now supports a `--concurrent` flag to run evaluations asynchronously via `evaluate_modules_async()`.
 - `scripts/distributed_eval.py` runs the harness across multiple processes or hosts and aggregates the results for large-scale testing.
 - `src/transformer_circuits.py` records attention weights and lets researchers ablate individual heads for interpretability experiments.
+- `src/ab_evaluator.py` compares two `eval_harness` runs given JSON configs so new features can be iteratively benchmarked.
 
 ### Recommended next steps
 

--- a/scripts/ab_evaluate.py
+++ b/scripts/ab_evaluate.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from asi.ab_evaluator import main
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()
+

--- a/src/ab_evaluator.py
+++ b/src/ab_evaluator.py
@@ -1,0 +1,64 @@
+"""A/B evaluation wrapper around :mod:`eval_harness`."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from .eval_harness import parse_modules, evaluate_modules, evaluate_modules_async
+
+ResultDict = Dict[str, Tuple[bool, str]]
+
+
+def _load_config(path: str | Path) -> Dict[str, Any]:
+    return json.loads(Path(path).read_text())
+
+
+def _modules_from_cfg(cfg: Dict[str, Any]) -> list[str]:
+    if "modules" in cfg:
+        return list(cfg["modules"])
+    plan = cfg.get("plan", "docs/Plan.md")
+    return parse_modules(plan)
+
+
+def run_config(path: str | Path, *, concurrent: bool = False) -> ResultDict:
+    cfg = _load_config(path)
+    mods = _modules_from_cfg(cfg)
+    if concurrent:
+        return asyncio.run(evaluate_modules_async(mods))
+    return evaluate_modules(mods)
+
+
+def compare_results(a: ResultDict, b: ResultDict) -> str:
+    modules = sorted(set(a) | set(b))
+    lines = []
+    pass_a = sum(int(res[0]) for res in a.values())
+    pass_b = sum(int(res[0]) for res in b.values())
+    lines.append(
+        f"Pass rate A: {pass_a}/{len(a)} B: {pass_b}/{len(b)} delta={pass_b-pass_a}"
+    )
+    for m in modules:
+        ok_a = int(a.get(m, (False, ""))[0])
+        ok_b = int(b.get(m, (False, ""))[0])
+        delta = ok_b - ok_a
+        lines.append(f"{m}: {ok_a}->{ok_b} delta={delta}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Compare two eval harness runs")
+    parser.add_argument("--config-a", required=True, help="Baseline config JSON")
+    parser.add_argument("--config-b", required=True, help="New config JSON")
+    parser.add_argument("--concurrent", action="store_true", help="Use asyncio")
+    args = parser.parse_args(argv)
+
+    res_a = run_config(args.config_a, concurrent=args.concurrent)
+    res_b = run_config(args.config_b, concurrent=args.concurrent)
+    print(compare_results(res_a, res_b))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_ab_evaluator.py
+++ b/tests/test_ab_evaluator.py
@@ -1,0 +1,65 @@
+import unittest
+import json
+import tempfile
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import numpy as np
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+sys.modules['scripts'] = types.ModuleType('scripts')
+
+torch = types.ModuleType('torch')
+torch.randn = lambda *s: np.random.randn(*s).astype(np.float32)
+torch.randint = lambda low, high, size: np.random.randint(low, high, size)
+torch.cuda = types.SimpleNamespace(
+    is_available=lambda: False,
+    max_memory_allocated=lambda: 0,
+    reset_peak_memory_stats=lambda: None,
+)
+sys.modules['torch'] = torch
+
+PIL = types.ModuleType('PIL')
+PIL.Image = object
+sys.modules['PIL'] = PIL
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+# Load minimal dependencies
+_load('asi.fairness_evaluator', 'src/fairness_evaluator.py')
+_load('asi.data_ingest', 'src/data_ingest.py')
+_load('asi.cross_lingual_fairness', 'src/cross_lingual_fairness.py')
+_load('asi.emotion_detector', 'src/emotion_detector.py')
+_load('asi.eval_harness', 'src/eval_harness.py')
+ab_mod = _load('asi.ab_evaluator', 'src/ab_evaluator.py')
+
+run_config = ab_mod.run_config
+compare_results = ab_mod.compare_results
+
+
+class TestABEvaluator(unittest.TestCase):
+    def test_compare_output_contains_delta(self):
+        with tempfile.NamedTemporaryFile('w+', suffix='.json') as a, tempfile.NamedTemporaryFile('w+', suffix='.json') as b:
+            json.dump({'modules': ['cross_lingual_fairness']}, a)
+            a.flush()
+            json.dump({'modules': ['cross_lingual_fairness', 'emotion_detector']}, b)
+            b.flush()
+            res_a = run_config(a.name)
+            res_b = run_config(b.name)
+            out = compare_results(res_a, res_b)
+            self.assertIn('delta=', out)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- implement `ab_evaluator` to compare two eval_harness runs
- provide CLI entry `ab_evaluate.py`
- test A/B evaluator output for deltas
- document iterative comparison of new features

## Testing
- `python -m unittest tests.test_ab_evaluator`

------
https://chatgpt.com/codex/tasks/task_e_686ae418c18083318df3e752b28b5297