### PR TITLE
Implement P2P dataset exchange

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,5 +8,6 @@ Thank you for improving the ASI prototype. To get started:
 4. Run tests with `pytest` before submitting a pull request.
 5. Run `python scripts/security_scan.py` to check dependencies and source code for vulnerabilities.
 6. Generate module docs with `python -m asi.doc_summarizer <module>` whenever you add new modules.
+7. Use `scripts/p2p_exchange.py` to push, seed or pull datasets when collaborating across nodes.
 
 You can run `scripts/setup_test_env.sh` to automate steps 2 and 3.

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -453,6 +453,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 75. **Dataset summarization**: `scripts/dataset_summary.py --content` clusters text samples with `dataset_summarizer.summarize_dataset()` and writes the result to `docs/datasets/`.
 
 75a. **Secure dataset exchange**: `SecureDatasetExchange` encrypts datasets and verifies signatures so collaborators can share data without exposing proprietary content. Use `scripts/secure_dataset_exchange.py` to push and pull archives between nodes.
+75b. **P2P dataset exchange**: `P2PDatasetExchange` breaks encrypted archives into chunks stored in a DHT. Metadata is signed via `BlockchainProvenanceLedger`. Run `scripts/p2p_exchange.py push|pull` to sync datasets or `seed` to serve chunks.
 76. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps to aid debugging.
 76. **Self-reflection history**: `self_reflect()` summarises reasoning graphs and `ReasoningHistoryLogger` stores each summary with timestamps to aid debugging. When initialised with a `CrossLingualTranslator` the logger records translated summaries for multilingual inspection.
 

--- a/scripts/p2p_exchange.py
+++ b/scripts/p2p_exchange.py
@@ -1,0 +1,74 @@
+import argparse
+from pathlib import Path
+from asi.p2p_dataset_exchange import P2PDatasetExchange, FileDHT
+
+
+def _load_key(hex_str: str | None) -> bytes | None:
+    return bytes.fromhex(hex_str) if hex_str else None
+
+
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(description="P2P dataset exchange")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    push = sub.add_parser("push", help="Encrypt and share a dataset")
+    push.add_argument("root", help="Exchange root directory")
+    push.add_argument("dataset_id", help="Dataset identifier")
+    push.add_argument("directory", help="Dataset directory")
+    push.add_argument("--key", required=True, help="AES key in hex")
+    push.add_argument("--sign-key", help="Ed25519 private key in hex")
+    push.add_argument("--chunk-size", type=int, default=1_048_576)
+
+    seed = sub.add_parser("seed", help="Run a simple DHT server")
+    seed.add_argument("root", help="Exchange root directory")
+    seed.add_argument("--port", type=int, default=8765)
+
+    pull = sub.add_parser("pull", help="Retrieve and decrypt a dataset")
+    pull.add_argument("root", help="Exchange root directory")
+    pull.add_argument("dataset_id", help="Dataset identifier")
+    pull.add_argument("directory", help="Destination directory")
+    pull.add_argument("--key", required=True, help="AES key in hex")
+    pull.add_argument("--verify-key", help="Ed25519 public key in hex")
+
+    args = p.parse_args(argv)
+    dht = FileDHT(Path(args.root) / "dht")
+
+    if args.cmd == "push":
+        ex = P2PDatasetExchange(
+            args.root,
+            dht,
+            bytes.fromhex(args.key),
+            signing_key=_load_key(args.sign_key),
+        )
+        ex.push(Path(args.directory), args.dataset_id, chunk_size=args.chunk_size)
+    elif args.cmd == "pull":
+        ex = P2PDatasetExchange(
+            args.root,
+            dht,
+            bytes.fromhex(args.key),
+            verify_key=_load_key(args.verify_key),
+        )
+        ex.pull(args.dataset_id, Path(args.directory))
+    else:  # seed
+        from aiohttp import web
+
+        async def handle_get(request: web.Request) -> web.Response:
+            key = request.match_info["key"]
+            data = dht.get(key)
+            if data is None:
+                raise web.HTTPNotFound()
+            return web.Response(body=data)
+
+        async def handle_put(request: web.Request) -> web.Response:
+            key = request.match_info["key"]
+            data = await request.read()
+            dht.put(key, data)
+            return web.Response(text="OK")
+
+        app = web.Application()
+        app.add_routes([web.get("/{key}", handle_get), web.put("/{key}", handle_put)])
+        web.run_app(app, port=args.port)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -37,6 +37,7 @@ from .iter_align import IterativeAligner
 from .critic_rlhf import CriticScorer, CriticRLHFTrainer
 from .chunkwise_retrainer import ChunkWiseRetrainer
 from .secure_dataset_exchange import SecureDatasetExchange
+from .p2p_dataset_exchange import P2PDatasetExchange
 from .self_healing_trainer import SelfHealingTrainer
 from .scaling_law import BreakpointScalingLaw
 from .link_slot_attention import LinkSlotAttention

--- a/src/p2p_dataset_exchange.py
+++ b/src/p2p_dataset_exchange.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import io
+import os
+import json
+import tarfile
+import hashlib
+from pathlib import Path
+from typing import Iterable, List, Dict
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.exceptions import InvalidSignature
+
+from .blockchain_provenance_ledger import BlockchainProvenanceLedger
+
+
+class InMemoryDHT:
+    """Very small DHT implementation backed by a dictionary."""
+
+    def __init__(self) -> None:
+        self.store: Dict[str, bytes] = {}
+
+    def put(self, key: str, value: bytes) -> None:
+        self.store[key] = value
+
+    def get(self, key: str) -> bytes | None:
+        return self.store.get(key)
+
+
+class FileDHT:
+    """Store DHT keys as files under a directory."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def put(self, key: str, value: bytes) -> None:
+        with open(self.root / key, "wb") as fh:
+            fh.write(value)
+
+    def get(self, key: str) -> bytes | None:
+        p = self.root / key
+        return p.read_bytes() if p.exists() else None
+
+
+class P2PDatasetExchange:
+    """Share encrypted dataset chunks via a simple DHT."""
+
+    def __init__(
+        self,
+        root: str | Path,
+        dht: InMemoryDHT | FileDHT,
+        key: bytes,
+        *,
+        signing_key: bytes | None = None,
+        verify_key: bytes | None = None,
+    ) -> None:
+        if len(key) not in (16, 24, 32):
+            raise ValueError("key must be 16, 24, or 32 bytes")
+        self.root = Path(root)
+        self.dht = dht
+        self.key = key
+        self.signing_key = signing_key
+        self.verify_key = verify_key
+        self.ledger = BlockchainProvenanceLedger(self.root)
+        self.meta_path = self.root / "dataset_metadata.json"
+        if self.meta_path.exists():
+            self.metadata: List[Dict[str, object]] = json.loads(self.meta_path.read_text())
+        else:
+            self.metadata = []
+
+    # ------------------------------------------------------------------
+    def _encrypt(self, data: bytes) -> bytes:
+        aes = AESGCM(self.key)
+        nonce = os.urandom(12)
+        enc = aes.encrypt(nonce, data, None)
+        return nonce + enc
+
+    def _decrypt(self, blob: bytes) -> bytes:
+        aes = AESGCM(self.key)
+        nonce, enc = blob[:12], blob[12:]
+        return aes.decrypt(nonce, enc, None)
+
+    def _sign(self, data: bytes) -> bytes:
+        if self.signing_key is None:
+            raise ValueError("signing key required")
+        priv = ed25519.Ed25519PrivateKey.from_private_bytes(self.signing_key)
+        return priv.sign(data)
+
+    def _verify(self, data: bytes, sig: bytes) -> None:
+        if self.verify_key is None:
+            raise ValueError("verify key required")
+        pub = ed25519.Ed25519PublicKey.from_public_bytes(self.verify_key)
+        try:
+            pub.verify(sig, data)
+        except InvalidSignature as e:
+            raise ValueError("invalid signature") from e
+
+    # ------------------------------------------------------------------
+    def push(self, directory: str | Path, dataset_id: str, *, chunk_size: int = 1_048_576) -> None:
+        """Encrypt ``directory`` and store it in the DHT as chunks."""
+        root = Path(directory)
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for p in root.rglob("*"):
+                tar.add(p, arcname=str(p.relative_to(root)))
+        enc = self._encrypt(buf.getvalue())
+
+        chunks: List[str] = []
+        for i in range(0, len(enc), chunk_size):
+            part = enc[i : i + chunk_size]
+            h = hashlib.sha256(part).hexdigest()
+            self.dht.put(h, part)
+            chunks.append(h)
+
+        meta = {"id": dataset_id, "chunks": chunks}
+        meta_str = json.dumps(meta, sort_keys=True)
+        self.metadata.append(meta)
+        self.meta_path.write_text(json.dumps(self.metadata, indent=2))
+        sig_hex = None
+        if self.signing_key is not None:
+            sig_hex = self._sign(meta_str.encode()).hex()
+        self.ledger.append(meta_str, signature=sig_hex)
+        self.dht.put(f"{dataset_id}:meta", meta_str.encode())
+
+    def seed(self) -> None:  # pragma: no cover - optional server
+        """Placeholder for starting a network seed."""
+        pass
+
+    def pull(self, dataset_id: str, dest_dir: str | Path) -> None:
+        """Retrieve ``dataset_id`` from the DHT and extract to ``dest_dir``."""
+        if self.meta_path.exists():
+            self.metadata = json.loads(self.meta_path.read_text())
+        records = [json.dumps(m, sort_keys=True) for m in self.metadata]
+        if not self.ledger.verify(records):
+            raise ValueError("ledger verification failed")
+        idx = next((i for i, m in enumerate(self.metadata) if m["id"] == dataset_id), None)
+        if idx is None:
+            raise ValueError("dataset not found")
+        meta = self.metadata[idx]
+        entry = self.ledger.entries[idx]
+        sig_hex = entry.get("sig")
+        if sig_hex and self.verify_key is not None:
+            self._verify(records[idx].encode(), bytes.fromhex(sig_hex))
+
+        parts = bytearray()
+        for h in meta["chunks"]:
+            chunk = self.dht.get(h)
+            if chunk is None:
+                raise ValueError(f"missing chunk {h}")
+            if hashlib.sha256(chunk).hexdigest() != h:
+                raise ValueError("chunk hash mismatch")
+            parts.extend(chunk)
+        data = self._decrypt(bytes(parts))
+        buf = io.BytesIO(data)
+        dest = Path(dest_dir)
+        with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+            tar.extractall(dest)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def generate_key() -> bytes:
+        return AESGCM.generate_key(bit_length=128)
+
+    @staticmethod
+    def generate_signing_key() -> tuple[bytes, bytes]:
+        priv = ed25519.Ed25519PrivateKey.generate()
+        pub = priv.public_key()
+        return (
+            priv.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption()),
+            pub.public_bytes(Encoding.Raw, PublicFormat.Raw),
+        )
+
+
+__all__ = ["P2PDatasetExchange", "InMemoryDHT", "FileDHT"]

--- a/tests/test_p2p_dataset_exchange.py
+++ b/tests/test_p2p_dataset_exchange.py
@@ -1,0 +1,89 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import tempfile
+import json
+from pathlib import Path
+
+pkg = types.ModuleType("src")
+pkg.__path__ = ["src"]
+pkg.__spec__ = importlib.machinery.ModuleSpec("src", None, is_package=True)
+sys.modules["src"] = pkg
+
+loader = importlib.machinery.SourceFileLoader(
+    "src.p2p_dataset_exchange", "src/p2p_dataset_exchange.py"
+)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+mod.__package__ = "src"
+sys.modules[loader.name] = mod
+loader.exec_module(mod)
+P2PDatasetExchange = mod.P2PDatasetExchange
+InMemoryDHT = mod.InMemoryDHT
+
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PrivateFormat,
+    PublicFormat,
+    NoEncryption,
+)
+
+
+class TestP2PDatasetExchange(unittest.TestCase):
+    def test_chunk_transfer_and_verify(self):
+        priv = ed25519.Ed25519PrivateKey.generate()
+        pub = priv.public_key()
+        priv_b = priv.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+        pub_b = pub.public_bytes(Encoding.Raw, PublicFormat.Raw)
+        key = P2PDatasetExchange.generate_key()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "root"
+            root.mkdir()
+            dht = InMemoryDHT()
+            src = Path(tmp) / "src"
+            src.mkdir()
+            (src / "a.txt").write_text("hello")
+
+            ex_push = P2PDatasetExchange(root, dht, key, signing_key=priv_b)
+            ex_push.push(src, "ds", chunk_size=32)
+
+            dst = Path(tmp) / "dst"
+            ex_pull = P2PDatasetExchange(root, dht, key, verify_key=pub_b)
+            ex_pull.pull("ds", dst)
+
+            self.assertEqual((dst / "a.txt").read_text(), "hello")
+
+    def test_detect_tampered_chunk(self):
+        priv = ed25519.Ed25519PrivateKey.generate()
+        pub = priv.public_key()
+        priv_b = priv.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+        pub_b = pub.public_bytes(Encoding.Raw, PublicFormat.Raw)
+        key = P2PDatasetExchange.generate_key()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "root"
+            root.mkdir()
+            dht = InMemoryDHT()
+            src = Path(tmp) / "src"
+            src.mkdir()
+            (src / "b.txt").write_text("data")
+
+            ex_push = P2PDatasetExchange(root, dht, key, signing_key=priv_b)
+            ex_push.push(src, "ds2", chunk_size=16)
+
+            meta = json.loads((root / "dataset_metadata.json").read_text())[0]
+            bad_hash = meta["chunks"][0]
+            dht.store[bad_hash] = b"bad" + dht.store[bad_hash][3:]
+
+            dst = Path(tmp) / "dst"
+            ex_pull = P2PDatasetExchange(root, dht, key, verify_key=pub_b)
+            with self.assertRaises(ValueError):
+                ex_pull.pull("ds2", dst)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `P2PDatasetExchange` module for sharing encrypted dataset chunks via a simple DHT
- sign dataset metadata with `BlockchainProvenanceLedger`
- provide CLI `scripts/p2p_exchange.py`
- test chunk verification and tamper detection
- document usage in CONTRIBUTING guide and Plan

## Testing
- `pytest tests/test_p2p_dataset_exchange.py -q`
- `pip install cryptography -q` (pre-install dependency)


------
https://chatgpt.com/codex/tasks/task_e_686b0110ba388331ae6119f28bc043a9