### PR TITLE
Add persistent Q-learning to AdaptiveCostScheduler

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -619,6 +619,14 @@ ID, waiting for the optimal delay if necessary.  See the
 `scripts/hpc_multi_schedule.py` CLI for a minimal example that prints which
 cluster was selected.
 
+`adaptive_cost_scheduler.AdaptiveCostScheduler` builds on this multi-cluster
+approach by training a simple Q-learning policy from the stored carbon and price
+histories.  The policy decides whether to wait for a cheaper, greener slot or
+submit immediately.  Tune `bins`, `epsilon`, `alpha`, `gamma` and
+`check_interval` to control exploration and learning rate.  A demonstration is
+available via `scripts/adaptive_cost_schedule.py`.  Set `qtable_path` to persist
+the learned Q-table between runs.
+
 
 
 

--- a/scripts/adaptive_cost_schedule.py
+++ b/scripts/adaptive_cost_schedule.py
@@ -1,0 +1,40 @@
+"""Experiment with AdaptiveCostScheduler for multiple clusters."""
+
+from __future__ import annotations
+
+import argparse
+from asi.hpc_forecast_scheduler import HPCForecastScheduler
+from asi.adaptive_cost_scheduler import AdaptiveCostScheduler
+
+
+def main() -> None:  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser(description="Adaptive cost scheduling demo")
+    parser.add_argument("command", nargs='+', help="Command to submit")
+    parser.add_argument("--qtable", type=str, help="Path to Q-table")
+    parser.add_argument("--bins", type=int, default=10, help="Number of score buckets")
+    parser.add_argument("--epsilon", type=float, default=0.1, help="Exploration rate")
+    parser.add_argument("--alpha", type=float, default=0.5, help="Learning rate")
+    parser.add_argument("--gamma", type=float, default=0.9, help="Discount factor")
+    parser.add_argument("--check-interval", type=float, default=60.0,
+                        help="Delay between checks when waiting")
+    args = parser.parse_args()
+
+    clusters = {
+        "east": HPCForecastScheduler(),
+        "west": HPCForecastScheduler(backend="k8s"),
+    }
+    sched = AdaptiveCostScheduler(
+        clusters,
+        bins=args.bins,
+        epsilon=args.epsilon,
+        alpha=args.alpha,
+        gamma=args.gamma,
+        check_interval=args.check_interval,
+        qtable_path=args.qtable,
+    )
+    cluster, job_id = sched.submit_best(args.command)
+    print(f"{cluster} -> {job_id}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/src/adaptive_cost_scheduler.py
+++ b/src/adaptive_cost_scheduler.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+"""Adaptive scheduler that learns from carbon and price histories."""
+
+from dataclasses import dataclass, field
+import json
+import os
+import random
+import time
+from typing import Dict, List, Optional, Union, Tuple
+
+from .hpc_multi_scheduler import MultiClusterScheduler, arima_forecast, submit_job
+
+
+@dataclass
+class AdaptiveCostScheduler(MultiClusterScheduler):
+    """Learn when to submit jobs using a simple Q-learning policy."""
+
+    bins: int = 10
+    epsilon: float = 0.1
+    alpha: float = 0.5
+    gamma: float = 0.9
+    check_interval: float = 60.0
+    qtable_path: Optional[str] = None
+    q: Dict[Tuple[int, int], float] = field(default_factory=dict, init=False)
+    min_score: float = field(default=0.0, init=False)
+    max_score: float = field(default=1.0, init=False)
+
+    def __post_init__(self) -> None:
+        if self.qtable_path and os.path.exists(self.qtable_path):
+            with open(self.qtable_path) as fh:
+                data = json.load(fh)
+                self.q = {
+                    (int(k.split(',')[0]), int(k.split(',')[1])): float(v)
+                    for k, v in data.items()
+                }
+        scores = []
+        for sched in self.clusters.values():
+            for c, p in zip(sched.carbon_history, sched.cost_history):
+                scores.append(sched.carbon_weight * c + sched.cost_weight * p)
+        if scores:
+            self.min_score = min(scores)
+            self.max_score = max(scores)
+            if not self.q:
+                self._train(10)
+
+    # --------------------------------------------------
+    def _bucket(self, score: float) -> int:
+        if self.max_score == self.min_score:
+            return 0
+        ratio = (score - self.min_score) / (self.max_score - self.min_score)
+        return max(0, min(self.bins - 1, int(ratio * (self.bins - 1))))
+
+    # --------------------------------------------------
+    def _train(self, cycles: int = 1) -> None:
+        hist: List[float] = []
+        for sched in self.clusters.values():
+            for c, p in zip(sched.carbon_history, sched.cost_history):
+                hist.append(sched.carbon_weight * c + sched.cost_weight * p)
+        for _ in range(cycles):
+            for idx in range(len(hist) - 1):
+                s = self._bucket(hist[idx])
+                sp = self._bucket(hist[idx + 1])
+                for action, reward in ((0, -hist[idx]), (1, -0.1)):
+                    cur = self.q.get((s, action), 0.0)
+                    next_max = max(self.q.get((sp, a), 0.0) for a in (0, 1))
+                    target = reward + self.gamma * next_max
+                    self.q[(s, action)] = cur + self.alpha * (target - cur)
+        self._save()
+
+    # --------------------------------------------------
+    def _save(self) -> None:
+        if self.qtable_path:
+            os.makedirs(os.path.dirname(self.qtable_path) or ".", exist_ok=True)
+            data = {f"{s},{a}": v for (s, a), v in self.q.items()}
+            with open(self.qtable_path, "w") as fh:
+                json.dump(data, fh)
+
+    # --------------------------------------------------
+    def _policy(self, score: float) -> int:
+        s = self._bucket(score)
+        if random.random() < self.epsilon:
+            return random.randint(0, 1)
+        run_q = self.q.get((s, 0), 0.0)
+        wait_q = self.q.get((s, 1), 0.0)
+        return 0 if run_q >= wait_q else 1
+
+    # --------------------------------------------------
+    def submit_best(
+        self, command: Union[str, List[str]], max_delay: float = 21600.0
+    ) -> Tuple[str, str]:
+        # refresh policy with the latest history
+        self._train(1)
+        while True:
+            best_cluster = None
+            best_backend = None
+            best_score = float("inf")
+            best_delay = 0.0
+
+            for name, sched in self.clusters.items():
+                steps = max(int(max_delay // 3600) + 1, 1)
+                carbon_pred = arima_forecast(sched.carbon_history, steps=steps)
+                cost_pred = arima_forecast(sched.cost_history, steps=steps)
+                n = min(len(carbon_pred), len(cost_pred))
+                if not n:
+                    continue
+                scores = [
+                    sched.carbon_weight * carbon_pred[i]
+                    + sched.cost_weight * cost_pred[i]
+                    for i in range(n)
+                ]
+                idx = int(min(range(n), key=lambda i: scores[i]))
+                if scores[idx] < best_score:
+                    best_score = scores[idx]
+                    best_delay = idx * 3600.0
+                    best_cluster = name
+                    best_backend = sched.backend
+
+            if best_cluster is None:
+                raise ValueError("No forecasts available to choose a cluster")
+
+            action = self._policy(best_score)
+            if action == 0 or best_delay > max_delay:
+                if best_delay and best_delay <= max_delay:
+                    time.sleep(best_delay)
+                job_id = submit_job(command, backend=best_backend)
+                return best_cluster, job_id
+            time.sleep(self.check_interval)
+
+
+__all__ = ["AdaptiveCostScheduler"]

--- a/tests/test_adaptive_cost_scheduler.py
+++ b/tests/test_adaptive_cost_scheduler.py
@@ -1,0 +1,74 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import os
+import tempfile
+from unittest.mock import patch
+import unittest
+
+psutil_stub = types.SimpleNamespace(
+    cpu_percent=lambda interval=None: 0.0,
+    virtual_memory=lambda: types.SimpleNamespace(percent=0.0),
+    net_io_counters=lambda: types.SimpleNamespace(bytes_sent=0, bytes_recv=0),
+)
+pynvml_stub = types.SimpleNamespace(
+    nvmlInit=lambda: None,
+    nvmlDeviceGetCount=lambda: 0,
+    nvmlDeviceGetHandleByIndex=lambda i: i,
+    nvmlDeviceGetPowerUsage=lambda h: 0,
+)
+sys.modules['psutil'] = psutil_stub
+sys.modules['pynvml'] = pynvml_stub
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+pkg.__path__ = ['src']
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+hfc = _load('asi.hpc_forecast_scheduler', 'src/hpc_forecast_scheduler.py')
+multi = _load('asi.hpc_multi_scheduler', 'src/hpc_multi_scheduler.py')
+mod = _load('asi.adaptive_cost_scheduler', 'src/adaptive_cost_scheduler.py')
+AdaptiveCostScheduler = mod.AdaptiveCostScheduler
+HPCForecastScheduler = hfc.HPCForecastScheduler
+
+
+class TestAdaptiveCostScheduler(unittest.TestCase):
+    def test_submit_best(self):
+        a = HPCForecastScheduler()
+        b = HPCForecastScheduler(backend='k8s')
+        sched = AdaptiveCostScheduler({'a': a, 'b': b})
+        with patch('asi.adaptive_cost_scheduler.arima_forecast', side_effect=[[10, 1], [1.0, 0.2], [5, 0.5], [0.5, 0.1]]), \
+             patch.object(sched, '_policy', return_value=0) as pol, \
+             patch('time.sleep') as sl, \
+             patch('asi.adaptive_cost_scheduler.submit_job', return_value='jid') as sj:
+            cluster, jid = sched.submit_best(['run.sh'], max_delay=7200.0)
+            sl.assert_called_with(3600.0)
+            sj.assert_called_with(['run.sh'], backend='k8s')
+            self.assertEqual(cluster, 'b')
+            self.assertEqual(jid, 'jid')
+            pol.assert_called()
+
+    def test_persist_qtable(self):
+        a = HPCForecastScheduler(carbon_history=[1, 2], cost_history=[2, 1])
+        b = HPCForecastScheduler(backend='k8s', carbon_history=[3, 4], cost_history=[4, 3])
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, 'q.json')
+            sched = AdaptiveCostScheduler({'a': a, 'b': b}, qtable_path=path)
+            self.assertTrue(os.path.exists(path))
+            q_pre = dict(sched.q)
+            sched2 = AdaptiveCostScheduler({'a': a, 'b': b}, qtable_path=path)
+            self.assertEqual(q_pre, sched2.q)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enhance `AdaptiveCostScheduler` with optional persistent Q-table
- expose Q-learning hyperparameters via CLI
- document new `qtable_path` option
- verify persistence in unit tests

## Testing
- `pytest tests/test_adaptive_cost_scheduler.py -q`
- `pytest tests/test_hpc_multi_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b331d37c083319344c6c24063ff61