### PR TITLE
Implement multi-modal summary memory

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -439,6 +439,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 49a. **Distributed anomaly monitoring**: `DistributedAnomalyMonitor` collects per-node anomaly metrics and flags cross-run spikes through `RiskDashboard`.
 50. **Parameter-efficient adaptation**: Explore low-rank fine-tuning across tasks; success is matching baseline accuracy with ≤10% extra parameters.
 51. **Context summarization memory**: Store compressed summaries for distant tokens and re-expand them on demand; success is >95% retrieval accuracy at 100× token length. *Implemented in `src/context_summary_memory.py` with tests.*
+51a. **Multi-modal summarization memory**: Compress image and audio features into short summaries stored with text embeddings; retrieval using fused summaries must reach ≥90% accuracy. *Implemented in `src/multimodal_summary_memory.py` with tests.*
 52. **Dataset lineage manager**: Automatically track dataset versions and transformations, enabling reproducible training pipelines. *Implemented in `src/dataset_lineage_manager.py`.*
     Use `DataProvenanceLedger` to append a signed hash of each lineage record. Run `scripts/check_provenance.py <root>` to verify the ledger.
 53. **Multi-stage oversight**: Combine constitutional AI, deliberative alignment, and critic-in-the-loop RLHF with formal verification; success is <1% harmful output on the existing benchmarks.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -198,6 +198,7 @@ from .cross_lingual_memory import CrossLingualMemory
 from .cross_lingual_kg_memory import CrossLingualKGMemory
 from .cross_lingual_graph import CrossLingualReasoningGraph
 from .context_summary_memory import ContextSummaryMemory
+from .multimodal_summary_memory import MultiModalSummaryMemory
 from .sensorimotor_pretrainer import (
     SensorimotorPretrainConfig,
     SensorimotorLogDataset,

--- a/src/multimodal_summary_memory.py
+++ b/src/multimodal_summary_memory.py
@@ -1,0 +1,61 @@
+"""Memory storing multi-modal summaries."""
+
+from __future__ import annotations
+
+from typing import Iterable, Any
+
+import torch
+
+from .hierarchical_memory import HierarchicalMemory
+from .cross_modal_fusion import encode_all, MultiModalDataset, CrossModalFusion
+
+
+class MultiModalSummaryMemory(HierarchicalMemory):
+    """HierarchicalMemory with compressed image and audio summaries."""
+
+    def __init__(
+        self,
+        *args: Any,
+        image_summarizer: Any,
+        audio_summarizer: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.image_summarizer = image_summarizer
+        self.audio_summarizer = audio_summarizer
+
+    def add_encoded(
+        self,
+        text: torch.Tensor,
+        images: torch.Tensor,
+        audio: torch.Tensor,
+        metadata: Iterable[Any] | None = None,
+    ) -> None:
+        metas = (
+            list(metadata)
+            if metadata is not None
+            else [self._next_id + i for i in range(text.size(0))]
+        )
+        self._next_id += text.size(0)
+        for idx, (t, i, a, m) in enumerate(zip(text, images, audio, metas)):
+            img_sum = self.image_summarizer.summarize(i.unsqueeze(0))
+            aud_sum = self.audio_summarizer.summarize(a.unsqueeze(0))
+            img_vec = self.image_summarizer.expand(img_sum)
+            aud_vec = self.audio_summarizer.expand(aud_sum)
+            fused = (t + img_vec + aud_vec) / 3.0
+            super().add(
+                fused.unsqueeze(0),
+                [{"id": m, "image_summary": img_sum, "audio_summary": aud_sum}],
+            )
+
+    def add_dataset(
+        self,
+        model: CrossModalFusion,
+        dataset: MultiModalDataset,
+        batch_size: int = 8,
+    ) -> None:
+        text, images, audio, _ = encode_all(model, dataset, batch_size=batch_size)
+        self.add_encoded(text, images, audio)
+
+
+__all__ = ["MultiModalSummaryMemory"]

--- a/tests/test_multimodal_summary_memory.py
+++ b/tests/test_multimodal_summary_memory.py
@@ -1,0 +1,88 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import unittest
+import torch
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+# load required modules
+loader_cmf = importlib.machinery.SourceFileLoader('cmf', 'src/cross_modal_fusion.py')
+spec_cmf = importlib.util.spec_from_loader(loader_cmf.name, loader_cmf)
+cmf = importlib.util.module_from_spec(spec_cmf)
+cmf.__package__ = 'asi'
+loader_cmf.exec_module(cmf)
+sys.modules['asi.cross_modal_fusion'] = cmf
+setattr(pkg, 'cross_modal_fusion', cmf)
+
+loader_hm = importlib.machinery.SourceFileLoader('hm', 'src/hierarchical_memory.py')
+spec_hm = importlib.util.spec_from_loader(loader_hm.name, loader_hm)
+hm = importlib.util.module_from_spec(spec_hm)
+hm.__package__ = 'asi'
+loader_hm.exec_module(hm)
+sys.modules['asi.hierarchical_memory'] = hm
+setattr(pkg, 'hierarchical_memory', hm)
+
+loader_mm = importlib.machinery.SourceFileLoader('mm', 'src/multimodal_summary_memory.py')
+spec_mm = importlib.util.spec_from_loader(loader_mm.name, loader_mm)
+mm = importlib.util.module_from_spec(spec_mm)
+mm.__package__ = 'asi'
+loader_mm.exec_module(mm)
+sys.modules['asi.multimodal_summary_memory'] = mm
+setattr(pkg, 'multimodal_summary_memory', mm)
+
+CrossModalFusionConfig = cmf.CrossModalFusionConfig
+CrossModalFusion = cmf.CrossModalFusion
+MultiModalDataset = cmf.MultiModalDataset
+encode_all = cmf.encode_all
+MultiModalSummaryMemory = mm.MultiModalSummaryMemory
+
+
+def tok(t: str):
+    return [ord(c) % 50 for c in t]
+
+
+class DummySummarizer:
+    def summarize(self, x):
+        return 'sum'
+
+    def expand(self, text):
+        return torch.ones(4)
+
+
+class TestMultiModalSummaryMemory(unittest.TestCase):
+    def test_retrieval_accuracy(self):
+        cfg = CrossModalFusionConfig(
+            vocab_size=50,
+            text_dim=8,
+            img_channels=3,
+            audio_channels=1,
+            latent_dim=4,
+        )
+        model = CrossModalFusion(cfg)
+        triples = [
+            ("foo", torch.randn(3, 16, 16), torch.randn(1, 32)),
+            ("bar", torch.randn(3, 16, 16), torch.randn(1, 32)),
+        ]
+        ds = MultiModalDataset(triples, tok)
+        mem = MultiModalSummaryMemory(
+            dim=4,
+            compressed_dim=2,
+            capacity=10,
+            image_summarizer=DummySummarizer(),
+            audio_summarizer=DummySummarizer(),
+        )
+        mem.add_dataset(model, ds, batch_size=1)
+        t_vecs, i_vecs, a_vecs, _ = encode_all(model, ds, batch_size=1)
+        img_v = mem.image_summarizer.expand('sum')
+        aud_v = mem.audio_summarizer.expand('sum')
+        for idx in range(len(ds)):
+            q = (t_vecs[idx] + img_v + aud_v) / 3.0
+            out, meta = mem.search(q, k=1)
+            self.assertEqual(meta[0]['id'], idx)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `MultiModalSummaryMemory` for storing image and audio summaries with text
- export class through `asi` package
- document multi-modal summarization memory in **Plan.md**
- test retrieval accuracy with fused summaries
- refine code formatting

## Testing
- `flake8 src/multimodal_summary_memory.py tests/test_multimodal_summary_memory.py`
- `pytest tests/test_multimodal_summary_memory.py -q` *(fails: libtorch_global_deps.so missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b331b25708331a9d4f33652f75cb4