### PR TITLE
Add consensus reasoner

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -480,6 +480,16 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     reconstructed and passed through the model for consolidation. Integrated
     with `DistributedTrainer` via the new replay hook.
 
+86a. **Consensus reasoner**: `consensus_reasoner.compute_consensus()` merges
+     reasoning graphs from a `MultiAgentCoordinator` and returns any timestamp
+     conflicts. Use `report_disagreements()` to print a summary.
+
+```python
+from asi import consensus_reasoner
+merged, issues = consensus_reasoner.compute_consensus(coord)
+print(consensus_reasoner.report_disagreements(issues))
+```
+
 
 
 

--- a/src/consensus_reasoner.py
+++ b/src/consensus_reasoner.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Tuple, List
+
+from .multi_agent_coordinator import MultiAgentCoordinator
+from .graph_of_thought import GraphOfThought
+from .reasoning_merger import merge_graphs
+
+
+def compute_consensus(
+    coordinator: MultiAgentCoordinator,
+) -> Tuple[GraphOfThought, List[Tuple[float, Tuple[str, ...]]]]:
+    """Return merged reasoning graph and inconsistencies.
+
+    The function collects ``GraphOfThought`` objects from all agents registered
+    in ``coordinator``.  It then calls :func:`reasoning_merger.merge_graphs` to
+    combine them and detect timestamp conflicts.  Agents are expected to expose
+    one of ``graph``, ``reasoning_graph`` or ``got`` attributes.
+    """
+    graphs: dict[str, GraphOfThought] = {}
+    for name, agent in coordinator.agents.items():
+        g = getattr(agent, "graph", None) or getattr(agent, "reasoning_graph", None) or getattr(agent, "got", None)
+        if isinstance(g, GraphOfThought):
+            graphs[name] = g
+    if not graphs:
+        raise ValueError("No agent graphs found")
+    merged, inconsistencies = merge_graphs(graphs)
+    return merged, inconsistencies
+
+
+def report_disagreements(inconsistencies: List[Tuple[float, Tuple[str, ...]]]) -> str:
+    """Return a text report summarising ``inconsistencies``."""
+    if not inconsistencies:
+        return "All agents agree"
+    lines = ["Disagreements detected:"]
+    for ts, texts in inconsistencies:
+        joined = ", ".join(texts)
+        lines.append(f"timestamp {ts}: {joined}")
+    return "\n".join(lines)
+
+
+__all__ = ["compute_consensus", "report_disagreements"]

--- a/tests/test_consensus_reasoner.py
+++ b/tests/test_consensus_reasoner.py
@@ -1,0 +1,71 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+import unittest
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+MultiAgentCoordinator = _load('asi.multi_agent_coordinator', 'src/multi_agent_coordinator.py').MultiAgentCoordinator
+GraphOfThought = _load('asi.graph_of_thought', 'src/graph_of_thought.py').GraphOfThought
+cons_mod = _load('asi.consensus_reasoner', 'src/consensus_reasoner.py')
+compute_consensus = cons_mod.compute_consensus
+report_disagreements = cons_mod.report_disagreements
+
+
+class DummyAgent:
+    def __init__(self, graph):
+        self.graph = graph
+
+    def select_action(self, state):
+        return 'act'
+
+    def update(self, state, action, reward, next_state):
+        pass
+
+    def train(self, entries):
+        pass
+
+
+class TestConsensusReasoner(unittest.TestCase):
+    def test_compute_no_conflict(self):
+        g1 = GraphOfThought()
+        a = g1.add_step('start', metadata={'timestamp': 0.0})
+        b = g1.add_step('end', metadata={'timestamp': 1.0})
+        g1.connect(a, b)
+
+        g2 = GraphOfThought()
+        a2 = g2.add_step('start', metadata={'timestamp': 0.0})
+        b2 = g2.add_step('end', metadata={'timestamp': 1.0})
+        g2.connect(a2, b2)
+
+        coord = MultiAgentCoordinator({'a': DummyAgent(g1), 'b': DummyAgent(g2)})
+        merged, inconsist = compute_consensus(coord)
+        self.assertEqual(len(inconsist), 0)
+        self.assertEqual(len(merged.nodes), 2)
+
+    def test_compute_conflict(self):
+        g1 = GraphOfThought()
+        g1.add_step('x', metadata={'timestamp': 0.0})
+        g2 = GraphOfThought()
+        g2.add_step('y', metadata={'timestamp': 0.0})
+        coord = MultiAgentCoordinator({'a': DummyAgent(g1), 'b': DummyAgent(g2)})
+        _merged, inconsist = compute_consensus(coord)
+        self.assertTrue(inconsist)
+        rep = report_disagreements(inconsist)
+        self.assertIn('timestamp', rep)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `consensus_reasoner` for merging agent graphs
- document consensus workflow in Plan
- add unit tests for consensus detection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asi.multi_stage_oversight')*

------
https://chatgpt.com/codex/tasks/task_e_686ae4390ff48331a9023bd3d048767e