### PR TITLE
Add introspection dashboard with CLI and tests

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -443,6 +443,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 84. **Natural-language graph editor**: `nl_graph_editor.py` interprets commands like "merge nodes A and B" or "add edge from X to Y". `GraphUI` exposes `/graph/nl_edit` so the web UI accepts these instructions.
 
 85. **Temporal telemetry monitoring**: `MemoryEventDetector` parses logged hardware metrics and flags change points. `TelemetryLogger` stores these events so the memory dashboard exposes them via `/events`.
+86. **Introspection dashboard**: `IntrospectionDashboard` merges reasoning history with telemetry metrics. Run `scripts/introspection_dashboard.py` and open `http://localhost:8060` to inspect graph evolution alongside hardware usage.
 82. **Dataset discovery pipeline**: `dataset_discovery.py` scans RSS feeds from
     HuggingFace and Kaggle, storing dataset names, URLs and license text in a
     lightweight SQLite database. `license_inspector.py` loads the database to

--- a/scripts/introspection_dashboard.py
+++ b/scripts/introspection_dashboard.py
@@ -1,0 +1,39 @@
+import argparse
+import time
+
+from asi.graph_of_thought import GraphOfThought
+from asi.reasoning_history import ReasoningHistoryLogger
+from asi.telemetry import TelemetryLogger
+from asi.introspection_dashboard import IntrospectionDashboard
+
+
+def main(port: int) -> None:
+    graph = GraphOfThought()
+    a = graph.add_step("start", metadata={"timestamp": 0.0})
+    b = graph.add_step("finish", metadata={"timestamp": 1.0})
+    graph.connect(a, b)
+
+    history = ReasoningHistoryLogger()
+    history.log(graph.self_reflect())
+
+    telemetry = TelemetryLogger(interval=0.5)
+    telemetry.start()
+
+    dash = IntrospectionDashboard(graph, history, telemetry)
+    dash.start(port=port)
+    print(f"Introspection dashboard running at http://localhost:{dash.port}")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    dash.stop()
+    telemetry.stop()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Launch introspection dashboard")
+    parser.add_argument("--port", type=int, default=8060)
+    args = parser.parse_args()
+    main(args.port)
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -246,6 +246,7 @@ from .adaptive_micro_batcher import AdaptiveMicroBatcher
 from .retrieval_explainer import RetrievalExplainer
 from .retrieval_rl import RetrievalPolicy, train_policy
 from .interpretability_dashboard import InterpretabilityDashboard
+from .introspection_dashboard import IntrospectionDashboard
 from .graph_ui import GraphUI
 from .nl_graph_editor import NLGraphEditor
 from .collaborative_healing import CollaborativeHealingLoop

--- a/src/introspection_dashboard.py
+++ b/src/introspection_dashboard.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Dict
+
+from .graph_of_thought import GraphOfThought
+from .reasoning_history import ReasoningHistoryLogger
+from .telemetry import TelemetryLogger
+
+
+class IntrospectionDashboard:
+    """Serve reasoning history merged with telemetry statistics."""
+
+    def __init__(
+        self,
+        graph: GraphOfThought,
+        history: ReasoningHistoryLogger,
+        telemetry: TelemetryLogger,
+    ) -> None:
+        self.graph = graph
+        self.history = history
+        self.telemetry = telemetry
+        self.httpd: HTTPServer | None = None
+        self.thread: threading.Thread | None = None
+        self.port: int | None = None
+
+    # --------------------------------------------------------------
+    def aggregate(self) -> Dict[str, Any]:
+        """Return graph JSON, history log and telemetry metrics."""
+        return {
+            "graph": self.graph.to_json(),
+            "history": self.history.get_history(),
+            "telemetry": self.telemetry.get_stats(),
+        }
+
+    # --------------------------------------------------------------
+    def to_html(self) -> str:
+        data = self.aggregate()
+        tele = data.get("telemetry", {})
+        rows = "".join(
+            f"<tr><td>{k}</td><td>{float(v):.2f}</td></tr>"
+            for k, v in tele.items()
+            if isinstance(v, (int, float))
+        )
+        hist_rows = "".join(
+            f"<li>{ts}: {summary}</li>" for ts, summary in data.get("history", [])[-5:]
+        )
+        return (
+            "<html><body><h1>Introspection Dashboard</h1>"
+            "<h2>Telemetry</h2><table border='1'>"
+            "<tr><th>Metric</th><th>Value</th></tr>"
+            f"{rows}</table>"
+            "<h2>History</h2><ul>" + hist_rows + "</ul>"
+            "</body></html>"
+        )
+
+    # --------------------------------------------------------------
+    def start(self, host: str = "localhost", port: int = 8060) -> None:
+        if self.httpd is not None:
+            return
+        dashboard = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: D401
+                if self.path == "/graph":
+                    data = json.dumps(dashboard.graph.to_json()).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                elif self.path == "/history":
+                    data = json.dumps(dashboard.history.get_history()).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                elif self.path in ("/stats", "/telemetry"):
+                    data = json.dumps(dashboard.telemetry.get_stats()).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                elif self.path == "/json":
+                    data = json.dumps(dashboard.aggregate()).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                else:
+                    html = dashboard.to_html().encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/html")
+                    self.end_headers()
+                    self.wfile.write(html)
+
+            def log_message(self, format: str, *args: Any) -> None:  # noqa: D401
+                return
+
+        self.httpd = HTTPServer((host, port), Handler)
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    # --------------------------------------------------------------
+    def stop(self) -> None:
+        if self.httpd is None:
+            return
+        assert self.thread is not None
+        self.httpd.shutdown()
+        self.thread.join(timeout=1.0)
+        self.httpd.server_close()
+        self.httpd = None
+        self.thread = None
+        self.port = None
+
+
+__all__ = ["IntrospectionDashboard"]
+

--- a/tests/test_introspection_dashboard.py
+++ b/tests/test_introspection_dashboard.py
@@ -1,0 +1,61 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import json
+import http.client
+import unittest
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    return mod
+
+GraphOfThought = _load('asi.graph_of_thought', 'src/graph_of_thought.py').GraphOfThought
+ReasoningHistoryLogger = _load('asi.reasoning_history', 'src/reasoning_history.py').ReasoningHistoryLogger
+TelemetryLogger = _load('asi.telemetry', 'src/telemetry.py').TelemetryLogger
+IntrospectionDashboard = _load('asi.introspection_dashboard', 'src/introspection_dashboard.py').IntrospectionDashboard
+
+
+class TestIntrospectionDashboard(unittest.TestCase):
+    def test_server(self):
+        graph = GraphOfThought()
+        a = graph.add_step('start', metadata={'timestamp': 0.0})
+        b = graph.add_step('end', metadata={'timestamp': 1.0})
+        graph.connect(a, b)
+
+        history = ReasoningHistoryLogger()
+        history.log('start -> end')
+
+        tel = TelemetryLogger(interval=0.1)
+        tel.start()
+        dash = IntrospectionDashboard(graph, history, tel)
+        dash.start(port=0)
+        port = dash.port
+        assert port is not None
+
+        conn = http.client.HTTPConnection('localhost', port)
+        conn.request('GET', '/json')
+        data = json.loads(conn.getresponse().read())
+        self.assertIn('graph', data)
+        self.assertIn('history', data)
+        self.assertIn('telemetry', data)
+
+        conn.request('GET', '/history')
+        hist = json.loads(conn.getresponse().read())
+        self.assertEqual(hist[0][1], 'start -> end')
+
+        dash.stop()
+        tel.stop()
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- implement `IntrospectionDashboard` for merging graph history and telemetry
- expose dashboard via `scripts/introspection_dashboard.py`
- document usage in Plan
- add unit test
- export dashboard in package

## Testing
- `pytest -q` *(fails: 167 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ae42cdb348331b47c8cf5a470408d