### PR TITLE
Add emotion-conditioned retriever

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -32,6 +32,7 @@ Citations point to the most recent public work so you can drill straight into th
 | **C-8** | **Distributed Hierarchical Memory Backend** | Share the vector store across nodes via a gRPC service (see `MemoryServer`, `RemoteMemory`) | Throughput scales to 4+ nodes with <1.2× single-node latency |
 | **C-9** | **Hopfield Associative Memory** | Store binary patterns as attractors and recall them from noisy cues | Recall accuracy >95 % on 32-bit vectors with up to 20 % noise |
 | **C-10** | **RL-guided retrieval** | Learn a policy to rank memory vectors by hit rate and latency | Recall improves after online training from query logs |
+| **C-11** | **Emotion-conditioned retrieval** | Re-rank memory hits by matching sentiment | Positive/negative queries return ≥1 matching-tone item first |
 
 **Path to “trillion-token” context:** combine *C-1/2/3* for linear-or-sub-linear scaling, add **hierarchical retrieval** (store distant tokens in an external vector DB and re-inject on-demand).  Recurrence handles the whole stream; retrieval gives random access—context length becomes limited only by storage, not RAM.  Privacy-preserving retrieval is now possible via `EncryptedVectorStore`, which stores AES-encrypted embeddings and manages keys through `HierarchicalMemory`.
 

--- a/src/emotion_conditioned_retriever.py
+++ b/src/emotion_conditioned_retriever.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import TYPE_CHECKING, Any, Iterable, Tuple, List
+
+from .emotion_detector import detect_emotion
+
+try:  # optional torch dependency
+    import torch
+except Exception:  # pragma: no cover - allow running without torch
+    torch = None
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .hierarchical_memory import HierarchicalMemory
+
+
+def _embed_text(text: str, dim: int) -> Any:
+    """Deterministically embed ``text`` using a hash RNG."""
+    seed = abs(hash(text)) % (2 ** 32)
+    rng = np.random.default_rng(seed)
+    vec = rng.standard_normal(dim).astype(np.float32)
+    if torch is not None:
+        return torch.from_numpy(vec)
+    return vec
+
+
+def _cosine_similarity(vecs: Any, query: Any) -> List[float]:
+    if torch is not None and isinstance(vecs, torch.Tensor):
+        q = query.expand_as(vecs)
+        sims = torch.nn.functional.cosine_similarity(vecs, q, dim=1)
+        return sims.cpu().tolist()
+    arr = np.asarray(vecs)
+    q = np.asarray(query)
+    denom = np.linalg.norm(arr, axis=1) * np.linalg.norm(q)
+    denom[denom == 0] = 1.0
+    sims = (arr @ q) / denom
+    return sims.tolist()
+
+
+class EmotionConditionedRetriever:
+    """Rank memory search results by emotional relevance."""
+
+    def __init__(self, memory: "HierarchicalMemory" | Any, *, dim: int | None = None) -> None:
+        self.memory = memory
+        if dim is not None:
+            self.dim = dim
+        else:
+            self.dim = getattr(memory, "dim", None)
+            if self.dim is None and hasattr(memory, "compressor"):
+                self.dim = getattr(memory.compressor.encoder, "in_features", 0)
+            if self.dim is None:
+                self.dim = 0
+
+    # ------------------------------------------------------------
+    def search_with_emotion(self, query_text: str, k: int = 5) -> Tuple[Any, List[Any]]:
+        """Return vectors ordered by matching the query emotion."""
+        q_vec = _embed_text(query_text, self.dim)
+        try:
+            vecs, meta, scores = self.memory.search(q_vec, k=k, return_scores=True)
+        except TypeError:
+            vecs, meta = self.memory.search(q_vec, k=k)
+            scores = _cosine_similarity(vecs, q_vec)
+        query_emotion = detect_emotion(query_text)
+        weights = []
+        for m in meta:
+            if isinstance(m, str):
+                emo = detect_emotion(m)
+                weights.append(1.0 if emo == query_emotion else 0.0)
+            else:
+                weights.append(0.0)
+        final = [s + w for s, w in zip(scores, weights)]
+        order = list(np.argsort(final)[::-1])
+        if torch is not None and isinstance(vecs, torch.Tensor):
+            vecs = vecs[order]
+        else:
+            vecs = np.asarray(vecs)[order]
+        meta = [meta[i] for i in order]
+        return vecs, meta
+
+
+__all__ = ["EmotionConditionedRetriever", "_embed_text"]

--- a/tests/test_emotion_conditioned_retriever.py
+++ b/tests/test_emotion_conditioned_retriever.py
@@ -1,0 +1,57 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import unittest
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+edet = load('asi.emotion_detector', 'src/emotion_detector.py')
+ed = load('asi.emotion_conditioned_retriever', 'src/emotion_conditioned_retriever.py')
+
+EmotionConditionedRetriever = ed.EmotionConditionedRetriever
+_embed_text = ed._embed_text
+
+def make_memory(texts):
+    vecs = [_embed_text(t, 8) for t in texts]
+    class Dummy:
+        def __init__(self, vs, ms):
+            import numpy as np
+            self.vs = np.stack(vs)
+            self.meta = list(ms)
+        def search(self, q, k=5, return_scores=False):
+            import numpy as np
+            sims = self.vs @ q / (np.linalg.norm(self.vs, axis=1) * np.linalg.norm(q))
+            idx = np.argsort(sims)[::-1][:k]
+            vecs = self.vs[idx]
+            metas = [self.meta[i] for i in idx]
+            if return_scores:
+                return vecs, metas, sims[idx].tolist()
+            return vecs, metas
+    return Dummy(vecs, texts)
+
+
+class TestEmotionConditionedRetriever(unittest.TestCase):
+    def test_rank_by_emotion(self):
+        mem = make_memory(['I love it', 'I hate it'])
+        retriever = EmotionConditionedRetriever(mem, dim=8)
+        vecs, meta = retriever.search_with_emotion('I love this', k=2)
+        self.assertEqual(meta[0], 'I love it')
+        vecs2, meta2 = retriever.search_with_emotion('I hate everything', k=2)
+        self.assertEqual(meta2[0], 'I hate it')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `EmotionConditionedRetriever` for ranking memory hits by emotion
- document new algorithm in Plan
- test emotion-conditioned retrieval ordering

## Testing
- `pytest -q tests/test_emotion_conditioned_retriever.py`

------
https://chatgpt.com/codex/tasks/task_e_686ae457ed5c833184f468f327ad9bc9