### PR TITLE
Add multilingual research ingestion

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -773,8 +773,9 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Introduce an `ARDebugger` that streams robot state via WebSockets so predicted
   and actual trajectories from `world_model_rl` can be overlaid in an AR client.
   See `scripts/ar_robot_demo.py` for a minimal demo.
-- Add `research_ingest.py` which fetches new papers and outputs daily summaries
-  under `research_logs/`.
+- `research_ingest.py` fetches arXiv titles and abstracts, translates them via
+  `CrossLingualTranslator` and stores language-tagged summaries under
+  `research_logs/`.
 - Expand `GenerativeDataAugmentor` with `synthesize_3d()` for basic 3D asset
   synthesis.
 - Extend `world_model_rl.train_world_model()` to accept 3D data from this

--- a/tests/test_research_ingest.py
+++ b/tests/test_research_ingest.py
@@ -4,14 +4,33 @@ import importlib.util
 import types
 import sys
 
+
 src_pkg = types.ModuleType('src')
 sys.modules['src'] = src_pkg
+sys.modules['numpy'] = types.ModuleType('numpy')
+sys.modules['torch'] = types.ModuleType('torch')
+sys.modules['requests'] = types.ModuleType('requests')
+sys.modules['aiohttp'] = types.ModuleType('aiohttp')
+sys.modules['PIL'] = types.ModuleType('PIL')
+sys.modules['PIL.Image'] = types.ModuleType('PIL.Image')
+sys.modules['src.carbon_tracker'] = types.SimpleNamespace(
+    CarbonFootprintTracker=type('CFT', (), {'__init__': lambda self, **kw: None})
+)
+
+di_loader = importlib.machinery.SourceFileLoader('src.data_ingest', 'src/data_ingest.py')
+di_spec = importlib.util.spec_from_loader(di_loader.name, di_loader)
+di = importlib.util.module_from_spec(di_spec)
+di.__package__ = 'src'
+sys.modules['src.data_ingest'] = di
+di_loader.exec_module(di)
+src_pkg.data_ingest = di
 
 loader = importlib.machinery.SourceFileLoader('src.research_ingest', 'src/research_ingest.py')
 spec = importlib.util.spec_from_loader(loader.name, loader)
 ri = importlib.util.module_from_spec(spec)
 ri.__package__ = 'src'
 sys.modules['src.research_ingest'] = ri
+src_pkg.research_ingest = ri
 loader.exec_module(ri)
 
 

--- a/tests/test_research_ingest_multilingual.py
+++ b/tests/test_research_ingest_multilingual.py
@@ -1,0 +1,55 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import tempfile
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+sys.modules['numpy'] = types.ModuleType('numpy')
+sys.modules['torch'] = types.ModuleType('torch')
+sys.modules['requests'] = types.ModuleType('requests')
+sys.modules['aiohttp'] = types.ModuleType('aiohttp')
+sys.modules['PIL'] = types.ModuleType('PIL')
+sys.modules['PIL.Image'] = types.ModuleType('PIL.Image')
+sys.modules['src.carbon_tracker'] = types.SimpleNamespace(
+    CarbonFootprintTracker=type('CFT', (), {'__init__': lambda self, **kw: None})
+)
+
+# load data_ingest and research_ingest dynamically
+loader_di = importlib.machinery.SourceFileLoader('src.data_ingest', 'src/data_ingest.py')
+spec_di = importlib.util.spec_from_loader(loader_di.name, loader_di)
+di = importlib.util.module_from_spec(spec_di)
+di.__package__ = 'src'
+loader_di.exec_module(di)
+sys.modules['src.data_ingest'] = di
+src_pkg.data_ingest = di
+CrossLingualTranslator = di.CrossLingualTranslator
+
+loader_ri = importlib.machinery.SourceFileLoader('src.research_ingest', 'src/research_ingest.py')
+spec_ri = importlib.util.spec_from_loader(loader_ri.name, loader_ri)
+ri = importlib.util.module_from_spec(spec_ri)
+ri.__package__ = 'src'
+loader_ri.exec_module(ri)
+sys.modules['src.research_ingest'] = ri
+src_pkg.research_ingest = ri
+
+
+class TestResearchIngestMultilingual(unittest.TestCase):
+    def test_run_ingestion_translates(self):
+        tr = CrossLingualTranslator(['es'])
+        with tempfile.TemporaryDirectory() as root:
+            with patch.object(ri, 'fetch_recent_papers', return_value=[{'title': 'T', 'summary': 'S'}]):
+                path = ri.run_ingestion(root, translator=tr)
+            data = json.loads(Path(path).read_text())
+            paper = data['papers'][0]
+            self.assertEqual(paper['title_translations']['es'], '[es] T')
+            self.assertEqual(paper['summary_translations']['es'], '[es] S')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- translate paper titles and abstracts using `CrossLingualTranslator`
- store language-tagged research summaries under `research_logs/`
- update docs about the translation workflow
- test multilingual ingestion logic

## Testing
- `pytest tests/test_research_ingest.py tests/test_research_ingest_multilingual.py -q`
- `pytest -q` *(fails: 174 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686b008ab9b083319912c64f93708e62