### PR TITLE
Add cross-lingual KG memory

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -300,6 +300,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 29. **Structured knowledge graph memory**: Store facts as triples in a `KnowledgeGraphMemory` and retrieve them through `HierarchicalMemory` for better planning context.
     The new `GraphNeuralReasoner` loads these triples and predicts missing relations so `HierarchicalPlanner.query_relation()` can infer edges not explicitly stored.
     `KnowledgeGraphMemory` now records optional timestamps per triple and supports temporal range queries for time-sensitive reasoning.
+29a. **Cross-lingual knowledge graph memory**: `CrossLingualKGMemory` wraps
+    `KnowledgeGraphMemory` with a `CrossLingualTranslator`. `add_triples_multilingual()`
+    stores translated triples and `query_translated()` returns results in the
+    requested language.
 29. **Temporal reasoner**: `TemporalReasoner` queries these timestamped triples
     to infer before/after relationships. `HierarchicalPlanner.compose_plan()`
     can optionally reorder intermediate steps using the reasoner for time-aware

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -182,6 +182,7 @@ from .graphql_memory_gateway import GraphQLMemoryGateway
 from .world_model_distiller import DistillConfig, distill_world_model
 from .summarizing_memory import SummarizingMemory
 from .cross_lingual_memory import CrossLingualMemory
+from .cross_lingual_kg_memory import CrossLingualKGMemory
 from .cross_lingual_graph import CrossLingualReasoningGraph
 from .context_summary_memory import ContextSummaryMemory
 from .sensorimotor_pretrainer import (

--- a/src/cross_lingual_kg_memory.py
+++ b/src/cross_lingual_kg_memory.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Iterable, Tuple, Union, Optional, List
+
+from .knowledge_graph_memory import KnowledgeGraphMemory, TimedTriple
+from .data_ingest import CrossLingualTranslator
+
+
+class CrossLingualKGMemory(KnowledgeGraphMemory):
+    """Knowledge graph memory that stores translations of triples."""
+
+    def __init__(
+        self,
+        *args,
+        translator: CrossLingualTranslator | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.translator = translator
+
+    # ------------------------------------------------------------
+    def add_triples_multilingual(
+        self,
+        triples: Iterable[Union[Tuple[str, str, str], Tuple[str, str, str, float], TimedTriple]],
+    ) -> None:
+        """Add triples and their translations."""
+        super().add_triples(triples)
+        if self.translator is None:
+            return
+        extra: List[Union[Tuple[str, str, str], Tuple[str, str, str, float]]] = []
+        for t in triples:
+            ts: Optional[float] = None
+            if isinstance(t, TimedTriple):
+                s, p, o, ts = t.subject, t.predicate, t.object, t.timestamp
+            else:
+                s, p, o = t[:3]
+                if len(t) == 4:
+                    ts = float(t[3])
+            for lang in self.translator.languages:
+                s_t = self.translator.translate(s, lang)
+                p_t = self.translator.translate(p, lang)
+                o_t = self.translator.translate(o, lang)
+                if ts is not None:
+                    extra.append((s_t, p_t, o_t, ts))
+                else:
+                    extra.append((s_t, p_t, o_t))
+        super().add_triples(extra)
+
+    # ------------------------------------------------------------
+    def query_translated(
+        self,
+        subject: Optional[str] = None,
+        predicate: Optional[str] = None,
+        object: Optional[str] = None,
+        *,
+        lang: Optional[str] = None,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
+    ) -> List[TimedTriple]:
+        """Query triples and optionally translate results and queries."""
+        results = self.query_triples(subject, predicate, object, start_time, end_time)
+        if self.translator is None:
+            return results
+        # query translated variants
+        queries: List[Tuple[Optional[str], Optional[str], Optional[str]]] = []
+        if subject is not None or predicate is not None or object is not None:
+            for l in self.translator.languages:
+                s = self.translator.translate(subject, l) if subject is not None else None
+                p = self.translator.translate(predicate, l) if predicate is not None else None
+                o = self.translator.translate(object, l) if object is not None else None
+                queries.append((s, p, o))
+        for s, p, o in queries:
+            results.extend(self.query_triples(s, p, o, start_time, end_time))
+        seen = set()
+        dedup: List[TimedTriple] = []
+        for t in results:
+            key = (t.subject, t.predicate, t.object, t.timestamp)
+            if key in seen:
+                continue
+            seen.add(key)
+            if lang is not None:
+                dedup.append(
+                    TimedTriple(
+                        self.translator.translate(t.subject, lang),
+                        self.translator.translate(t.predicate, lang),
+                        self.translator.translate(t.object, lang),
+                        t.timestamp,
+                    )
+                )
+            else:
+                dedup.append(t)
+        return dedup
+
+
+__all__ = ["CrossLingualKGMemory"]

--- a/tests/test_cross_lingual_kg_memory.py
+++ b/tests/test_cross_lingual_kg_memory.py
@@ -1,0 +1,51 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import unittest
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+
+kg = load('asi.knowledge_graph_memory', 'src/knowledge_graph_memory.py')
+di = load('asi.data_ingest', 'src/data_ingest.py')
+kgm = load('asi.cross_lingual_kg_memory', 'src/cross_lingual_kg_memory.py')
+
+CrossLingualKGMemory = kgm.CrossLingualKGMemory
+CrossLingualTranslator = di.CrossLingualTranslator
+TimedTriple = kgm.TimedTriple
+
+
+class TestCrossLingualKGMemory(unittest.TestCase):
+    def test_multilingual_add_query(self):
+        tr = CrossLingualTranslator(['es'])
+        kg = CrossLingualKGMemory(translator=tr)
+        kg.add_triples_multilingual([('a', 'likes', 'b')])
+        es = kg.query_triples(subject='[es] a')
+        self.assertEqual(len(es), 1)
+        res = kg.query_translated(subject='a', lang='es')
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0].subject, '[es] a')
+
+    def test_cross_query(self):
+        tr = CrossLingualTranslator(['es'])
+        kg = CrossLingualKGMemory(translator=tr)
+        kg.add_triples_multilingual([('x', 'y', 'z')])
+        res = kg.query_translated(subject='[es] x', lang='en')
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0].subject, 'x')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_knowledge_graph_memory.py
+++ b/tests/test_knowledge_graph_memory.py
@@ -5,6 +5,12 @@ import sys
 torch_stub = types.SimpleNamespace(
     tensor=lambda *a, **k: None,
     randn=lambda *a, **k: None,
+    Tensor=object,
+    nn=types.SimpleNamespace(
+        Module=object,
+        Linear=lambda *a, **k: None,
+        functional=types.SimpleNamespace(cosine_similarity=lambda *a, **k: None),
+    ),
 )
 sys.modules['torch'] = torch_stub
 import importlib.machinery


### PR DESCRIPTION
## Summary
- extend `KnowledgeGraphMemory` with a cross‑lingual variant
- export `CrossLingualKGMemory` from the package
- document multilingual triple storage
- test translation of triples

## Testing
- `pytest tests/test_cross_lingual_kg_memory.py tests/test_knowledge_graph_memory.py -q` *(fails: ModuleNotFoundError: 'asi.vector_store')*

------
https://chatgpt.com/codex/tasks/task_e_686ae42a8fd883319cb4522e4e7b6a40