### PR TITLE
Add security scan tooling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,8 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -e .
+          pip install pip-audit bandit
       - name: Run tests
         run: pytest -q
+      - name: Security scan
+        run: python scripts/security_scan.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Thank you for improving the ASI prototype. To get started:
 2. Install dependencies with `pip install -r requirements.txt`.
 3. Install the package in editable mode with `pip install -e .`.
 4. Run tests with `pytest` before submitting a pull request.
-5. Generate module docs with `python -m asi.doc_summarizer <module>` whenever you add new modules.
+5. Run `python scripts/security_scan.py` to check dependencies and source code for vulnerabilities.
+6. Generate module docs with `python -m asi.doc_summarizer <module>` whenever you add new modules.
 
 You can run `scripts/setup_test_env.sh` to automate steps 2 and 3.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -480,6 +480,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     reconstructed and passed through the model for consolidation. Integrated
     with `DistributedTrainer` via the new replay hook.
 
+87. **Dependency security scan**: `scripts/security_scan.py` runs `pip-audit`
+    and `bandit` to catch vulnerable packages and risky code. The CI workflow
+    executes this scan after the unit tests.
+
 
 
 

--- a/scripts/security_scan.py
+++ b/scripts/security_scan.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Run dependency and source-code security scans."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_tool(tool: str, args: list[str]) -> int:
+    """Return exit code after running ``tool`` with ``args``.
+
+    Prints a warning if the tool is not installed.
+    """
+    if shutil.which(tool) is None:
+        print(f"{tool} not found; install it with `pip install {tool}`")
+        return 1
+    cmd = [tool] + args
+    print("$", " ".join(cmd))
+    return subprocess.call(cmd)
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    requirements = repo_root / "requirements.txt"
+    src_dir = repo_root / "src"
+
+    status = 0
+    status |= run_tool("pip-audit", ["-r", str(requirements)])
+    status |= run_tool("bandit", ["-r", str(src_dir)])
+    sys.exit(status)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- run `pip-audit` and `bandit` with `scripts/security_scan.py`
- call the scan from CI
- describe the scan in docs
- add the step to contributing guide

## Testing
- `pytest -q` *(fails: 166 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ae430007c8331bed2ee6f850a35e5