### PR TITLE
Add multimodal summary improvements

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -358,6 +358,7 @@ To reproduce the toy run step by step:
 - `src/hierarchical_memory.py` and `src/link_slot_attention.py` provide a two-tier memory backed by FAISS.
 - The store compresses vectors before writing them to disk and loads the nearest neighbours on demand.
 - `RetrievalExplainer.summarize()` distills query results into a brief text used by `MemoryDashboard` to show context for each retrieval.
+- `RetrievalExplainer.summarize_multimodal()` collapses text snippets and lists referenced images or audio so multimodal queries render clearly in the dashboard.
 
 ## C-8 Distributed Hierarchical Memory Backend
 

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -258,7 +258,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     five self-play cycles.
 14. **Attention trace analysis**: Use the new `AttentionVisualizer` to
    inspect long-context retrieval patterns on ≥1&nbsp;M-token evaluations.
-    `RetrievalExplainer` extends `HierarchicalMemory.search()` with similarity scores and provenance so these traces are visible through the memory dashboard.
+    `RetrievalExplainer` extends `HierarchicalMemory.search()` with similarity scores and provenance so these traces are visible through the memory dashboard. `summarize_multimodal()` now formats text snippets and media paths for richer summaries.
 15. **Graph-of-thought planning**: Implement `GraphOfThought` (see
     `src/graph_of_thought.py`) and measure refactor quality gains over the
     baseline meta-RL agent. The `ReasoningDebugger` now aggregates loops and
@@ -526,7 +526,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
      trigger `dataset_summarizer.summarize_dataset` on the referenced folder.
      Run `python -m asi.streaming_dataset_watcher db.sqlite <rss-url>` to start
      watching feeds.
- 
+
 83. **Analogy-based retrieval evaluation**: Use `analogical_retrieval.analogy_search()`
     on a small word-analogy dataset. For each tuple `(A, B, Q)` compute the
     offset `B - A` and query `HierarchicalMemory.search(mode="analogy")`. Report
@@ -541,7 +541,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     reasoning steps with expected analogies by calling
     `analogical_retrieval.analogy_search()` and logs mismatches via
     `ReasoningHistoryLogger`.
-    
+
 
 84. **Privacy-preserving federated RL**: Wrap `EdgeRLTrainer` with encrypted gradient
     aggregation. Gradients are clipped and noised before averaging so reward

--- a/src/memory_dashboard.py
+++ b/src/memory_dashboard.py
@@ -137,7 +137,15 @@ class MemoryDashboard:
                         meta = trace.get("provenance", [])
                         scores = trace.get("scores", [])
                         items = RetrievalExplainer.format(q, r, scores, meta)
-                        summary = RetrievalExplainer.summarize(q, r, scores, meta)
+                        is_multi = any(
+                            isinstance(m, dict)
+                            and any(k in m for k in ("text", "image", "audio"))
+                            for m in meta
+                        ) if meta else False
+                        if is_multi and hasattr(RetrievalExplainer, "summarize_multimodal"):
+                            summary = RetrievalExplainer.summarize_multimodal(q, r, scores, meta)
+                        else:
+                            summary = RetrievalExplainer.summarize(q, r, scores, meta)
                         data = json.dumps({"items": items, "summary": summary}).encode()
                     self.send_response(200)
                     self.send_header("Content-Type", "application/json")

--- a/src/retrieval_explainer.py
+++ b/src/retrieval_explainer.py
@@ -26,4 +26,34 @@ class RetrievalExplainer:
             parts.append(f"{i}. {src} (score={score:.3f})")
         return " | ".join(parts)
 
+    @staticmethod
+    def summarize_multimodal(
+        query: torch.Tensor,
+        results: torch.Tensor,
+        scores: List[float],
+        provenance: List[Any],
+    ) -> str:
+        """Return a short description of multimodal provenance."""
+
+        def _fmt(p: Any) -> str:
+            if not isinstance(p, dict):
+                return str(p)
+            fields = []
+            if (txt := p.get("text")):
+                snippet = str(txt)
+                if len(snippet) > 40:
+                    snippet = snippet[:37] + "..."
+                fields.append(f"text='{snippet}'")
+            if (img := p.get("image")):
+                fields.append(f"image={img}")
+            if (aud := p.get("audio")):
+                fields.append(f"audio={aud}")
+            return ", ".join(fields) if fields else str(p)
+
+        parts = [
+            f"{i}. {_fmt(prov)} (score={score:.3f})"
+            for i, (score, prov) in enumerate(zip(scores, provenance), start=1)
+        ]
+        return " | ".join(parts)
+
 __all__ = ["RetrievalExplainer"]

--- a/tests/test_retrieval_explainer.py
+++ b/tests/test_retrieval_explainer.py
@@ -3,7 +3,38 @@ import importlib.machinery
 import importlib.util
 import types
 import sys
-import torch
+try:
+    import torch
+except Exception:  # pragma: no cover - torch may be unavailable
+    class _Tensor(list):
+        @property
+        def ndim(self):
+            return 2 if self and isinstance(self[0], list) else 1
+        def unsqueeze(self, dim):
+            return _Tensor([self])
+        def tolist(self):
+            return list(self)
+        def __iter__(self):
+            for x in list.__iter__(self):
+                if isinstance(x, list):
+                    yield _Tensor(x)
+                else:
+                    yield x
+
+    def _full(val, *shape):
+        if len(shape) == 1:
+            return _Tensor([val for _ in range(shape[0])])
+        rows = shape[0]
+        cols = shape[1]
+        return _Tensor([[val for _ in range(cols)] for _ in range(rows)])
+
+    torch = types.SimpleNamespace(
+        zeros=lambda *a, **k: _full(0.0, *a),
+        ones=lambda *a, **k: _full(1.0, *a),
+        tensor=lambda v, dtype=None: _Tensor(v),
+        Tensor=_Tensor,
+    )
+    sys.modules['torch'] = torch
 
 src_pkg = types.ModuleType('src')
 src_pkg.__path__ = ['src']
@@ -35,6 +66,19 @@ class TestRetrievalExplainer(unittest.TestCase):
         summary = RetrievalExplainer.summarize(q, r, scores, prov)
         self.assertIn('a', summary)
         self.assertIn('0.9', summary)
+
+    def test_summarize_multimodal(self):
+        q = torch.zeros(1, 2)
+        r = torch.ones(2, 2)
+        scores = [0.5, 0.4]
+        prov = [
+            {'text': 'hello', 'image': 'img1.png', 'audio': 'a1.wav'},
+            {'text': 'world', 'image': 'img2.png', 'audio': 'a2.wav'},
+        ]
+        summary = RetrievalExplainer.summarize_multimodal(q, r, scores, prov)
+        self.assertIn('hello', summary)
+        self.assertIn('img1.png', summary)
+        self.assertIn('a1.wav', summary)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- refine `summarize_multimodal` formatting
- detect multimodal metadata more robustly
- test dashboard trace summaries
- document richer multimodal summaries

## Testing
- `pytest -q tests/test_retrieval_explainer.py tests/test_memory_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_686b332866c88331863e93c2d8c10efa