### PR TITLE
Add neuroevolution search module

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -302,6 +302,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     The search now logs energy usage via `TelemetryLogger` and supports an
     `energy_weight` option to trade off accuracy against consumption.
     *Implemented in `src/neural_arch_search.py`.*
+25a. **Neuroevolution search**: `src/neuroevolution_search.py` mutates and
+    crosses over configs in a population. Each generation benchmarks
+    candidates via `eval_harness`. The CLI script
+    `scripts/neuroevolution_search.py` runs experiments.
 25. **Self-healing distributed training**: Deploy `SelfHealingTrainer` to
     restart failed jobs automatically and track overall utilization.
     *Implemented in `src/self_healing_trainer.py`.*

--- a/scripts/neuroevolution_search.py
+++ b/scripts/neuroevolution_search.py
@@ -1,0 +1,44 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from asi.neuroevolution_search import NeuroevolutionSearch
+from asi.eval_harness import evaluate_modules
+
+
+def _load_space(path: str | Path) -> Dict[str, list[Any]]:
+    data = json.loads(Path(path).read_text())
+    return {k: list(v) for k, v in data.items()}
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run neuroevolution search")
+    parser.add_argument("--space", required=True, help="JSON file describing search space")
+    parser.add_argument("--generations", type=int, default=3, help="Number of generations")
+    parser.add_argument("--population", type=int, default=4, help="Population size")
+    parser.add_argument("--modules", nargs="*", help="Modules to benchmark")
+    args = parser.parse_args(argv)
+
+    space = _load_space(args.space)
+
+    def eval_cfg(cfg: Dict[str, Any]) -> float:
+        modules = args.modules or cfg.get("modules", [])
+        if not modules:
+            return 0.0
+        res = evaluate_modules(modules)
+        return sum(1.0 for ok, _ in res.values() if ok) / len(modules)
+
+    search = NeuroevolutionSearch(
+        space,
+        eval_cfg,
+        population_size=args.population,
+        mutation_rate=0.3,
+        crossover_rate=0.5,
+    )
+    best, score = search.evolve(generations=args.generations)
+    print(json.dumps({"best": best, "score": score}, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -144,6 +144,7 @@ from .transformer_circuits import (
     AttentionVisualizer,
 )
 from .neural_arch_search import DistributedArchSearch
+from .neuroevolution_search import NeuroevolutionSearch
 from .onnx_utils import export_to_onnx
 from .hierarchical_planner import HierarchicalPlanner
 try:

--- a/src/eval_harness.py
+++ b/src/eval_harness.py
@@ -249,6 +249,21 @@ def _eval_neural_arch_search() -> Tuple[bool, str]:
     return ok, f"score={val:.2f}"
 
 
+def _eval_neuroevolution_search() -> Tuple[bool, str]:
+    """Run a tiny population-based search to verify the module."""
+    from asi.neuroevolution_search import NeuroevolutionSearch
+
+    space = {"layers": [1, 2], "hidden": [8, 16]}
+
+    def score(cfg: Dict[str, int]) -> float:
+        return cfg["layers"] * cfg["hidden"]
+
+    evo = NeuroevolutionSearch(space, score, population_size=4, mutation_rate=0.5)
+    best, val = evo.evolve(generations=2)
+    ok = "layers" in best and "hidden" in best
+    return ok, f"score={val:.2f}"
+
+
 def _eval_self_alignment() -> Tuple[bool, str]:
     """Check simple alignment using :class:`DeliberativeAligner`."""
     from asi.deliberative_alignment import DeliberativeAligner
@@ -395,6 +410,7 @@ EVALUATORS: Dict[str, Callable[[], Tuple[bool, str]]] = {
     "paper_to_code": _eval_paper_to_code,
     "autobench": _eval_autobench,
     "neural_arch_search": _eval_neural_arch_search,
+    "neuroevolution_search": _eval_neuroevolution_search,
     "self_alignment": _eval_self_alignment,
     "adversarial_robustness": _eval_adversarial_robustness,
     "fairness_evaluator": _eval_fairness_evaluator,

--- a/src/neuroevolution_search.py
+++ b/src/neuroevolution_search.py
@@ -1,0 +1,81 @@
+"""Population-based neuroevolution for model configurations."""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Callable, Dict, Iterable, Tuple, List
+
+
+class NeuroevolutionSearch:
+    """Evolve model configs via mutation and crossover."""
+
+    def __init__(
+        self,
+        search_space: Dict[str, Iterable[Any]],
+        eval_func: Callable[[Dict[str, Any]], float],
+        *,
+        population_size: int = 4,
+        mutation_rate: float = 0.3,
+        crossover_rate: float = 0.5,
+    ) -> None:
+        self.search_space = {k: list(v) for k, v in search_space.items()}
+        if population_size < 2:
+            raise ValueError("population_size must be at least 2")
+        if not 0.0 <= mutation_rate <= 1.0:
+            raise ValueError("mutation_rate must be between 0 and 1")
+        if not 0.0 <= crossover_rate <= 1.0:
+            raise ValueError("crossover_rate must be between 0 and 1")
+        self.eval_func = eval_func
+        self.population_size = population_size
+        self.mutation_rate = float(mutation_rate)
+        self.crossover_rate = float(crossover_rate)
+
+    # ------------------------------------------------------------------
+    def _random_cfg(self) -> Dict[str, Any]:
+        return {k: random.choice(v) for k, v in self.search_space.items()}
+
+    def _mutate(self, cfg: Dict[str, Any]) -> Dict[str, Any]:
+        new = dict(cfg)
+        for k, choices in self.search_space.items():
+            if random.random() < self.mutation_rate:
+                new[k] = random.choice(choices)
+        return new
+
+    def _crossover(self, a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            k: (a[k] if random.random() < 0.5 else b[k]) for k in self.search_space
+        }
+
+    # ------------------------------------------------------------------
+    def evolve(self, generations: int = 5) -> Tuple[Dict[str, Any], float]:
+        """Run ``generations`` of evolution and return the best config."""
+        if generations <= 0:
+            raise ValueError("generations must be positive")
+        population = [self._random_cfg() for _ in range(self.population_size)]
+        scores = [float(self.eval_func(c)) for c in population]
+        best_idx = max(range(self.population_size), key=lambda i: scores[i])
+        best_cfg = population[best_idx]
+        best_score = scores[best_idx]
+
+        for _ in range(generations):
+            ranked = sorted(zip(population, scores), key=lambda x: x[1], reverse=True)
+            parents = [cfg for cfg, _ in ranked[: max(2, self.population_size // 2)]]
+            next_pop: List[Dict[str, Any]] = []
+            while len(next_pop) < self.population_size:
+                if random.random() < self.crossover_rate and len(parents) >= 2:
+                    p1, p2 = random.sample(parents, 2)
+                    child = self._crossover(p1, p2)
+                else:
+                    p = random.choice(parents)
+                    child = self._mutate(p)
+                next_pop.append(child)
+            population = next_pop
+            scores = [float(self.eval_func(c)) for c in population]
+            idx = max(range(self.population_size), key=lambda i: scores[i])
+            if scores[idx] > best_score:
+                best_score = scores[idx]
+                best_cfg = population[idx]
+        return best_cfg, best_score
+
+
+__all__ = ["NeuroevolutionSearch"]

--- a/tests/test_neuroevolution_search.py
+++ b/tests/test_neuroevolution_search.py
@@ -1,0 +1,40 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import random
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+NeuroevolutionSearch = _load('asi.neuroevolution_search', 'src/neuroevolution_search.py').NeuroevolutionSearch
+
+
+class TestNeuroevolutionSearch(unittest.TestCase):
+    def test_evolve_finds_best(self):
+        space = {"x": [0, 1], "y": [1, 2]}
+        random.seed(0)
+
+        def score(cfg):
+            return cfg["x"] + cfg["y"]
+
+        search = NeuroevolutionSearch(space, score, population_size=4, mutation_rate=0.5)
+        best, val = search.evolve(generations=2)
+        self.assertEqual(best["x"], 1)
+        self.assertEqual(best["y"], 2)
+        self.assertEqual(val, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `NeuroevolutionSearch` class for population-based architecture search
- integrate search with `eval_harness` and expose new evaluator
- add CLI `scripts/neuroevolution_search.py`
- export class from package
- document neuroevolution search in the research plan
- add minimal unit test

## Testing
- `pytest tests/test_neuroevolution_search.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b00d79a088331b54000eddee0e90c