### PR TITLE
Enable emotion-adaptive multilingual prompting

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -425,7 +425,11 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 76. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps to aid debugging. When initialised with a `CrossLingualTranslator` the logger records translated summaries for multilingual inspection.
 
 77. **User preference modeling**: `UserPreferences` maintains per-user vectors and feedback counts so `PromptOptimizer` can personalise prompts. Aggregate stats expose fairness gaps across demographics.
-78. **Emotion-aware prompts**: `emotion_detector.detect_emotion()` labels text as positive, neutral or negative. `PromptOptimizer` now adjusts scores based on the detected emotion and stored user feedback.
+78. **Emotion-adaptive prompting**: `PromptOptimizer.optimize()` consults `CrossLingualTranslator`
+    to render prompts in each user's preferred language and calls
+    `emotion_detector.detect_emotion()` on the translation. The score is then
+    biased toward the user's stored emotion so that the optimizer steers outputs
+    to match both language preference and mood.
 
 76. **Trusted execution inference**: `EnclaveRunner` launches model inference inside a trusted enclave. `DistributedTrainer` can route its steps through the enclave to keep weights in a protected address space. This guards intermediate activations but does not eliminate side-channel risk.
 77. **Collaboration portal**: `CollaborationPortal` lists active tasks and exposes

--- a/src/user_preferences.py
+++ b/src/user_preferences.py
@@ -11,6 +11,8 @@ class UserPreferences:
         self.dim = dim
         self.vectors: Dict[str, np.ndarray] = {}
         self.stats: Dict[str, Dict[str, int]] = {}
+        self.languages: Dict[str, str] = {}
+        self.emotions: Dict[str, str] = {}
 
     # --------------------------------------------------------------
     def embed_text(self, text: str) -> np.ndarray:
@@ -31,6 +33,22 @@ class UserPreferences:
     def get_stats(self, user_id: str) -> Tuple[int, int]:
         st = self.stats.get(user_id, {"pos": 0, "neg": 0})
         return st["pos"], st["neg"]
+
+    # --------------------------------------------------------------
+    def set_language(self, user_id: str, language: str) -> None:
+        """Store the preferred ``language`` for ``user_id``."""
+        self.languages[user_id] = language
+
+    def get_language(self, user_id: str) -> str | None:
+        return self.languages.get(user_id)
+
+    # --------------------------------------------------------------
+    def set_emotion(self, user_id: str, emotion: str) -> None:
+        """Store the detected ``emotion`` for ``user_id``."""
+        self.emotions[user_id] = emotion
+
+    def get_emotion(self, user_id: str) -> str | None:
+        return self.emotions.get(user_id)
 
     # --------------------------------------------------------------
     def update(self, user_id: str, vector: np.ndarray, feedback: float = 1.0) -> None:


### PR DESCRIPTION
## Summary
- extend `UserPreferences` with language and emotion storage
- update `PromptOptimizer` to translate prompts, detect emotion and store it
- add multilingual emotion handling tests
- document emotion-adaptive prompting

## Testing
- `pytest -q tests/test_prompt_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_686ae42087d483318140e170489e967d