### PR TITLE
Add sign language ingestion

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -471,6 +471,11 @@ img = random_crop(Image.open(pairs[0][1]), (32, 32))
 txt = generate_transcript(pairs[0][2])
 ```
 
+`download_triples()` also accepts `sign_urls` to ingest sign-language videos.
+`src/sign_language.py` implements `SignLanguageRecognizer` using MediaPipe hand
+landmarks. When passed to `cross_modal_fusion.encode_all()` the recognizer
+stores sign embeddings and transcripts in `CrossLingualMemory` for retrieval.
+
 `offline_synthesizer()` rolls out the multimodal world model to generate
 simplified synthetic triples offline:
 

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -238,6 +238,8 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 10. **Checkpointed world model**: *(done)* the multimodal world model now
    supports a `checkpoint_blocks` flag which reduces memory usage during
    training.
+11. **Sign-language retrieval**: `download_triples()` ingests sign videos and
+    `SignLanguageRecognizer` stores their embeddings for cross-modal search.
 11. **Self-play dataset fusion**: *(implemented)* `train_with_self_play` records
    trajectories from `self_play_skill_loop.run_loop` and feeds them into
    `train_world_model` for mixed-modality experiments.

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -193,11 +193,12 @@ class HierarchicalMemory:
         text: torch.Tensor | None = None,
         images: torch.Tensor | None = None,
         audio: torch.Tensor | None = None,
+        sign: torch.Tensor | None = None,
         metadata: Iterable[Any] | None = None,
     ) -> None:
-        """Add text/image/audio embeddings with modality metadata."""
+        """Add text/image/audio/sign embeddings with modality metadata."""
         n = None
-        for t in (text, images, audio):
+        for t in (text, images, audio, sign):
             if t is not None:
                 n = t.shape[0]
                 break
@@ -216,6 +217,8 @@ class HierarchicalMemory:
             self.add(images, [{"id": m, "modality": "image"} for m in metas])
         if audio is not None:
             self.add(audio, [{"id": m, "modality": "audio"} for m in metas])
+        if sign is not None:
+            self.add(sign, [{"id": m, "modality": "sign"} for m in metas])
 
     def add_from_fusion(
         self,
@@ -349,10 +352,14 @@ class HierarchicalMemory:
         text: torch.Tensor,
         images: torch.Tensor,
         audio: torch.Tensor,
+        sign: torch.Tensor | None = None,
         metadata: Iterable[Any] | None = None,
     ) -> None:
         """Store averaged multimodal embeddings."""
-        vecs = (text + images + audio) / 3.0
+        if sign is None:
+            vecs = (text + images + audio) / 3.0
+        else:
+            vecs = (text + images + audio + sign) / 4.0
         self.add(vecs, metadata)
 
     def _evict_if_needed(self) -> None:
@@ -434,10 +441,14 @@ class HierarchicalMemory:
         text: torch.Tensor,
         images: torch.Tensor,
         audio: torch.Tensor,
+        sign: torch.Tensor | None = None,
         metadata: Iterable[Any] | None = None,
     ) -> None:
         """Asynchronously store averaged multimodal embeddings."""
-        vecs = (text + images + audio) / 3.0
+        if sign is None:
+            vecs = (text + images + audio) / 3.0
+        else:
+            vecs = (text + images + audio + sign) / 4.0
         await self.aadd(vecs, metadata)
 
     async def adelete(self, index: int | Iterable[int] | None = None, tag: Any | None = None) -> None:

--- a/src/sign_language.py
+++ b/src/sign_language.py
@@ -1,0 +1,68 @@
+import numpy as np
+
+try:  # optional dependency
+    import mediapipe as mp  # type: ignore
+    import cv2  # type: ignore
+    _HAS_MEDIAPIPE = True
+except Exception:  # pragma: no cover - optional
+    mp = None
+    cv2 = None
+    _HAS_MEDIAPIPE = False
+
+
+class SignLanguageRecognizer:
+    """Extract simple sign embeddings and classify them."""
+
+    def __init__(self, known_signs: dict[str, np.ndarray] | None = None) -> None:
+        self.known_signs = {
+            k: np.asarray(v, dtype=np.float32) for k, v in (known_signs or {}).items()
+        }
+        if _HAS_MEDIAPIPE:
+            self._hands = mp.solutions.hands.Hands(static_image_mode=False)
+        else:  # pragma: no cover - fallback
+            self._hands = None
+
+    # ------------------------------------------------------------------
+    def encode(self, video: str | np.ndarray) -> np.ndarray:
+        """Return a landmark embedding for ``video``."""
+        if isinstance(video, np.ndarray):
+            return np.asarray(video, dtype=np.float32)
+        if not _HAS_MEDIAPIPE or self._hands is None:
+            return np.zeros(63 * 2, dtype=np.float32)
+        cap = cv2.VideoCapture(str(video))
+        frames: list[np.ndarray] = []
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            res = self._hands.process(frame)
+            vec: list[float] = []
+            if res.left_hand_landmarks:
+                for lm in res.left_hand_landmarks.landmark:
+                    vec.extend([lm.x, lm.y, lm.z])
+            if res.right_hand_landmarks:
+                for lm in res.right_hand_landmarks.landmark:
+                    vec.extend([lm.x, lm.y, lm.z])
+            if vec:
+                frames.append(np.asarray(vec, dtype=np.float32))
+        cap.release()
+        if not frames:
+            return np.zeros(63 * 2, dtype=np.float32)
+        return np.stack(frames).mean(axis=0)
+
+    # ------------------------------------------------------------------
+    def recognize(self, video_or_emb: str | np.ndarray) -> str:
+        """Return the closest known sign label or ``""``."""
+        emb = self.encode(video_or_emb) if not isinstance(video_or_emb, np.ndarray) else np.asarray(video_or_emb, dtype=np.float32)
+        best = ""
+        best_score = -float("inf")
+        for name, ref in self.known_signs.items():
+            score = float(np.dot(emb, ref) / (np.linalg.norm(emb) * np.linalg.norm(ref) + 1e-8))
+            if score > best_score:
+                best_score = score
+                best = name
+        return best
+
+
+__all__ = ["SignLanguageRecognizer"]

--- a/tests/test_sign_language.py
+++ b/tests/test_sign_language.py
@@ -1,0 +1,61 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+import unittest
+import numpy as np
+import torch
+from unittest.mock import patch
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+cmf = load('asi.cross_modal_fusion', 'src/cross_modal_fusion.py')
+clm = load('asi.cross_lingual_memory', 'src/cross_lingual_memory.py')
+sl = load('asi.sign_language', 'src/sign_language.py')
+
+SignLanguageRecognizer = sl.SignLanguageRecognizer
+CrossLingualMemory = clm.CrossLingualMemory
+CrossModalFusionConfig = cmf.CrossModalFusionConfig
+CrossModalFusion = cmf.CrossModalFusion
+MultiModalDataset = cmf.MultiModalDataset
+
+
+class TestSignLanguage(unittest.TestCase):
+    def test_recognize_and_retrieve(self):
+        ref = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        rec = SignLanguageRecognizer({'hi': ref})
+        with patch.object(rec, 'encode', return_value=ref):
+            mem = CrossLingualMemory(dim=3, compressed_dim=2, capacity=10, sign_recognizer=rec)
+            sign = torch.from_numpy(ref)
+            mem.add_modalities(sign=sign.unsqueeze(0), metadata=[0])
+            vecs, meta = mem.search_text('hi', k=1)
+            self.assertEqual(len(meta), 1)
+            self.assertEqual(meta[0], 0)
+
+    def test_encode_all_store_sign(self):
+        cfg = CrossModalFusionConfig(vocab_size=10, text_dim=3, img_channels=1, audio_channels=1, latent_dim=3)
+        model = CrossModalFusion(cfg)
+        data = [('hi', torch.zeros(1,1,1), torch.zeros(1,1), np.array([1.0,0.0,0.0], dtype=np.float32))]
+        ds = MultiModalDataset(data, lambda x: [0])
+        rec = SignLanguageRecognizer({'hi': np.array([1.0,0.0,0.0], dtype=np.float32)})
+        with patch.object(rec, 'encode', return_value=np.array([1.0,0.0,0.0], dtype=np.float32)):
+            mem = CrossLingualMemory(dim=3, compressed_dim=2, capacity=10, sign_recognizer=rec)
+            cmf.encode_all(model, ds, batch_size=1, memory=mem, sign_recognizer=rec)
+            vecs, meta = mem.search_text('hi', k=1)
+            self.assertTrue(meta)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `SignLanguageRecognizer` for basic sign embeddings
- handle sign-language videos in `download_triples`
- store sign embeddings via `encode_all` and `CrossLingualMemory.add_modalities`
- support sign modality in `HierarchicalMemory`
- document usage and add sign-language tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b01010d248331a75f1a7af03e0fed