### PR TITLE
Add energy-aware architecture search

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -279,6 +279,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     `src/adaptive_planner.py`.*
 25. **Neural architecture search**: Evaluate `src/neural_arch_search.py` across
     candidate module configurations and report accuracy vs. compute costs.
+    The search now logs energy usage via `TelemetryLogger` and supports an
+    `energy_weight` option to trade off accuracy against consumption.
     *Implemented in `src/neural_arch_search.py`.*
 25. **Self-healing distributed training**: Deploy `SelfHealingTrainer` to
     restart failed jobs automatically and track overall utilization.

--- a/src/neural_arch_search.py
+++ b/src/neural_arch_search.py
@@ -7,6 +7,8 @@ from itertools import product
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from typing import Any, Callable, Dict, Iterable, Tuple, List
 
+from .telemetry import TelemetryLogger
+
 
 class DistributedArchSearch:
     """Explore architecture configurations using multiple worker processes."""
@@ -16,12 +18,17 @@ class DistributedArchSearch:
         search_space: Dict[str, Iterable[Any]],
         eval_func: Callable[[Dict[str, Any]], float],
         max_workers: int = 2,
+        *,
+        telemetry: TelemetryLogger | None = None,
+        energy_weight: float = 0.0,
     ) -> None:
         self.search_space = {k: list(v) for k, v in search_space.items()}
         if max_workers < 1:
             raise ValueError("max_workers must be positive")
         self.eval_func = eval_func
         self.max_workers = max_workers
+        self.telemetry = telemetry or TelemetryLogger(interval=0.1)
+        self.energy_weight = energy_weight
 
     def sample(self) -> Dict[str, Any]:
         """Randomly draw a configuration from the search space."""
@@ -36,14 +43,32 @@ class DistributedArchSearch:
         """Evaluate up to ``num_samples`` configs and return the best one."""
         if num_samples <= 0:
             raise ValueError("num_samples must be positive")
+
         all_cfgs = self._all_configs()
         candidates = random.sample(all_cfgs, min(num_samples, len(all_cfgs)))
+
         best_cfg: Dict[str, Any] | None = None
+        best_adj = float("-inf")
         best_score = float("-inf")
+
+        self.telemetry.start()
+        prev_energy = self.telemetry.get_stats().get("energy_kwh", 0.0)
+
+        def eval_candidate(cfg: Dict[str, Any]) -> Tuple[float, float]:
+            nonlocal prev_energy
+            pre = self.telemetry.get_stats().get("energy_kwh", 0.0)
+            score = float(self.eval_func(cfg))
+            post = self.telemetry.get_stats().get("energy_kwh", 0.0)
+            energy = post - pre
+            prev_energy = post
+            adj = score - self.energy_weight * energy
+            return score, adj
+
         if self.max_workers == 1:
             for cfg in candidates:
-                score = float(self.eval_func(cfg))
-                if score > best_score:
+                score, adj = eval_candidate(cfg)
+                if adj > best_adj:
+                    best_adj = adj
                     best_score = score
                     best_cfg = cfg
         else:
@@ -52,9 +77,16 @@ class DistributedArchSearch:
                 for fut in as_completed(fut_to_cfg):
                     cfg = fut_to_cfg[fut]
                     score = float(fut.result())
-                    if score > best_score:
+                    now = self.telemetry.get_stats().get("energy_kwh", 0.0)
+                    energy = now - prev_energy
+                    prev_energy = now
+                    adj = score - self.energy_weight * energy
+                    if adj > best_adj:
+                        best_adj = adj
                         best_score = score
                         best_cfg = cfg
+
+        self.telemetry.stop()
         assert best_cfg is not None
         return best_cfg, best_score
 

--- a/tests/test_neural_arch_search.py
+++ b/tests/test_neural_arch_search.py
@@ -1,15 +1,67 @@
 import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
 import random
-import torch
 
-from asi.neural_arch_search import DistributedArchSearch
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+sys.modules['psutil'] = types.SimpleNamespace(
+    cpu_percent=lambda interval=None: 0.0,
+    virtual_memory=lambda: types.SimpleNamespace(percent=0.0),
+    net_io_counters=lambda: types.SimpleNamespace(bytes_sent=0, bytes_recv=0),
+)
+sys.modules['torch'] = types.SimpleNamespace(
+    cuda=types.SimpleNamespace(
+        utilization=lambda: 0.0,
+        is_available=lambda: False,
+        memory_allocated=lambda: 0,
+        get_device_properties=lambda _: types.SimpleNamespace(total_memory=1),
+    )
+)
+sys.modules['asi.carbon_tracker'] = types.SimpleNamespace(
+    CarbonFootprintTracker=type(
+        'CF',
+        (),
+        {
+            '__init__': lambda self, **kw: None,
+            'start': lambda self: None,
+            'stop': lambda self: None,
+            'get_stats': lambda self: {},
+        },
+    )
+)
+sys.modules['asi.memory_event_detector'] = types.SimpleNamespace(
+    MemoryEventDetector=type(
+        'MED',
+        (),
+        {
+            '__init__': lambda self, **kw: None,
+            'update': lambda self, x: [],
+            'events': [],
+        },
+    )
+)
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+TelemetryLogger = _load('asi.telemetry', 'src/telemetry.py').TelemetryLogger
+DistributedArchSearch = _load('asi.neural_arch_search', 'src/neural_arch_search.py').DistributedArchSearch
 
 
 class TestNeuralArchSearch(unittest.TestCase):
     def test_search_selects_best(self):
         space = {"layers": [1, 2], "hidden": [8, 16]}
         random.seed(0)
-        torch.manual_seed(0)
 
         def score(cfg):
             return cfg["layers"] * cfg["hidden"]
@@ -19,6 +71,37 @@ class TestNeuralArchSearch(unittest.TestCase):
         self.assertEqual(best["layers"], 2)
         self.assertEqual(best["hidden"], 16)
         self.assertEqual(val, 32)
+
+    def test_energy_weight_affects_ranking(self):
+        space = {"layers": [1, 2]}
+        random.seed(0)
+        energies = [0.0, 0.0, 3.0, 3.0, 3.1]
+
+        class DummyLogger(TelemetryLogger):
+            def __init__(self, vals):
+                super().__init__(interval=0.01)
+                self.vals = vals
+                self.idx = 0
+
+            def start(self):
+                pass
+
+            def stop(self):
+                pass
+
+            def get_stats(self):
+                val = self.vals[self.idx]
+                if self.idx < len(self.vals) - 1:
+                    self.idx += 1
+                return {"energy_kwh": val}
+
+        def score(cfg):
+            return float(cfg["layers"]) * 10
+
+        tel = DummyLogger(energies)
+        search = DistributedArchSearch(space, score, max_workers=1, telemetry=tel, energy_weight=5.0)
+        best, _ = search.search(num_samples=2)
+        self.assertEqual(best["layers"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track energy usage in `DistributedArchSearch` through `TelemetryLogger`
- add `energy_weight` parameter to penalize high power candidates
- document energy-aware search
- test how energy weighting influences architecture search

## Testing
- `pytest tests/test_neural_arch_search.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae43abedc8331a7c790031dd5cdee