### PR TITLE
Implement GNN memory

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -248,6 +248,7 @@ from .cross_lingual_fairness import CrossLingualFairnessEvaluator
 from .risk_dashboard import RiskDashboard
 from .alignment_dashboard import AlignmentDashboard
 from .graph_neural_reasoner import GraphNeuralReasoner
+from .gnn_memory import GNNMemory
 from .temporal_reasoner import TemporalReasoner
 from .lora_merger import merge_adapters
 from .edge_rl_trainer import EdgeRLTrainer

--- a/src/gnn_memory.py
+++ b/src/gnn_memory.py
@@ -1,0 +1,103 @@
+"""Graph Neural Network memory over GraphOfThought nodes."""
+
+from __future__ import annotations
+
+import random
+from typing import Iterable, Dict, List, Tuple
+
+import numpy as np
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from .graph_of_thought import ThoughtNode
+
+
+def _embed_text(text: str, dim: int) -> torch.Tensor:
+    """Deterministically embed ``text`` using a hash based RNG."""
+    seed = abs(hash(text)) % (2 ** 32)
+    rng = np.random.default_rng(seed)
+    vec = rng.standard_normal(dim).astype(np.float32)
+    return torch.from_numpy(vec)
+
+
+class GNNMemory(nn.Module):
+    """Simple GraphSAGE-style encoder for reasoning graphs."""
+
+    def __init__(
+        self,
+        nodes: Iterable[ThoughtNode],
+        edges: Dict[int, List[int]],
+        dim: int = 16,
+    ) -> None:
+        super().__init__()
+        node_list = list(nodes)
+        self.id_to_idx = {n.id: i for i, n in enumerate(node_list)}
+        self.idx_to_id = {i: n.id for i, n in enumerate(node_list)}
+        self.edges = {k: list(v) for k, v in edges.items()}
+        self.dim = dim
+        self.embed = nn.Embedding(len(node_list), dim)
+        with torch.no_grad():
+            init = torch.stack([_embed_text(n.text, dim) for n in node_list])
+            self.embed.weight.copy_(init)
+        self.lin_self = nn.Linear(dim, dim)
+        self.lin_neigh = nn.Linear(dim, dim)
+
+    # ------------------------------------------------------------------
+    def encode_nodes(self) -> torch.Tensor:
+        """Return embeddings for all nodes after one message pass."""
+        h = self.embed.weight
+        neigh = torch.zeros_like(h)
+        for src, dsts in self.edges.items():
+            if src not in self.id_to_idx or not dsts:
+                continue
+            idx = self.id_to_idx[src]
+            idxs = [self.id_to_idx[d] for d in dsts if d in self.id_to_idx]
+            if idxs:
+                neigh[idx] = h[idxs].mean(dim=0)
+        out = self.lin_self(h) + self.lin_neigh(neigh)
+        return F.relu(out)
+
+    # ------------------------------------------------------------------
+    def edge_loss(self) -> torch.Tensor:
+        """Return link prediction loss over observed edges."""
+        h = self.encode_nodes()
+        n = h.size(0)
+        loss = 0.0
+        count = 0
+        for src, dsts in self.edges.items():
+            src_idx = self.id_to_idx.get(src)
+            if src_idx is None:
+                continue
+            for dst in dsts:
+                dst_idx = self.id_to_idx.get(dst)
+                if dst_idx is None:
+                    continue
+                pos_score = (h[src_idx] * h[dst_idx]).sum()
+                neg = random.randrange(n)
+                neg_score = (h[src_idx] * h[neg]).sum()
+                loss += F.binary_cross_entropy_with_logits(pos_score, torch.tensor(1.0))
+                loss += F.binary_cross_entropy_with_logits(neg_score, torch.tensor(0.0))
+                count += 2
+        if count == 0:
+            return h.sum() * 0
+        return loss / count
+
+    # ------------------------------------------------------------------
+    def query(self, context: int | Iterable[int]) -> Tuple[torch.Tensor, List[int]]:
+        """Return neighbour embeddings for ``context`` node(s)."""
+        if isinstance(context, int):
+            ctx = [context]
+        else:
+            ctx = list(context)
+        neigh_ids = set()
+        for n in ctx:
+            neigh_ids.update(self.edges.get(n, []))
+        idxs = [self.id_to_idx[i] for i in neigh_ids if i in self.id_to_idx]
+        if not idxs:
+            return torch.empty(0, self.dim), []
+        emb = self.encode_nodes()
+        return emb[idxs], [self.idx_to_id[i] for i in idxs]
+
+
+__all__ = ["GNNMemory"]

--- a/tests/test_gnn_memory.py
+++ b/tests/test_gnn_memory.py
@@ -1,0 +1,58 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+import unittest
+import torch
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+
+got = load('asi.graph_of_thought', 'src/graph_of_thought.py')
+mem_mod = load('asi.gnn_memory', 'src/gnn_memory.py')
+
+GraphOfThought = got.GraphOfThought
+GNNMemory = mem_mod.GNNMemory
+
+
+class TestGNNMemory(unittest.TestCase):
+    def test_training_closeness(self):
+        torch.manual_seed(0)
+        g = GraphOfThought()
+        a = g.add_step('a')
+        b = g.add_step('b')
+        c = g.add_step('c')
+        d = g.add_step('d')
+        g.connect(a, b)
+        g.connect(b, c)
+        nodes = list(g.nodes.values())
+        mem = GNNMemory(nodes, g.edges, dim=8)
+        opt = torch.optim.SGD(mem.parameters(), lr=0.1)
+        for _ in range(100):
+            opt.zero_grad()
+            loss = mem.edge_loss()
+            loss.backward()
+            opt.step()
+        emb = mem.encode_nodes().detach()
+        idx_a = mem.id_to_idx[a]
+        idx_b = mem.id_to_idx[b]
+        idx_d = mem.id_to_idx[d]
+        sim_ab = torch.cosine_similarity(emb[idx_a], emb[idx_b], dim=0)
+        sim_ad = torch.cosine_similarity(emb[idx_a], emb[idx_d], dim=0)
+        self.assertGreater(sim_ab, sim_ad)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a small GraphSAGE encoder as `GNNMemory`
- document graph neural memory message passing and training
- export `GNNMemory` from the main package
- add unit test verifying embeddings after training

## Testing
- `python -m pytest tests/test_gnn_memory.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b3458923083319a67866890dfa908