### PR TITLE
Add ephemeral vector store

### DIFF
--- a/asi/__init__.py
+++ b/asi/__init__.py
@@ -24,6 +24,7 @@ for _m in [
     "vector_store",
     "pq_vector_store",
     "async_vector_store",
+    "ephemeral_vector_store",
     "quantum_retrieval",
     "quantum_sampler",
     "quantum_hpo",

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -344,6 +344,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
      for vector search using `quantum_retrieval.amplify_search`. The accompanying
      `QuantumMemoryClient` lets peers push embeddings and query the server over
      the network.
+37c. **Ephemeral vector store**: `EphemeralVectorStore` keeps in-memory vectors
+     with a TTL and integrates into `HierarchicalMemory` via `store_type="ephemeral"`.
 38. **Duplicate data filter**: Use CLIP embeddings with locality-sensitive
     hashing to drop near-duplicate samples during ingestion and connect it to
     `AutoDatasetFilter`.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -31,6 +31,7 @@ from .vector_store import VectorStore, FaissVectorStore
 from .encrypted_vector_store import EncryptedVectorStore
 from .pq_vector_store import PQVectorStore
 from .async_vector_store import AsyncFaissVectorStore
+from .ephemeral_vector_store import EphemeralVectorStore
 from .iter_align import IterativeAligner
 from .critic_rlhf import CriticScorer, CriticRLHFTrainer
 from .chunkwise_retrainer import ChunkWiseRetrainer

--- a/src/ephemeral_vector_store.py
+++ b/src/ephemeral_vector_store.py
@@ -1,0 +1,64 @@
+import time
+from typing import Iterable, Any, List, Tuple
+
+import numpy as np
+
+
+class EphemeralVectorStore:
+    """In-memory vector store that drops old entries after ``ttl`` seconds."""
+
+    def __init__(self, dim: int, ttl: float = 60.0) -> None:
+        self.dim = dim
+        self.ttl = float(ttl)
+        self._vectors: List[np.ndarray] = []
+        self._meta: List[Any] = []
+        self._time: List[float] = []
+
+    def __len__(self) -> int:
+        self.cleanup_expired()
+        return len(self._meta)
+
+    def add(self, vectors: np.ndarray, metadata: Iterable[Any] | None = None) -> None:
+        """Add vectors with optional metadata."""
+        arr = np.asarray(vectors, dtype=np.float32)
+        if arr.ndim == 1:
+            arr = arr[None, :]
+        if arr.shape[1] != self.dim:
+            raise ValueError("vector dimension mismatch")
+        if metadata is None:
+            metas = [None] * arr.shape[0]
+        else:
+            metas = list(metadata)
+            if len(metas) != arr.shape[0]:
+                raise ValueError("metadata length mismatch")
+        now = time.time()
+        self._vectors.extend(arr)
+        self._meta.extend(metas)
+        self._time.extend([now] * arr.shape[0])
+        self.cleanup_expired()
+
+    def search(self, query: np.ndarray, k: int = 5) -> Tuple[np.ndarray, List[Any]]:
+        self.cleanup_expired()
+        if not self._vectors:
+            return np.empty((0, self.dim), dtype=np.float32), []
+        mat = np.vstack(self._vectors)
+        q = np.asarray(query, dtype=np.float32).reshape(1, self.dim)
+        scores = mat @ q.T
+        idx = np.argsort(scores.ravel())[::-1][:k]
+        return mat[idx], [self._meta[i] for i in idx]
+
+    def cleanup_expired(self) -> None:
+        """Remove entries older than the TTL."""
+        if not self._time:
+            return
+        cutoff = time.time() - self.ttl
+        mask = [t >= cutoff for t in self._time]
+        if all(mask):
+            return
+        self._vectors = [v for v, m in zip(self._vectors, mask) if m]
+        self._meta = [m for m, keep in zip(self._meta, mask) if keep]
+        self._time = [t for t in self._time if t >= cutoff]
+
+
+__all__ = ["EphemeralVectorStore"]
+

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -18,6 +18,7 @@ from .encrypted_vector_store import EncryptedVectorStore
 from .pq_vector_store import PQVectorStore
 from .async_vector_store import AsyncFaissVectorStore
 from .hopfield_memory import HopfieldMemory
+from .ephemeral_vector_store import EphemeralVectorStore
 from .data_ingest import CrossLingualTranslator
 from .retrieval_rl import RetrievalPolicy
 from .user_preferences import UserPreferences
@@ -125,6 +126,8 @@ class HierarchicalMemory:
         retrieval_policy: "RetrievalPolicy | None" = None,
 
         encryption_key: bytes | None = None,
+        store_type: str | None = None,
+        ephemeral_ttl: float = 60.0,
 
     ) -> None:
         if temporal_decay is None:
@@ -135,7 +138,9 @@ class HierarchicalMemory:
             )
         self.use_async = use_async
         self._next_id = 0
-        if use_hopfield:
+        if store_type == "ephemeral":
+            self.store = EphemeralVectorStore(dim=compressed_dim, ttl=ephemeral_ttl)
+        elif use_hopfield:
             self.store = HopfieldStore(dim=compressed_dim)
         elif use_async:
             self.store = AsyncFaissVectorStore(dim=compressed_dim, path=db_path)

--- a/tests/test_ephemeral_vector_store.py
+++ b/tests/test_ephemeral_vector_store.py
@@ -1,0 +1,35 @@
+import time
+import unittest
+import numpy as np
+
+from asi.ephemeral_vector_store import EphemeralVectorStore
+
+
+class TestEphemeralVectorStore(unittest.TestCase):
+    def test_add_and_search(self):
+        store = EphemeralVectorStore(dim=2, ttl=1.0)
+        store.add(np.array([[1.0, 0.0], [0.0, 1.0]]), metadata=["a", "b"])
+        vecs, meta = store.search(np.array([1.0, 0.0]), k=1)
+        np.testing.assert_allclose(vecs, np.array([[1.0, 0.0]], dtype=np.float32))
+        self.assertEqual(meta, ["a"])
+
+    def test_expiration(self):
+        store = EphemeralVectorStore(dim=2, ttl=0.1)
+        store.add(np.array([[1.0, 0.0]]), metadata=["x"])
+        time.sleep(0.2)
+        store.cleanup_expired()
+        self.assertEqual(len(store), 0)
+
+    def test_search_after_expire(self):
+        store = EphemeralVectorStore(dim=2, ttl=0.1)
+        store.add(np.array([[1.0, 0.0]]), metadata=["a"])
+        time.sleep(0.05)
+        store.add(np.array([[0.0, 1.0]]), metadata=["b"])
+        time.sleep(0.07)
+        vecs, meta = store.search(np.array([0.0, 1.0]), k=2)
+        self.assertEqual(meta, ["b"])
+        self.assertEqual(len(vecs), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `EphemeralVectorStore` for transient vectors
- integrate with `HierarchicalMemory` via `store_type="ephemeral"`
- load module automatically through `asi.__init__`
- document new feature in `Plan.md`
- test insertion, expiration and search

## Testing
- `pytest tests/test_ephemeral_vector_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae45376e08331b13266dbd25ffa86