### PR TITLE
Implement battery-aware scheduler

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -230,6 +230,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
    energy cost for each run and stop training when the budget is exhausted.
 7. **Budget-aware scheduler**: Automatically lower batch size and learning rate
    via `BudgetAwareScheduler` when `remaining()` falls below a threshold.
+7a. **Battery-aware scheduler**: Delay jobs when system battery level falls
+    below a configurable threshold. `BatteryAwareScheduler` queries the OS for
+    the current percentage and logs it via `TelemetryLogger` so runs on laptops
+    can conserve power.
 8. **Distributed memory benchmark**: Run `DistributedMemory` with four
    `MemoryServer` nodes using `distributed_memory_benchmark.py` and measure
    query latency and throughput versus the single-node baseline.

--- a/src/adaptive_scheduler.py
+++ b/src/adaptive_scheduler.py
@@ -47,6 +47,8 @@ class AdaptiveScheduler:
         *,
         energy_scheduler: bool = False,
         intensity_threshold: float = 0.5,
+        battery_scheduler: bool = False,
+        battery_threshold: float = 0.2,
         region_config: str | None = None,
     ) -> None:
         if energy_scheduler and type(self) is AdaptiveScheduler:
@@ -61,6 +63,20 @@ class AdaptiveScheduler:
                 window=window,
                 min_improvement=min_improvement,
                 intensity_threshold=intensity_threshold,
+            )
+            return
+        if battery_scheduler and type(self) is AdaptiveScheduler:
+            from .battery_aware_scheduler import BatteryAwareScheduler
+            self.__class__ = BatteryAwareScheduler
+            BatteryAwareScheduler.__init__(
+                self,
+                budget,
+                run_id,
+                max_mem=max_mem,
+                check_interval=check_interval,
+                window=window,
+                min_improvement=min_improvement,
+                battery_threshold=battery_threshold,
             )
             return
         self.budget = budget

--- a/src/battery_aware_scheduler.py
+++ b/src/battery_aware_scheduler.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import psutil
+
+from .adaptive_scheduler import AdaptiveScheduler
+
+
+class BatteryAwareScheduler(AdaptiveScheduler):
+    """Pause jobs when system battery level is low."""
+
+    def __init__(
+        self,
+        budget,
+        run_id: str,
+        max_mem: float = 0.9,
+        check_interval: float = 1.0,
+        window: int = 3,
+        min_improvement: float = 0.01,
+        battery_threshold: float = 0.2,
+    ) -> None:
+        super().__init__(
+            budget,
+            run_id,
+            max_mem=max_mem,
+            check_interval=check_interval,
+            window=window,
+            min_improvement=min_improvement,
+        )
+        self.battery_threshold = battery_threshold
+
+    # --------------------------------------------------------------
+    def _battery_level(self) -> float:
+        try:
+            info = psutil.sensors_battery()
+            if info is not None and info.percent is not None:
+                level = float(info.percent) / 100.0
+                self.telemetry.metrics["battery"] = info.percent
+                return level
+        except Exception:
+            pass
+        self.telemetry.metrics["battery"] = 100.0
+        return 1.0
+
+    # --------------------------------------------------------------
+    def _should_pause(self) -> bool:  # type: ignore[override]
+        if self._battery_level() < self.battery_threshold:
+            return True
+        return super()._should_pause()
+
+
+__all__ = ["BatteryAwareScheduler"]

--- a/tests/test_battery_aware_scheduler.py
+++ b/tests/test_battery_aware_scheduler.py
@@ -1,0 +1,101 @@
+import importlib.util
+import types
+import sys
+import time
+import unittest
+
+# stub psutil and torch
+psutil_stub = types.SimpleNamespace(
+    sensors_battery=lambda: types.SimpleNamespace(percent=10, power_plugged=False),
+    cpu_percent=lambda interval=None: 0.0,
+    virtual_memory=lambda: types.SimpleNamespace(percent=0.0),
+    net_io_counters=lambda: types.SimpleNamespace(bytes_sent=0, bytes_recv=0),
+)
+torch_stub = types.SimpleNamespace(
+    cuda=types.SimpleNamespace(
+        utilization=lambda: 0.0,
+        is_available=lambda: False,
+        memory_allocated=lambda: 0,
+        get_device_properties=lambda _: types.SimpleNamespace(total_memory=1),
+    )
+)
+sys.modules['psutil'] = psutil_stub
+sys.modules['torch'] = torch_stub
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+ct_stub = types.ModuleType('asi.carbon_tracker')
+class _CT:
+    def __init__(self, *a, **k):
+        pass
+    def start(self):
+        pass
+    def stop(self):
+        pass
+    def get_stats(self):
+        return {}
+ct_stub.CarbonFootprintTracker = _CT
+sys.modules['asi.carbon_tracker'] = ct_stub
+med_stub = types.ModuleType('asi.memory_event_detector')
+class _MED:
+    def __init__(self, *a, **k):
+        self.events = []
+    def update(self, snapshot):
+        return []
+med_stub.MemoryEventDetector = _MED
+sys.modules['asi.memory_event_detector'] = med_stub
+cas_stub = types.ModuleType('asi.cost_aware_scheduler')
+cas_stub.get_current_price = lambda provider, region, inst: 0.0
+sys.modules['asi.cost_aware_scheduler'] = cas_stub
+TelemetryLogger = _load('asi.telemetry', 'src/telemetry.py').TelemetryLogger
+sys.modules['asi.telemetry']._HAS_PROM = False
+ComputeBudgetTracker = _load('asi.compute_budget_tracker', 'src/compute_budget_tracker.py').ComputeBudgetTracker
+AdaptiveScheduler = _load('asi.adaptive_scheduler', 'src/adaptive_scheduler.py').AdaptiveScheduler
+BatteryAwareScheduler = _load('asi.battery_aware_scheduler', 'src/battery_aware_scheduler.py').BatteryAwareScheduler
+
+
+class TestBatteryAwareScheduler(unittest.TestCase):
+    def test_pause_low_battery(self):
+        logger = TelemetryLogger(interval=0.05)
+        tracker = ComputeBudgetTracker(1.0, telemetry=logger)
+        sched = BatteryAwareScheduler(tracker, 'run', check_interval=0.05, battery_threshold=0.5)
+        ran = []
+
+        def job():
+            ran.append(1)
+
+        sched.add(job)
+        time.sleep(0.2)
+        sched.stop()
+        self.assertLess(logger.metrics.get('battery', 100.0), 100.0)
+
+    def test_adaptive_integration(self):
+        psutil_stub.sensors_battery = lambda: types.SimpleNamespace(percent=80)
+        logger = TelemetryLogger(interval=0.05)
+        tracker = ComputeBudgetTracker(1.0, telemetry=logger)
+        sched = AdaptiveScheduler(tracker, 'run', check_interval=0.05, battery_scheduler=True, battery_threshold=0.5)
+        self.assertIsInstance(sched, BatteryAwareScheduler)
+        ran = []
+
+        def job():
+            ran.append(1)
+
+        sched.add(job)
+        time.sleep(0.2)
+        sched.stop()
+        self.assertGreaterEqual(len(ran), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `BatteryAwareScheduler` to pause work on low battery
- integrate battery-aware logic with `AdaptiveScheduler`
- record battery level in `TelemetryLogger`
- test battery scheduler behaviour
- document battery-aware scheduling in `Plan.md`

## Testing
- `pytest tests/test_battery_aware_scheduler.py -q`
- `pytest tests/test_adaptive_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b007961fc833186ace9cef2b5fb46