### PR TITLE
Add dataset lineage dashboard

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -703,6 +703,8 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   **Implemented in `src/dataset_versioner.py` and wired through `data_ingest`.**
 - Add a `DatasetLineageManager` that records transformation steps and resulting file hashes for reproducible pipelines.
   **Implemented in `src/dataset_lineage_manager.py` with tests.**
+- Provide a `DatasetLineageDashboard` exposing `/graph` and `/steps` endpoints for searching lineage records. Run `python scripts/lineage_dashboard.py <root>` to launch it.
+  **Implemented in `src/dataset_lineage_dashboard.py` with tests.**
 - Introduce a `BlockchainProvenanceLedger` that links each record to the previous hash. Ingestion helpers append their lineage to this ledger and `scripts/check_blockchain_provenance.py` verifies the chain.
 - Implement a `ContextWindowProfiler` that measures memory footprint and wall-clock time at various sequence lengths. **Implemented as `src/context_profiler.py` and integrated with `eval_harness.py`.**
 - Extend `HierarchicalMemory` with an adaptive eviction policy that prunes rarely used vectors and emit statistics on hit/miss ratios.

--- a/scripts/lineage_dashboard.py
+++ b/scripts/lineage_dashboard.py
@@ -1,0 +1,36 @@
+"""Start a dataset lineage dashboard."""
+from __future__ import annotations
+
+import argparse
+import time
+
+try:  # pragma: no cover - prefer package import
+    from asi.dataset_lineage_manager import DatasetLineageManager
+    from asi.dataset_lineage_dashboard import DatasetLineageDashboard
+except Exception:  # pragma: no cover - fallback for tests
+    from src.dataset_lineage_manager import DatasetLineageManager  # type: ignore
+    from src.dataset_lineage_dashboard import DatasetLineageDashboard  # type: ignore
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Dataset lineage dashboard")
+    parser.add_argument("root", help="Dataset root directory")
+    parser.add_argument("--port", type=int, default=8011)
+    args = parser.parse_args(argv)
+
+    mgr = DatasetLineageManager(args.root)
+    mgr.load()
+    dash = DatasetLineageDashboard(mgr)
+    dash.start(port=args.port)
+    print(f"Serving on http://localhost:{dash.port}")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:  # pragma: no cover - manual stop
+        pass
+    finally:
+        dash.stop()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -164,6 +164,7 @@ from .cognitive_load_monitor import CognitiveLoadMonitor
 from .license_inspector import LicenseInspector
 from .dataset_versioner import DatasetVersioner
 from .dataset_lineage_manager import DatasetLineageManager
+from .dataset_lineage_dashboard import DatasetLineageDashboard
 from .dataset_anonymizer import DatasetAnonymizer
 from .dataset_discovery import (
     DiscoveredDataset,

--- a/src/dataset_lineage_dashboard.py
+++ b/src/dataset_lineage_dashboard.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import asdict
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+from typing import Any, Iterable, List
+
+from .dataset_lineage_manager import DatasetLineageManager, LineageStep
+
+
+class DatasetLineageDashboard:
+    """Serve dataset lineage graphs with basic filtering and search."""
+
+    def __init__(self, manager: DatasetLineageManager) -> None:
+        self.manager = manager
+        self.httpd: HTTPServer | None = None
+        self.thread: threading.Thread | None = None
+        self.port: int | None = None
+
+    # --------------------------------------------------------------
+    def _filter_steps(
+        self,
+        *,
+        query: str | None = None,
+        note: str | None = None,
+        inp: str | None = None,
+        out: str | None = None,
+    ) -> List[LineageStep]:
+        steps = self.manager.steps
+        results: List[LineageStep] = []
+        for s in steps:
+            if note and note not in s.note:
+                continue
+            if inp and inp not in s.inputs:
+                continue
+            if out and out not in s.outputs:
+                continue
+            if query:
+                hay = " ".join([s.note] + s.inputs + list(s.outputs.keys()) + list(s.outputs.values()))
+                if query not in hay:
+                    continue
+            results.append(s)
+        return results
+
+    # --------------------------------------------------------------
+    def graph_json(self, steps: Iterable[LineageStep] | None = None) -> dict[str, list]:
+        if steps is None:
+            steps = self.manager.steps
+        nodes: dict[str, dict[str, str]] = {}
+        links: list[dict[str, str]] = []
+        for step in steps:
+            for inp in step.inputs:
+                nodes[inp] = {"id": inp}
+            for out in step.outputs.keys():
+                nodes[out] = {"id": out}
+                for inp in step.inputs:
+                    links.append({"source": inp, "target": out, "note": step.note})
+        return {"nodes": list(nodes.values()), "links": links}
+
+    # --------------------------------------------------------------
+    def steps_json(self, steps: Iterable[LineageStep]) -> list[dict[str, Any]]:
+        return [asdict(s) for s in steps]
+
+    # --------------------------------------------------------------
+    def to_html(self) -> str:
+        return (
+            "<html><body><h1>Dataset Lineage Dashboard</h1>"
+            "<input id='q' placeholder='search'><button onclick='load()'>Search</button>"
+            "<script src='https://cdn.jsdelivr.net/npm/d3@7'></script>"
+            "<svg width='800' height='600'></svg>"
+            "<script>"
+            "function draw(data){const svg=d3.select('svg');svg.selectAll('*').remove();"
+            "const width=+svg.attr('width'),height=+svg.attr('height');"
+            "const sim=d3.forceSimulation(data.nodes)"
+            ".force('link',d3.forceLink(data.links).id(d=>d.id).distance(40))"
+            ".force('charge',d3.forceManyBody().strength(-200))"
+            ".force('center',d3.forceCenter(width/2,height/2));"
+            "const link=svg.append('g').selectAll('line')"
+            ".data(data.links).enter().append('line').attr('stroke','#999');"
+            "const node=svg.append('g').selectAll('circle')"
+            ".data(data.nodes).enter().append('circle').attr('r',5)"
+            ".call(d3.drag()"
+            ".on('start',e=>{if(!e.active)sim.alphaTarget(0.3).restart();e.subject.fx=e.subject.x;e.subject.fy=e.subject.y;})"
+            ".on('drag',e=>{e.subject.fx=e.x;e.subject.fy=e.y;})"
+            ".on('end',e=>{if(!e.active)sim.alphaTarget(0);e.subject.fx=null;e.subject.fy=null;}));"
+            "const text=svg.append('g').selectAll('text')"
+            ".data(data.nodes).enter().append('text').text(d=>d.id.split('/').pop());"
+            "sim.on('tick',()=>{"
+            "link.attr('x1',d=>d.source.x).attr('y1',d=>d.source.y)"
+            ".attr('x2',d=>d.target.x).attr('y2',d=>d.target.y);"
+            "node.attr('cx',d=>d.x).attr('cy',d=>d.y);"
+            "text.attr('x',d=>d.x+6).attr('y',d=>d.y+4);"
+            "});}"
+            "function load(){const q=document.getElementById('q').value;"
+            "fetch('/graph?q='+encodeURIComponent(q)).then(r=>r.json()).then(draw);}"
+            "load();"
+            "</script></body></html>"
+        )
+
+    # --------------------------------------------------------------
+    def start(self, host: str = "localhost", port: int = 8011) -> None:
+        if self.httpd is not None:
+            return
+        dashboard = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: D401
+                parsed = urlparse(self.path)
+                q = parse_qs(parsed.query)
+                if parsed.path == "/graph":
+                    steps = dashboard._filter_steps(
+                        query=q.get("q", [None])[0],
+                        note=q.get("note", [None])[0],
+                        inp=q.get("input", [None])[0],
+                        out=q.get("output", [None])[0],
+                    )
+                    data = json.dumps(dashboard.graph_json(steps)).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                elif parsed.path in ("/steps", "/search"):
+                    steps = dashboard._filter_steps(
+                        query=q.get("q", [None])[0],
+                        note=q.get("note", [None])[0],
+                        inp=q.get("input", [None])[0],
+                        out=q.get("output", [None])[0],
+                    )
+                    data = json.dumps(dashboard.steps_json(steps)).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(data)
+                else:
+                    html = dashboard.to_html().encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/html")
+                    self.end_headers()
+                    self.wfile.write(html)
+
+            def log_message(self, format: str, *args: Any) -> None:  # noqa: D401
+                return
+
+        self.httpd = HTTPServer((host, port), Handler)
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    # --------------------------------------------------------------
+    def stop(self) -> None:
+        if self.httpd is None:
+            return
+        assert self.thread is not None
+        self.httpd.shutdown()
+        self.thread.join(timeout=1.0)
+        self.httpd.server_close()
+        self.httpd = None
+        self.thread = None
+        self.port = None
+
+
+__all__ = ["DatasetLineageDashboard"]

--- a/tests/test_dataset_lineage_dashboard.py
+++ b/tests/test_dataset_lineage_dashboard.py
@@ -1,0 +1,56 @@
+import unittest
+import tempfile
+import json
+import http.client
+from pathlib import Path
+import importlib.machinery
+import importlib.util
+import sys
+import types
+
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+src_pkg.__path__ = ['src']
+src_pkg.__spec__ = importlib.machinery.ModuleSpec('src', None, is_package=True)
+
+
+def _load(name: str, path: str):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'src'
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+DatasetLineageManager = _load('src.dataset_lineage_manager', 'src/dataset_lineage_manager.py').DatasetLineageManager
+DatasetLineageDashboard = _load('src.dataset_lineage_dashboard', 'src/dataset_lineage_dashboard.py').DatasetLineageDashboard
+
+
+class TestDatasetLineageDashboard(unittest.TestCase):
+    def test_http_server(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            inp = root / 'in.txt'
+            outp = root / 'out.txt'
+            inp.write_text('a')
+            outp.write_text('b')
+            mgr = DatasetLineageManager(root)
+            mgr.record([inp], [outp], note='copy')
+            dash = DatasetLineageDashboard(mgr)
+            dash.start(port=0)
+            port = dash.port
+            conn = http.client.HTTPConnection('localhost', port)
+            conn.request('GET', '/graph')
+            resp = conn.getresponse()
+            data = json.loads(resp.read())
+            self.assertEqual(len(data['nodes']), 2)
+            conn.request('GET', '/steps?q=copy')
+            resp = conn.getresponse()
+            steps = json.loads(resp.read())
+            self.assertEqual(len(steps), 1)
+            dash.stop()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a DatasetLineageDashboard with search/filter endpoints
- expose the dashboard via a new script
- export the class from the package
- document launch instructions in the implementation notes
- add unit test for the dashboard server

## Testing
- `pytest tests/test_dataset_lineage_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b007ef7c48331a12a4174978cf19a