### PR TITLE
Add multi-cluster scheduler

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -577,6 +577,15 @@ records estimated energy usage and wait time via `TelemetryLogger`.
 
 The new `CarbonCostAwareScheduler` extends this by also polling cloud price APIs and weighting the forecasts. Configurable `carbon_weight` and `cost_weight` pick the cheapest-greenest slot before calling `submit_job()`.
 
+`hpc_forecast_scheduler.HPCForecastScheduler` fits an ARIMA model to past
+carbon-intensity and price traces for a single cluster and sleeps until the
+predicted lowest-score slot.  Building on that,
+`hpc_multi_scheduler.MultiClusterScheduler` compares those forecasts across
+multiple clusters.  Its `submit_best()` helper returns the chosen cluster and job
+ID, waiting for the optimal delay if necessary.  See the
+`scripts/hpc_multi_schedule.py` CLI for a minimal example that prints which
+cluster was selected.
+
 
 
 

--- a/scripts/hpc_multi_schedule.py
+++ b/scripts/hpc_multi_schedule.py
@@ -1,0 +1,25 @@
+"""Submit a job to the best HPC cluster based on forecasted cost and carbon."""
+
+from __future__ import annotations
+
+import argparse
+from asi.hpc_forecast_scheduler import HPCForecastScheduler
+from asi.hpc_multi_scheduler import MultiClusterScheduler
+
+
+def main() -> None:  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser(description="Multi-cluster scheduling demo")
+    parser.add_argument("command", nargs='+', help="Command to submit")
+    args = parser.parse_args()
+
+    clusters = {
+        "east": HPCForecastScheduler(),
+        "west": HPCForecastScheduler(backend="k8s"),
+    }
+    sched = MultiClusterScheduler(clusters)
+    cluster, job_id = sched.submit_best(args.command)
+    print(f"{cluster} -> {job_id}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/src/hpc_multi_scheduler.py
+++ b/src/hpc_multi_scheduler.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Select the best HPC cluster based on forecasted cost and carbon intensity."""
+
+from dataclasses import dataclass, field
+import time
+from typing import Dict, List, Union, Tuple
+
+from .hpc_forecast_scheduler import arima_forecast, HPCForecastScheduler
+from .hpc_scheduler import submit_job
+
+
+@dataclass
+class MultiClusterScheduler:
+    """Compare forecasts from multiple clusters and submit to the best one."""
+
+    clusters: Dict[str, HPCForecastScheduler] = field(default_factory=dict)
+
+    # --------------------------------------------------
+    def submit_best(
+        self, command: Union[str, List[str]], max_delay: float = 21600.0
+    ) -> Tuple[str, str]:
+        """Return chosen cluster name and job id after submission."""
+
+        best_cluster = None
+        best_backend = None
+        best_score = float("inf")
+        best_delay = 0.0
+
+        for name, sched in self.clusters.items():
+            steps = max(int(max_delay // 3600) + 1, 1)
+            carbon_pred = arima_forecast(sched.carbon_history, steps=steps)
+            cost_pred = arima_forecast(sched.cost_history, steps=steps)
+            n = min(len(carbon_pred), len(cost_pred))
+            if not n:
+                continue
+            scores = [
+                sched.carbon_weight * carbon_pred[i]
+                + sched.cost_weight * cost_pred[i]
+                for i in range(n)
+            ]
+            idx = int(min(range(n), key=lambda i: scores[i]))
+            if scores[idx] < best_score:
+                best_score = scores[idx]
+                best_delay = idx * 3600.0
+                best_cluster = name
+                best_backend = sched.backend
+
+        if best_cluster is None:
+            raise ValueError("No forecasts available to choose a cluster")
+        if best_delay and best_delay <= max_delay:
+            time.sleep(best_delay)
+        job_id = submit_job(command, backend=best_backend)
+        return best_cluster, job_id
+
+
+__all__ = ["MultiClusterScheduler"]

--- a/tests/test_hpc_multi_scheduler.py
+++ b/tests/test_hpc_multi_scheduler.py
@@ -1,0 +1,59 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+from unittest.mock import patch
+import unittest
+
+psutil_stub = types.SimpleNamespace(
+    cpu_percent=lambda interval=None: 0.0,
+    virtual_memory=lambda: types.SimpleNamespace(percent=0.0),
+    net_io_counters=lambda: types.SimpleNamespace(bytes_sent=0, bytes_recv=0),
+)
+pynvml_stub = types.SimpleNamespace(
+    nvmlInit=lambda: None,
+    nvmlDeviceGetCount=lambda: 0,
+    nvmlDeviceGetHandleByIndex=lambda i: i,
+    nvmlDeviceGetPowerUsage=lambda h: 0,
+)
+sys.modules['psutil'] = psutil_stub
+sys.modules['pynvml'] = pynvml_stub
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+pkg.__path__ = ['src']
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+hpc_mod = _load('asi.hpc_scheduler', 'src/hpc_scheduler.py')
+forecast_mod = _load('asi.hpc_forecast_scheduler', 'src/hpc_forecast_scheduler.py')
+mod = _load('asi.hpc_multi_scheduler', 'src/hpc_multi_scheduler.py')
+HPCForecastScheduler = forecast_mod.HPCForecastScheduler
+MultiClusterScheduler = mod.MultiClusterScheduler
+
+
+class TestMultiClusterScheduler(unittest.TestCase):
+    def test_submit_best(self):
+        a = HPCForecastScheduler()
+        b = HPCForecastScheduler(backend='k8s')
+        sched = MultiClusterScheduler({'a': a, 'b': b})
+        with patch('asi.hpc_multi_scheduler.arima_forecast', side_effect=[[10, 1], [1.0, 0.2], [5, 0.5], [0.5, 0.1]]), \
+             patch('time.sleep') as sl, \
+             patch('asi.hpc_multi_scheduler.submit_job', return_value='jid') as sj:
+            cluster, jid = sched.submit_best(['run.sh'], max_delay=7200.0)
+            sl.assert_called_with(3600.0)
+            sj.assert_called_with(['run.sh'], backend='k8s')
+            self.assertEqual(cluster, 'b')
+            self.assertEqual(jid, 'jid')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `MultiClusterScheduler` to pick the best cluster
- add CLI `hpc_multi_schedule.py`
- test multi-cluster scheduler logic
- document forecast and multi-cluster scheduling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686b01064640833193a07deea4600474