### PR TITLE
Add PrivacyGuard for differential privacy in ingestion

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -519,6 +519,17 @@ paraphrase_multilingual([Path("./data/text/0.txt")], translator, None, inspector
 Run `scripts/lineage_viewer.py ./data` to browse the recorded steps.
 ```
 
+To inject noise for differential privacy, create a `PrivacyGuard` and pass it to
+`download_triples()`. After ingestion, inspect the remaining budget:
+
+```python
+from asi.privacy_guard import PrivacyGuard
+
+guard = PrivacyGuard(budget=1.0)
+download_triples(text_urls, img_urls, aud_urls, "./data", privacy_guard=guard)
+print("epsilon left", guard.remaining_budget())
+```
+
 ## L-6 Mechanistic Interpretability Tools
 
 - `src/transformer_circuits.py` provides utilities to record attention weights
@@ -652,6 +663,7 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Implement a `PQVectorStore` using FAISS `IndexIVFPQ` for compressed vector storage and integrate it with `HierarchicalMemory`. Benchmark retrieval accuracy against `FaissVectorStore`. **Implemented in `src/pq_vector_store.py` and integrated with `HierarchicalMemory`.**
 - Add a `DuplicateDetector` that uses CLIP embeddings with locality-sensitive hashing to drop near-duplicate samples during ingestion and connect it to `AutoDatasetFilter`. **Implemented in `src/duplicate_detector.py` and integrated with `filter_text_files()`.**
 - Add a `DataPoisonDetector` that clusters word statistics and flags poisoned samples during ingestion. `download_triples()` now drops flagged triples. **Implemented in `src/data_poison_detector.py` and wired through `data_ingest`.**
+- Add a `PrivacyGuard` that injects noise into downloaded triples and tracks epsilon usage. `download_triples()` records the budget per sample. **Implemented in `src/privacy_guard.py` and integrated with `data_ingest.download_triples`.**
 - Implement a `TemporalVectorCompressor` in `streaming_compression.py` with a
   decay factor so `HierarchicalMemory` can prioritize recent context. Benchmark
   retrieval accuracy against the existing compressor. **Implemented in

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -229,6 +229,7 @@ from .multi_agent_coordinator import MultiAgentCoordinator, RLNegotiator, Negoti
 from .dp_memory import DifferentialPrivacyMemory
 from .privacy_budget_manager import PrivacyBudgetManager
 from .privacy_auditor import PrivacyAuditor
+from .privacy_guard import PrivacyGuard
 from .causal_reasoner import CausalReasoner
 from .multi_agent_graph_planner import MultiAgentGraphPlanner
 from .world_model_debugger import WorldModelDebugger

--- a/src/privacy_guard.py
+++ b/src/privacy_guard.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import random
+from typing import Tuple
+import numpy as np
+
+
+class PrivacyGuard:
+    """Inject random noise and track a privacy budget."""
+
+    def __init__(self, budget: float, noise_scale: float = 0.1) -> None:
+        self.budget = float(budget)
+        self.noise_scale = float(noise_scale)
+        self._consumed = 0.0
+
+    # --------------------------------------------------
+    def _noisy_text(self, text: str) -> str:
+        words = text.split()
+        if not words:
+            return text
+        p = min(self.noise_scale, 0.5)
+        kept = [w for w in words if random.random() > p]
+        if not kept:
+            kept = [words[0]]
+        return " ".join(kept)
+
+    def _noisy_array(self, arr: np.ndarray) -> np.ndarray:
+        noise = np.random.normal(scale=self.noise_scale, size=arr.shape)
+        out = arr.astype(float) + noise
+        return out.astype(arr.dtype)
+
+    # --------------------------------------------------
+    def inject(
+        self,
+        text: str,
+        image: np.ndarray,
+        audio: np.ndarray,
+        epsilon: float = 0.1,
+    ) -> Tuple[str, np.ndarray, np.ndarray]:
+        """Return noisy versions of ``text``/``image``/``audio``."""
+        if self.remaining_budget() <= 0.0:
+            return text, image, audio
+        txt = self._noisy_text(text)
+        img = self._noisy_array(np.asarray(image))
+        aud = self._noisy_array(np.asarray(audio))
+        self._consumed += epsilon
+        return txt, img, aud
+
+    # --------------------------------------------------
+    def remaining_budget(self) -> float:
+        return max(self.budget - self._consumed, 0.0)
+
+
+__all__ = ["PrivacyGuard"]

--- a/tests/test_privacy_guard.py
+++ b/tests/test_privacy_guard.py
@@ -1,0 +1,83 @@
+import unittest
+import tempfile
+from pathlib import Path
+import types
+import json
+import numpy as np
+import wave
+from unittest.mock import patch
+import importlib.machinery
+import importlib.util
+import importlib
+import sys
+
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+src_pkg.__path__ = ['src']
+src_pkg.__spec__ = importlib.machinery.ModuleSpec('src', None, is_package=True)
+
+# stub heavy deps
+sys.modules['torch'] = types.SimpleNamespace()
+sys.modules['psutil'] = types.SimpleNamespace()
+
+loader_pg = importlib.machinery.SourceFileLoader('src.privacy_guard', 'src/privacy_guard.py')
+spec_pg = importlib.util.spec_from_loader(loader_pg.name, loader_pg)
+pg_mod = importlib.util.module_from_spec(spec_pg)
+pg_mod.__package__ = 'src'
+sys.modules['src.privacy_guard'] = pg_mod
+loader_pg.exec_module(pg_mod)
+PrivacyGuard = pg_mod.PrivacyGuard
+
+loader_di = importlib.machinery.SourceFileLoader('src.data_ingest', 'src/data_ingest.py')
+spec_di = importlib.util.spec_from_loader(loader_di.name, loader_di)
+di = importlib.util.module_from_spec(spec_di)
+di.__package__ = 'src'
+sys.modules['src.data_ingest'] = di
+loader_di.exec_module(di)
+Image = importlib.import_module('PIL.Image')
+
+
+class TestPrivacyGuard(unittest.TestCase):
+    def test_inject_budget(self):
+        pg = PrivacyGuard(1.0, noise_scale=0.5)
+        txt, img, aud = pg.inject("hello world", np.zeros((2, 2)), np.zeros(4), epsilon=0.2)
+        self.assertLess(pg.remaining_budget(), 1.0)
+        self.assertEqual(pg.remaining_budget(), 0.8)
+        changed = txt != "hello world" or not np.allclose(img, 0) or not np.allclose(aud, 0)
+        self.assertTrue(changed)
+
+    def test_download_triples_privacy(self):
+        async def fake_download(session, url, dest):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if dest.suffix == ".txt":
+                dest.write_text("hello world")
+            elif dest.suffix == ".png":
+                Image.new("RGB", (1, 1)).save(dest)
+            else:
+                with wave.open(str(dest), "wb") as w:
+                    w.setnchannels(1)
+                    w.setsampwidth(2)
+                    w.setframerate(16000)
+                    w.writeframes(np.zeros(1, dtype=np.int16).tobytes())
+
+        with tempfile.TemporaryDirectory() as root:
+            pg = PrivacyGuard(0.5, noise_scale=0.5)
+            urls = ["u"]
+            with patch.object(di, "_download_file_async", fake_download):
+                di._HAS_AIOHTTP = True
+                class DummySession:
+                    async def __aenter__(self):
+                        return self
+                    async def __aexit__(self, exc_type, exc, tb):
+                        pass
+                di.aiohttp = types.SimpleNamespace(ClientSession=DummySession)
+                di.download_triples(urls, urls, urls, root, privacy_guard=pg)
+            meta = Path(root) / "text/0.json"
+            self.assertTrue(meta.exists())
+            info = json.loads(meta.read_text())
+            self.assertIn("epsilon", info)
+            self.assertLess(pg.remaining_budget(), 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `PrivacyGuard` to inject noise and track epsilon budget
- integrate `PrivacyGuard` with `download_triples` in `data_ingest`
- document how to enable privacy guard and monitor the budget
- add unit tests for the new functionality

## Testing
- `pytest tests/test_privacy_guard.py tests/test_data_ingest.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b346d23008331ba595b7b48eaa5d6