### PR TITLE
Add BCI integration to fusion model

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -538,6 +538,9 @@ Run `scripts/lineage_viewer.py ./data` to browse the recorded steps.
   retrieve averaged multimodal embeddings via `add_multimodal`. **Implemented**:
   `encode_all()` now calls `memory.add_multimodal()` when a memory instance is
   passed, enabling lookup on the fused embedding.
+- BCI embeddings can now be fused and stored the same way. `CrossModalFusion`
+  encodes EEG/ECoG signals and `HierarchicalMemory.add_multimodal()` averages
+  them with text, image and audio vectors for world-model training.
 - Add a `log_memory_usage()` helper to `eval_harness.py` and print GPU memory usage alongside accuracy metrics. **Implemented**
 - Integrate `QAEHyperparamSearch` into `MetaRLRefactorAgent` to tune the exploration rate during refactoring. **Implemented**
 - Rewrite `download_triples()` with asyncio to fetch dataset files

--- a/src/bci_dataset.py
+++ b/src/bci_dataset.py
@@ -1,0 +1,32 @@
+from typing import Iterable
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+class BCIDataset(Dataset):
+    """Simple dataset for BCI recordings."""
+
+    def __init__(self, recordings: Iterable[np.ndarray], normalize: bool = True) -> None:
+        self.data = []
+        for rec in recordings:
+            arr = torch.tensor(rec, dtype=torch.float32)
+            if normalize:
+                arr = (arr - arr.mean()) / (arr.std() + 1e-6)
+            self.data.append(arr)
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        return self.data[idx]
+
+
+def load_synthetic_bci(num_samples: int = 4, channels: int = 2, length: int = 32) -> BCIDataset:
+    """Return a :class:`BCIDataset` with random signals."""
+    rng = np.random.default_rng(0)
+    recs = [rng.standard_normal((channels, length)).astype("float32") for _ in range(num_samples)]
+    return BCIDataset(recs)
+
+
+__all__ = ["BCIDataset", "load_synthetic_bci"]

--- a/src/bci_decoder.py
+++ b/src/bci_decoder.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import mne  # type: ignore
+    _HAS_MNE = True
+except Exception:  # pragma: no cover - during tests
+    _HAS_MNE = False
+
+
+def load_bci(path: str) -> np.ndarray:
+    """Return EEG/ECoG signal data loaded via ``mne``."""
+    if not _HAS_MNE:
+        raise ImportError("mne not available")
+    raw = mne.io.read_raw(path, preload=True)
+    return raw.get_data().astype("float32")
+
+
+__all__ = ["load_bci", "_HAS_MNE"]

--- a/src/cross_modal_analogy.py
+++ b/src/cross_modal_analogy.py
@@ -28,10 +28,15 @@ def cross_modal_analogy_search(
     offset ``b - a`` and query ``query + offset``.
     """
 
-    t_vecs, i_vecs, a_vecs = encode_all(
+    out = encode_all(
         model, dataset, batch_size=batch_size, memory=memory, **kwargs
     )
-    fused = (t_vecs + i_vecs + a_vecs) / 3.0
+    if len(out) == 4:
+        t_vecs, i_vecs, a_vecs, b_vecs = out
+        fused = (t_vecs + i_vecs + a_vecs + b_vecs) / 4.0
+    else:
+        t_vecs, i_vecs, a_vecs = out  # type: ignore[misc]
+        fused = (t_vecs + i_vecs + a_vecs) / 3.0
 
     offset = analogy_offset(fused[a_index], fused[b_index])
     return memory.search(fused[query_index], k=k, mode="analogy", offset=offset)

--- a/src/eval_harness.py
+++ b/src/eval_harness.py
@@ -215,8 +215,11 @@ class MultiModalEval:
             compressed_dim=max(1, self.model.cfg.latent_dim // 2),
             capacity=len(self.dataset) * 2,
         )
-        t_vecs, i_vecs, a_vecs = encode_all(
-            self.model, self.dataset, batch_size=self.batch_size, memory=mem
+        t_vecs, i_vecs, a_vecs, _ = encode_all(
+            self.model,
+            self.dataset,
+            batch_size=self.batch_size,
+            memory=mem,
         )
         recalls: Dict[str, float] = {}
         for name, vecs in {

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -349,10 +349,14 @@ class HierarchicalMemory:
         text: torch.Tensor,
         images: torch.Tensor,
         audio: torch.Tensor,
+        bci: torch.Tensor | None = None,
         metadata: Iterable[Any] | None = None,
     ) -> None:
         """Store averaged multimodal embeddings."""
-        vecs = (text + images + audio) / 3.0
+        vecs_list = [text, images, audio]
+        if bci is not None and bci.numel():
+            vecs_list.append(bci)
+        vecs = sum(vecs_list) / len(vecs_list)
         self.add(vecs, metadata)
 
     def _evict_if_needed(self) -> None:
@@ -434,10 +438,14 @@ class HierarchicalMemory:
         text: torch.Tensor,
         images: torch.Tensor,
         audio: torch.Tensor,
+        bci: torch.Tensor | None = None,
         metadata: Iterable[Any] | None = None,
     ) -> None:
         """Asynchronously store averaged multimodal embeddings."""
-        vecs = (text + images + audio) / 3.0
+        vecs_list = [text, images, audio]
+        if bci is not None and bci.numel():
+            vecs_list.append(bci)
+        vecs = sum(vecs_list) / len(vecs_list)
         await self.aadd(vecs, metadata)
 
     async def adelete(self, index: int | Iterable[int] | None = None, tag: Any | None = None) -> None:

--- a/tests/test_bci_dataset.py
+++ b/tests/test_bci_dataset.py
@@ -1,0 +1,48 @@
+import importlib.machinery
+import importlib.util
+import sys
+import unittest
+import torch
+
+loader_ds = importlib.machinery.SourceFileLoader('bci_ds', 'src/bci_dataset.py')
+spec_ds = importlib.util.spec_from_loader(loader_ds.name, loader_ds)
+bci_ds = importlib.util.module_from_spec(spec_ds)
+loader_ds.exec_module(bci_ds)
+BCIDataset = bci_ds.BCIDataset
+load_synthetic_bci = bci_ds.load_synthetic_bci
+
+loader_cmf = importlib.machinery.SourceFileLoader('cmf', 'src/cross_modal_fusion.py')
+spec_cmf = importlib.util.spec_from_loader(loader_cmf.name, loader_cmf)
+cmf = importlib.util.module_from_spec(spec_cmf)
+loader_cmf.exec_module(cmf)
+CrossModalFusionConfig = cmf.CrossModalFusionConfig
+CrossModalFusion = cmf.CrossModalFusion
+MultiModalDataset = cmf.MultiModalDataset
+encode_all = cmf.encode_all
+
+from asi.hierarchical_memory import HierarchicalMemory
+
+
+def simple_tokenizer(text: str):
+    return [ord(c) % 50 for c in text]
+
+
+class TestBCIDataset(unittest.TestCase):
+    def test_synthetic_retrieval(self):
+        bci = load_synthetic_bci(num_samples=2, channels=2, length=32)
+        texts = ["x", "y"]
+        imgs = [torch.randn(3, 16, 16) for _ in texts]
+        auds = [torch.randn(1, 32) for _ in texts]
+        samples = [(texts[i], imgs[i], auds[i], bci[i]) for i in range(2)]
+        ds = MultiModalDataset(samples, simple_tokenizer, bci_shape=(2, 32))
+        cfg = CrossModalFusionConfig(vocab_size=50, text_dim=8, img_channels=3, audio_channels=1, bci_channels=2, latent_dim=4)
+        model = CrossModalFusion(cfg)
+        mem = HierarchicalMemory(dim=4, compressed_dim=2, capacity=10)
+        t, i, a, b = encode_all(model, ds, batch_size=1, memory=mem, include_bci=True)
+        q = (t[0] + i[0] + a[0] + b[0]) / 4.0
+        out, meta = mem.search(q, k=1)
+        self.assertEqual(meta[0], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support loading and normalizing EEG/ECoG recordings
- handle optional BCI signals in `CrossModalFusion`
- store fused BCI embeddings in `HierarchicalMemory`
- document BCI embedding storage
- test encoding and retrieval with synthetic BCI data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch.utils'; 'torch' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_686b011f1f148331a2273969b5a006db