### PR TITLE
Enable WebSocket updates in collaboration portal

### DIFF
--- a/docs/collaboration_client.html
+++ b/docs/collaboration_client.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Collaboration Client</title>
+</head>
+<body>
+<h1>Collaboration Client</h1>
+<ul id="tasks"></ul>
+<ul id="logs"></ul>
+<input id="taskInput" placeholder="new task">
+<button id="addTask">Add</button>
+<input id="logInput" placeholder="log message">
+<button id="addLog">Log</button>
+<script>
+const ws = new WebSocket(`ws://${location.hostname}:${location.port}/ws`);
+ws.onmessage = (ev) => {
+  const data = JSON.parse(ev.data);
+  if (data.tasks) {
+    const ul = document.getElementById('tasks');
+    ul.innerHTML = '';
+    data.tasks.forEach(t => {
+      const li = document.createElement('li');
+      li.textContent = t;
+      ul.appendChild(li);
+    });
+  }
+  if (data.logs) {
+    const ul = document.getElementById('logs');
+    ul.innerHTML = '';
+    data.logs.forEach(([ts, msg]) => {
+      const li = document.createElement('li');
+      li.textContent = `${ts}: ${msg}`;
+      ul.appendChild(li);
+    });
+  }
+};
+document.getElementById('addTask').onclick = () => {
+  const task = document.getElementById('taskInput').value;
+  ws.send(JSON.stringify({type: 'add_task', task, ts: new Date().toISOString()}));
+};
+document.getElementById('addLog').onclick = () => {
+  const msg = document.getElementById('logInput').value;
+  ws.send(JSON.stringify({type: 'log', message: msg, ts: new Date().toISOString()}));
+};
+</script>
+</body>
+</html>

--- a/src/collaboration_portal.py
+++ b/src/collaboration_portal.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import socket
 import threading
+from datetime import datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Iterable, Any
+
+from aiohttp import web
 
 from .telemetry import TelemetryLogger
 from .reasoning_history import ReasoningHistoryLogger
@@ -25,14 +30,80 @@ class CollaborationPortal:
         self.thread: threading.Thread | None = None
         self.port: int | None = None
 
-    # --------------------------------------------------------------
-    def add_task(self, task: str) -> None:
-        self.tasks.append(task)
+        # websocket server state
+        self.ws_app = web.Application()
+        self.ws_app.router.add_get('/ws', self._ws_handler)
+        self.ws_clients: list[web.WebSocketResponse] = []
+        self.ws_loop: asyncio.AbstractEventLoop | None = None
+        self.ws_runner: web.AppRunner | None = None
+        self.ws_thread: threading.Thread | None = None
+        self.ws_port: int | None = None
+
+        # track timestamps for conflict resolution
+        self.task_ts: dict[str, str] = {}
+        self.log_ts: str | None = None
 
     # --------------------------------------------------------------
-    def complete_task(self, task: str) -> None:
-        if task in self.tasks:
+    async def _ws_handler(self, request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        self.ws_clients.append(ws)
+        # send initial state
+        await ws.send_str(json.dumps({"tasks": self.get_tasks(), "logs": self.get_logs()}))
+        try:
+            async for msg in ws:
+                if msg.type == web.WSMsgType.TEXT:
+                    try:
+                        data = json.loads(msg.data)
+                    except Exception:
+                        continue
+                    self._handle_ws_message(data)
+        finally:
+            if ws in self.ws_clients:
+                self.ws_clients.remove(ws)
+        return ws
+
+    def _handle_ws_message(self, data: dict) -> None:
+        typ = data.get("type")
+        ts = data.get("ts") or datetime.utcnow().isoformat()
+        if typ == "add_task" and "task" in data:
+            self.add_task(str(data["task"]), ts)
+        elif typ == "complete_task" and "task" in data:
+            self.complete_task(str(data["task"]), ts)
+        elif typ == "log" and "message" in data:
+            self.add_log(str(data["message"]), ts)
+
+    async def _broadcast(self, payload: dict) -> None:
+        msg = json.dumps(payload)
+        for ws in list(self.ws_clients):
+            try:
+                await ws.send_str(msg)
+            except Exception:
+                self.ws_clients.remove(ws)
+
+    def _schedule_broadcast(self) -> None:
+        if self.ws_loop is None:
+            return
+        payload = {"tasks": self.get_tasks(), "logs": self.get_logs()}
+        asyncio.run_coroutine_threadsafe(self._broadcast(payload), self.ws_loop)
+
+    # --------------------------------------------------------------
+    def add_task(self, task: str, ts: str | None = None) -> None:
+        ts = ts or datetime.utcnow().isoformat()
+        if ts < self.task_ts.get(task, ""):
+            return
+        if task not in self.tasks:
+            self.tasks.append(task)
+        self.task_ts[task] = ts
+        self._schedule_broadcast()
+
+    # --------------------------------------------------------------
+    def complete_task(self, task: str, ts: str | None = None) -> None:
+        ts = ts or datetime.utcnow().isoformat()
+        if task in self.tasks and ts >= self.task_ts.get(task, ""):
             self.tasks.remove(task)
+            self.task_ts.pop(task, None)
+            self._schedule_broadcast()
 
     # --------------------------------------------------------------
     def get_tasks(self) -> list[str]:
@@ -45,6 +116,17 @@ class CollaborationPortal:
     # --------------------------------------------------------------
     def get_logs(self) -> list[tuple[str, str]]:
         return self.reasoning.get_history() if self.reasoning else []
+
+    # --------------------------------------------------------------
+    def add_log(self, message: str, ts: str | None = None) -> None:
+        ts = ts or datetime.utcnow().isoformat()
+        if self.log_ts is not None and ts <= self.log_ts:
+            return
+        if self.reasoning is None:
+            self.reasoning = ReasoningHistoryLogger()
+        self.reasoning.log(message)
+        self.log_ts = ts
+        self._schedule_broadcast()
 
     # --------------------------------------------------------------
     def to_html(self) -> str:
@@ -67,7 +149,12 @@ class CollaborationPortal:
         )
 
     # --------------------------------------------------------------
-    def start(self, host: str = "localhost", port: int = 8070) -> None:
+    def start(
+        self,
+        host: str = "localhost",
+        port: int = 8070,
+        ws_port: int | None = None,
+    ) -> None:
         if self.httpd is not None:
             return
         portal = self
@@ -107,17 +194,52 @@ class CollaborationPortal:
         self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
         self.thread.start()
 
+        if ws_port is not None:
+            self._start_ws(host, ws_port)
+
+    def _run_ws(self, host: str, port: int) -> None:
+        assert self.ws_loop is not None and self.ws_runner is not None
+        asyncio.set_event_loop(self.ws_loop)
+        self.ws_loop.run_until_complete(self.ws_runner.setup())
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind((host, port))
+        _, real_port = sock.getsockname()
+        self.ws_port = real_port
+        site = web.SockSite(self.ws_runner, sock)
+        self.ws_loop.run_until_complete(site.start())
+        try:
+            self.ws_loop.run_forever()
+        finally:
+            self.ws_loop.run_until_complete(self.ws_runner.cleanup())
+
+    def _start_ws(self, host: str, port: int) -> None:
+        if self.ws_thread is not None:
+            return
+        self.ws_loop = asyncio.new_event_loop()
+        self.ws_runner = web.AppRunner(self.ws_app)
+        self.ws_thread = threading.Thread(target=self._run_ws, args=(host, port), daemon=True)
+        self.ws_thread.start()
+        import time
+        time.sleep(0.1)
+
     # --------------------------------------------------------------
     def stop(self) -> None:
-        if self.httpd is None:
-            return
-        assert self.thread is not None
-        self.httpd.shutdown()
-        self.thread.join(timeout=1.0)
-        self.httpd.server_close()
-        self.httpd = None
-        self.thread = None
-        self.port = None
+        if self.httpd is not None:
+            assert self.thread is not None
+            self.httpd.shutdown()
+            self.thread.join(timeout=1.0)
+            self.httpd.server_close()
+            self.httpd = None
+            self.thread = None
+            self.port = None
+
+        if self.ws_thread is not None and self.ws_loop is not None:
+            self.ws_loop.call_soon_threadsafe(self.ws_loop.stop)
+            self.ws_thread.join(timeout=1.0)
+            self.ws_thread = None
+            self.ws_loop = None
+            self.ws_runner = None
+            self.ws_port = None
 
 
 __all__ = ["CollaborationPortal"]

--- a/tests/test_collaboration_portal.py
+++ b/tests/test_collaboration_portal.py
@@ -2,10 +2,20 @@ import unittest
 import http.client
 import json
 import time
+import importlib
+import types
+import sys
+from pathlib import Path
 
-from asi.collaboration_portal import CollaborationPortal
-from asi.telemetry import TelemetryLogger
-from asi.reasoning_history import ReasoningHistoryLogger
+asi_pkg = types.ModuleType('asi')
+sys.modules.setdefault('asi', asi_pkg)
+src_pkg = types.ModuleType('src')
+src_pkg.__path__ = [str(Path('src'))]
+sys.modules.setdefault('src', src_pkg)
+
+CollaborationPortal = importlib.import_module('src.collaboration_portal').CollaborationPortal
+TelemetryLogger = importlib.import_module('src.telemetry').TelemetryLogger
+ReasoningHistoryLogger = importlib.import_module('src.reasoning_history').ReasoningHistoryLogger
 
 
 class TestCollaborationPortal(unittest.TestCase):

--- a/tests/test_collaboration_portal_ws.py
+++ b/tests/test_collaboration_portal_ws.py
@@ -1,0 +1,58 @@
+import unittest
+import asyncio
+import json
+from datetime import datetime
+import importlib
+import types
+import sys
+from pathlib import Path
+
+asi_pkg = types.ModuleType('asi')
+sys.modules.setdefault('asi', asi_pkg)
+src_pkg = types.ModuleType('src')
+src_pkg.__path__ = [str(Path('src'))]
+sys.modules.setdefault('src', src_pkg)
+
+CollaborationPortal = importlib.import_module('src.collaboration_portal').CollaborationPortal
+ReasoningHistoryLogger = importlib.import_module('src.reasoning_history').ReasoningHistoryLogger
+from aiohttp import ClientSession
+
+
+class TestCollaborationPortalWS(unittest.TestCase):
+    def test_ws_updates(self):
+        rh = ReasoningHistoryLogger()
+        portal = CollaborationPortal([], None, rh)
+        portal.start(port=0, ws_port=0)
+        ws_port = portal.ws_port
+        self.assertIsNotNone(ws_port)
+
+        async def run_client():
+            assert ws_port is not None
+            async with ClientSession() as session:
+                async with session.ws_connect(f'http://localhost:{ws_port}/ws') as ws:
+                    await ws.receive()  # initial state
+                    await ws.send_str(json.dumps({
+                        'type': 'add_task',
+                        'task': 'demo',
+                        'ts': datetime.utcnow().isoformat()
+                    }))
+                    msg = await ws.receive()
+                    data = json.loads(msg.data)
+                    await ws.send_str(json.dumps({
+                        'type': 'log',
+                        'message': 'done',
+                        'ts': datetime.utcnow().isoformat()
+                    }))
+                    msg2 = await ws.receive()
+                    data2 = json.loads(msg2.data)
+                    return data, data2
+
+        data1, data2 = asyncio.get_event_loop().run_until_complete(run_client())
+        portal.stop()
+
+        self.assertIn('demo', data1['tasks'])
+        self.assertEqual(data2['logs'][-1][1], 'done')
+
+
+if __name__ == '__main__':  # pragma: no cover - test helper
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional WebSocket server in `CollaborationPortal`
- broadcast task and log updates with timestamp conflict resolution
- provide example HTML/JS client
- add websocket integration tests
- adapt existing tests to load modules without installing

## Testing
- `pytest tests/test_collaboration_portal.py tests/test_collaboration_portal_ws.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae4599fac83318b109832048fc6e7