### PR TITLE
Add zero trust memory server test

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ logger = TelemetryLogger(port=8000)
 server = serve(mem, "localhost:50070", telemetry=logger)
 ```
 
+If a `BlockchainProvenanceLedger` is supplied, `serve()` launches a
+`ZeroTrustMemoryServer` that checks signed access tokens before allowing
+operations:
+
+```python
+from asi.blockchain_provenance_ledger import BlockchainProvenanceLedger
+
+ledger = BlockchainProvenanceLedger("/tmp/ledger")
+ledger.append("valid-token", signature="sig")
+server = serve(mem, "localhost:50070", ledger=ledger)
+```
+
 To search across languages, wrap the memory with `CrossLingualMemory` and
 provide a `CrossLingualTranslator`:
 

--- a/asi/__init__.py
+++ b/asi/__init__.py
@@ -33,8 +33,12 @@ for _m in [
     "quantum_memory_server",
     "quantum_memory_client",
     "enclave_runner",
+    "zero_trust_memory_server",
 ]:
-    _import(_m)
+    try:  # pragma: no cover - optional deps
+        _import(_m)
+    except Exception:
+        pass
 
 
 def __getattr__(name: str):

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -441,6 +441,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 51. **Context summarization memory**: Store compressed summaries for distant tokens and re-expand them on demand; success is >95% retrieval accuracy at 100× token length. *Implemented in `src/context_summary_memory.py` with tests.*
 52. **Dataset lineage manager**: Automatically track dataset versions and transformations, enabling reproducible training pipelines. *Implemented in `src/dataset_lineage_manager.py`.*
     Use `DataProvenanceLedger` to append a signed hash of each lineage record. Run `scripts/check_provenance.py <root>` to verify the ledger.
+52a. **Zero-trust memory server**: `ZeroTrustMemoryServer` validates signed access tokens against a `BlockchainProvenanceLedger` before serving requests. Unauthorized clients are rejected.
 53. **Multi-stage oversight**: Combine constitutional AI, deliberative alignment, and critic-in-the-loop RLHF with formal verification; success is <1% harmful output on the existing benchmarks.
 54. **Self-supervised sensorimotor pretraining**: Pretrain the embodied world model on large unlabelled multimodal logs; success is 20% fewer real-world samples to reach 90% task success.
 55. **Gradient compression for distributed training**: Implement a `GradientCompressor`

--- a/src/memory_service.py
+++ b/src/memory_service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from .hierarchical_memory import HierarchicalMemory, MemoryServer
 from .telemetry import TelemetryLogger
+from .zero_trust_memory_server import ZeroTrustMemoryServer
+from .blockchain_provenance_ledger import BlockchainProvenanceLedger
 
 
 def serve(
@@ -11,13 +13,30 @@ def serve(
     address: str,
     max_workers: int = 4,
     telemetry: TelemetryLogger | None = None,
+    ledger: BlockchainProvenanceLedger | None = None,
 ) -> MemoryServer:
-    """Start a :class:`MemoryServer` at ``address`` and return it."""
-    server = MemoryServer(
-        memory, address=address, max_workers=max_workers, telemetry=telemetry
-    )
+    """Start a ``MemoryServer`` at ``address`` and return it.
+
+    If ``ledger`` is provided, a :class:`ZeroTrustMemoryServer` is started
+    which validates access tokens against the ledger.
+    """
+    server: MemoryServer
+    if ledger is not None:
+        if ZeroTrustMemoryServer is None:
+            raise ImportError("grpcio is required for ZeroTrustMemoryServer")
+        server = ZeroTrustMemoryServer(
+            memory,
+            ledger,
+            address=address,
+            max_workers=max_workers,
+            telemetry=telemetry,
+        )
+    else:
+        server = MemoryServer(
+            memory, address=address, max_workers=max_workers, telemetry=telemetry
+        )
     server.start()
     return server
 
 
-__all__ = ["serve", "MemoryServer"]
+__all__ = ["serve", "MemoryServer", "ZeroTrustMemoryServer"]

--- a/src/zero_trust_memory_server.py
+++ b/src/zero_trust_memory_server.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from .blockchain_provenance_ledger import BlockchainProvenanceLedger
+from typing import Any
+
+try:
+    import grpc  # type: ignore
+    from . import memory_pb2
+    _HAS_GRPC = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAS_GRPC = False
+
+if _HAS_GRPC:
+
+    from concurrent import futures
+    import torch
+    from . import memory_pb2_grpc
+    from . import memory_pb2
+
+    class ZeroTrustMemoryServer(memory_pb2_grpc.MemoryServiceServicer):
+        """Memory server that verifies signed access tokens."""
+
+        def __init__(
+            self,
+            memory: Any,
+            ledger: BlockchainProvenanceLedger,
+            address: str = "localhost:50051",
+            max_workers: int = 4,
+            telemetry: "TelemetryLogger | None" = None,
+        ) -> None:
+            self.memory = memory
+            self.ledger = ledger
+            self.address = address
+            self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))
+            memory_pb2_grpc.add_MemoryServiceServicer_to_server(self, self.server)
+            self.server.add_insecure_port(address)
+            self.telemetry = telemetry
+
+        # --------------------------------------------------
+        def _check_token(self, context: grpc.ServicerContext) -> bool:
+            md = dict(context.invocation_metadata())
+            token = md.get("authorization")
+            if not token:
+                return False
+            try:
+                return self.ledger.verify([token])
+            except Exception:
+                return False
+
+        # --------------------------------------------------
+        def Push(self, request: memory_pb2.PushRequest, context) -> memory_pb2.PushReply:  # noqa: N802
+            if not self._check_token(context):
+                context.abort(grpc.StatusCode.UNAUTHENTICATED, "invalid token")
+            vec = torch.tensor(request.vector).reshape(1, -1)
+            meta = request.metadata if request.metadata else None
+            self.memory.add(vec, metadata=[meta])
+            return memory_pb2.PushReply(ok=True)
+
+        def Query(self, request: memory_pb2.QueryRequest, context) -> memory_pb2.QueryReply:  # noqa: N802
+            if not self._check_token(context):
+                context.abort(grpc.StatusCode.UNAUTHENTICATED, "invalid token")
+            q = torch.tensor(request.vector).reshape(1, -1)
+            out, meta = self.memory.search(q, k=int(request.k))
+            flat = out.detach().cpu().view(-1).tolist()
+            meta = [str(m) for m in meta]
+            return memory_pb2.QueryReply(vectors=flat, metadata=meta)
+
+        def PushBatch(self, request: memory_pb2.PushBatchRequest, context) -> memory_pb2.PushReply:  # noqa: N802
+            if not self._check_token(context):
+                context.abort(grpc.StatusCode.UNAUTHENTICATED, "invalid token")
+            for item in request.items:
+                vec = torch.tensor(item.vector).reshape(1, -1)
+                meta = item.metadata if item.metadata else None
+                self.memory.add(vec, metadata=[meta])
+            return memory_pb2.PushReply(ok=True)
+
+        def QueryBatch(self, request: memory_pb2.QueryBatchRequest, context) -> memory_pb2.QueryBatchReply:  # noqa: N802
+            if not self._check_token(context):
+                context.abort(grpc.StatusCode.UNAUTHENTICATED, "invalid token")
+            replies = []
+            for qreq in request.items:
+                qt = torch.tensor(qreq.vector).reshape(1, -1)
+                out, meta = self.memory.search(qt, k=int(qreq.k))
+                flat = out.detach().cpu().view(-1).tolist()
+                meta = [str(m) for m in meta]
+                replies.append(memory_pb2.QueryReply(vectors=flat, metadata=meta))
+            return memory_pb2.QueryBatchReply(items=replies)
+
+        def start(self) -> None:
+            if self.telemetry:
+                self.telemetry.start()
+            self.server.start()
+
+        def stop(self, grace: float = 0) -> None:
+            self.server.stop(grace)
+            if self.telemetry:
+                self.telemetry.stop()
+
+    __all__ = ["ZeroTrustMemoryServer"]
+else:  # pragma: no cover - optional dependency
+    ZeroTrustMemoryServer = None  # type: ignore
+    __all__ = ["ZeroTrustMemoryServer"]

--- a/tests/test_zero_trust_memory_server.py
+++ b/tests/test_zero_trust_memory_server.py
@@ -1,0 +1,110 @@
+import os
+import sys
+import tempfile
+import unittest
+import importlib.util
+import importlib.machinery
+import types
+
+try:
+    import torch
+    _HAS_TORCH = True
+except Exception:  # pragma: no cover - optional
+    torch = None
+    _HAS_TORCH = False
+
+try:
+    import grpc  # noqa: F401
+    _HAS_GRPC = True
+except Exception:  # pragma: no cover - optional
+    grpc = None
+    _HAS_GRPC = False
+
+SRC_DIR = os.path.join(os.path.dirname(__file__), "..", "src")
+
+
+
+class TestZeroTrustMemoryServer(unittest.TestCase):
+    def test_unauthorized_rejected(self):
+        if not (_HAS_GRPC and _HAS_TORCH):
+            self.skipTest("dependencies not available")
+        pkg = types.ModuleType("src")
+        pkg.__path__ = [SRC_DIR]
+        pkg.__spec__ = importlib.machinery.ModuleSpec("src", None, is_package=True)
+        sys.modules["src"] = pkg
+        spec_pb2 = importlib.util.spec_from_file_location(
+            "src.memory_pb2", os.path.join(SRC_DIR, "memory_pb2.py"),
+            submodule_search_locations=[SRC_DIR],
+        )
+        memory_pb2 = importlib.util.module_from_spec(spec_pb2)
+        sys.modules["src.memory_pb2"] = memory_pb2
+        sys.modules["memory_pb2"] = memory_pb2
+        spec_pb2.loader.exec_module(memory_pb2)
+
+        spec_pb2_grpc = importlib.util.spec_from_file_location(
+            "src.memory_pb2_grpc", os.path.join(SRC_DIR, "memory_pb2_grpc.py"),
+            submodule_search_locations=[SRC_DIR],
+        )
+        memory_pb2_grpc = importlib.util.module_from_spec(spec_pb2_grpc)
+        sys.modules["src.memory_pb2_grpc"] = memory_pb2_grpc
+        spec_pb2_grpc.loader.exec_module(memory_pb2_grpc)
+
+        spec_ledger = importlib.util.spec_from_file_location(
+            "src.blockchain_provenance_ledger",
+            os.path.join(SRC_DIR, "blockchain_provenance_ledger.py"),
+            submodule_search_locations=[SRC_DIR],
+        )
+        ledger_mod = importlib.util.module_from_spec(spec_ledger)
+        sys.modules["src.blockchain_provenance_ledger"] = ledger_mod
+        spec_ledger.loader.exec_module(ledger_mod)
+        BlockchainProvenanceLedger = ledger_mod.BlockchainProvenanceLedger
+
+        spec_zts = importlib.util.spec_from_file_location(
+            "src.zero_trust_memory_server",
+            os.path.join(SRC_DIR, "zero_trust_memory_server.py"),
+            submodule_search_locations=[SRC_DIR],
+        )
+        zts_mod = importlib.util.module_from_spec(spec_zts)
+        sys.modules["src.zero_trust_memory_server"] = zts_mod
+        spec_zts.loader.exec_module(zts_mod)
+        ZeroTrustMemoryServer = zts_mod.ZeroTrustMemoryServer
+
+        class DummyMemory:
+            def __init__(self, dim: int) -> None:
+                self.dim = dim
+                self.vectors: list[torch.Tensor] = []
+
+            def add(self, vec: torch.Tensor, metadata=None) -> None:
+                self.vectors.append(vec.clone())
+
+            def search(self, q: torch.Tensor, k: int = 1):
+                if not self.vectors:
+                    return torch.zeros(k, self.dim), [None] * k
+                out = self.vectors[0].unsqueeze(0).expand(k, -1)
+                return out, [None] * k
+
+        mem = DummyMemory(dim=4)
+        with tempfile.TemporaryDirectory() as root:
+            ledger = BlockchainProvenanceLedger(root)
+            ledger.append("valid-token", signature="sig")
+
+            server = ZeroTrustMemoryServer(mem, ledger, address="localhost:50800")
+            server.start()
+
+            vec = torch.randn(1, 4)
+            req = memory_pb2.PushRequest(vector=vec[0].tolist(), metadata="")
+
+            with grpc.insecure_channel("localhost:50800") as channel:
+                stub = memory_pb2_grpc.MemoryServiceStub(channel)
+                with self.assertRaises(grpc.RpcError):
+                    stub.Push(req, timeout=5, metadata=(("authorization", "bad"),))
+                reply = stub.Push(
+                    req, timeout=5, metadata=(("authorization", "valid-token"),)
+                )
+                self.assertTrue(reply.ok)
+
+            server.stop(0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refactor `ZeroTrustMemoryServer` into a standalone gRPC service
- add unit test using a dummy memory backend
- ensure access tokens are validated before accepting requests

## Testing
- `pytest tests/test_zero_trust_memory_server.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686b331e635883319e55858a96cb1b1a