### PR TITLE
Add device-aware DNC backend

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -33,8 +33,10 @@ Citations point to the most recent public work so you can drill straight into th
 | **C-9** | **Hopfield Associative Memory** | Store binary patterns as attractors and recall them from noisy cues | Recall accuracy >95 % on 32-bit vectors with up to 20 % noise |
 | **C-10** | **RL-guided retrieval** | Learn a policy to rank memory vectors by hit rate and latency | Recall improves after online training from query logs |
 | **C-11** | **Emotion-conditioned retrieval** | Re-rank memory hits by matching sentiment | Positive/negative queries return ≥1 matching-tone item first |
+| **C-12** | **Differentiable Neural Computer memory** | Addressable memory matrix with learnable read/write heads | Store and recall 1 k vectors with <1 % error |
 
 **Path to “trillion-token” context:** combine *C-1/2/3* for linear-or-sub-linear scaling, add **hierarchical retrieval** (store distant tokens in an external vector DB and re-inject on-demand).  Recurrence handles the whole stream; retrieval gives random access—context length becomes limited only by storage, not RAM.  Privacy-preserving retrieval is now possible via `EncryptedVectorStore`, which stores AES-encrypted embeddings and manages keys through `HierarchicalMemory`. FHEMemoryServer goes a step further, allowing remote encrypted queries via TenSEAL.
+Experiments with a `DNCMemory` backend add learnable read/write heads on top of the vector store. The module now exposes device and dtype options and supports memory resets.
 
 ---
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -33,6 +33,7 @@ from .encrypted_vector_store import EncryptedVectorStore
 from .pq_vector_store import PQVectorStore
 from .async_vector_store import AsyncFaissVectorStore
 from .ephemeral_vector_store import EphemeralVectorStore
+from .dnc_memory import DNCMemory
 from .iter_align import IterativeAligner
 from .critic_rlhf import CriticScorer, CriticRLHFTrainer
 from .chunkwise_retrainer import ChunkWiseRetrainer

--- a/src/dnc_memory.py
+++ b/src/dnc_memory.py
@@ -1,0 +1,155 @@
+"""A lightweight Differentiable Neural Computer memory backend."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from pathlib import Path
+from typing import Iterable, Any, List, Tuple
+
+
+class DNCMemory:
+    """Minimal Differentiable Neural Computer memory.
+
+    This implementation keeps a fixed-size memory matrix and performs
+    content-based reads using cosine similarity. Writes append new vectors
+    in a ring buffer manner. Metadata is stored alongside each slot.
+    """
+
+    def __init__(
+        self,
+        memory_size: int,
+        word_size: int,
+        num_reads: int = 1,
+        num_writes: int = 1,
+        *,
+        device: str | torch.device | None = None,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        self.memory_size = int(memory_size)
+        self.word_size = int(word_size)
+        self.num_reads = int(num_reads)
+        self.num_writes = int(num_writes)
+        self.device = torch.device(device) if device is not None else torch.device("cpu")
+        self.dtype = dtype
+
+        self.memory = torch.zeros(self.memory_size, self.word_size, device=self.device, dtype=self.dtype)
+        self.read_weights = torch.zeros(self.num_reads, self.memory_size, device=self.device, dtype=self.dtype)
+        self.write_weights = torch.zeros(self.num_writes, self.memory_size, device=self.device, dtype=self.dtype)
+        self.meta: List[Any] = [None] * self.memory_size
+        self.ptr = 0
+        self.count = 0
+
+    def __len__(self) -> int:
+        return self.count
+
+    @property
+    def capacity(self) -> int:
+        return self.memory_size
+
+    def reset(self) -> None:
+        """Clear all memory slots."""
+        self.memory.zero_()
+        self.read_weights.zero_()
+        self.write_weights.zero_()
+        self.meta = [None] * self.memory_size
+        self.ptr = 0
+        self.count = 0
+
+    # --------------------------------------------------------------
+    # Write/Read operations
+
+    def write(self, vectors: torch.Tensor, metadata: Iterable[Any] | None = None) -> None:
+        """Store ``vectors`` sequentially in memory."""
+        vecs = torch.as_tensor(vectors, dtype=self.dtype, device=self.device)
+        if vecs.ndim == 1:
+            vecs = vecs.unsqueeze(0)
+        metas = list(metadata) if metadata is not None else [None] * vecs.size(0)
+        for v, m in zip(vecs, metas):
+            idx = self.ptr % self.memory_size
+            self.memory[idx] = v
+            self.write_weights.zero_()
+            self.write_weights[0, idx] = 1.0
+            self.meta[idx] = m
+            self.ptr = (self.ptr + 1) % self.memory_size
+            self.count = min(self.count + 1, self.memory_size)
+
+    def _content_weights(self, key: torch.Tensor, beta: float = 1.0) -> torch.Tensor:
+        sim = torch.nn.functional.cosine_similarity(key.unsqueeze(0), self.memory, dim=1)
+        if self.count < self.memory_size:
+            mask = torch.arange(self.memory_size, device=self.device) < self.count
+            sim = sim.masked_fill(~mask, -float('inf'))
+        return torch.nn.functional.softmax(beta * sim, dim=0)
+
+    def read(self, keys: torch.Tensor, k: int = 1, beta: float = 1.0) -> Tuple[torch.Tensor, List[List[Any]]]:
+        """Return up to ``k`` memory vectors matching each ``key``."""
+        ks = torch.as_tensor(keys, dtype=self.dtype, device=self.device)
+        if ks.ndim == 1:
+            ks = ks.unsqueeze(0)
+
+        out_vecs = []
+        out_meta = []
+        for i, key in enumerate(ks[: self.num_reads]):
+            weights = self._content_weights(key, beta)
+            self.read_weights[i] = weights
+            idx = torch.topk(weights, k).indices
+            vec = self.memory[idx]
+            meta = [self.meta[j] for j in idx.tolist()]
+            out_vecs.append(vec)
+            out_meta.append(meta)
+
+        stacked = torch.stack([v.mean(dim=0) for v in out_vecs])
+        return stacked if stacked.shape[0] > 1 else stacked[0].unsqueeze(0), out_meta
+
+    # --------------------------------------------------------------
+    # Convenience wrappers for VectorStore-like usage
+
+    def add(self, vectors: torch.Tensor, metadata: Iterable[Any] | None = None) -> None:
+        """Alias of :meth:`write`. Provided for VectorStore compatibility."""
+        self.write(vectors, metadata)
+
+    def search(self, query: torch.Tensor, k: int = 1) -> Tuple[torch.Tensor, List[Any]]:
+        vecs, metas = self.read(query, k=k)
+        return vecs[0], metas[0]
+
+    def delete(self, index: int | Iterable[int] | None = None, tag: Any | None = None) -> None:
+        if index is None and tag is None:
+            raise ValueError("index or tag must be specified")
+        if index is not None:
+            idxs = [int(index)] if not isinstance(index, Iterable) else [int(i) for i in index]
+        else:
+            idxs = [i for i, m in enumerate(self.meta) if m == tag]
+        for i in idxs:
+            if 0 <= i < self.memory_size and self.meta[i] is not None:
+                self.memory[i].zero_()
+                self.meta[i] = None
+                self.count -= 1
+
+    def save(self, path: str | Path) -> None:
+        arr = self.memory.detach().cpu().numpy()
+        np.savez_compressed(
+            path,
+            memory=arr,
+            meta=np.array(self.meta, dtype=object),
+            ptr=self.ptr,
+            count=self.count,
+            dtype=str(self.dtype),
+        )
+
+    @classmethod
+    def load(cls, path: str | Path) -> 'DNCMemory':
+        data = np.load(path, allow_pickle=True)
+        mem = cls(
+            data["memory"].shape[0],
+            data["memory"].shape[1],
+            device="cpu",
+            dtype=getattr(torch, str(data.get("dtype", "float32"))),
+        )
+        mem.memory = torch.from_numpy(data["memory"]).to(mem.dtype)
+        mem.meta = data["meta"].tolist()
+        mem.ptr = int(data["ptr"])
+        mem.count = int(data.get("count", mem.ptr))
+        return mem
+
+
+__all__ = ["DNCMemory"]

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -18,6 +18,7 @@ from .encrypted_vector_store import EncryptedVectorStore
 from .pq_vector_store import PQVectorStore
 from .async_vector_store import AsyncFaissVectorStore
 from .hopfield_memory import HopfieldMemory
+from .dnc_memory import DNCMemory
 from .ephemeral_vector_store import EphemeralVectorStore
 from .data_ingest import CrossLingualTranslator
 from .retrieval_rl import RetrievalPolicy
@@ -113,6 +114,11 @@ class HierarchicalMemory:
         db_path: str | Path | None = None,
         use_async: bool = False,
         use_hopfield: bool = False,
+        use_dnc: bool = False,
+        dnc_size: int = 128,
+        dnc_reads: int = 1,
+        dnc_writes: int = 1,
+        dnc_device: str | None = None,
         use_lsh: bool = False,
         use_pq: bool = False,
         lsh_planes: int = 16,
@@ -144,6 +150,14 @@ class HierarchicalMemory:
             self.store = EphemeralVectorStore(dim=compressed_dim, ttl=ephemeral_ttl)
         elif use_hopfield:
             self.store = HopfieldStore(dim=compressed_dim)
+        elif use_dnc:
+            self.store = DNCMemory(
+                memory_size=dnc_size,
+                word_size=compressed_dim,
+                num_reads=dnc_reads,
+                num_writes=dnc_writes,
+                device=dnc_device,
+            )
         elif use_async:
             self.store = AsyncFaissVectorStore(dim=compressed_dim, path=db_path)
         elif use_lsh:

--- a/tests/test_dnc_memory.py
+++ b/tests/test_dnc_memory.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+import torch
+
+from asi.dnc_memory import DNCMemory
+
+
+class TestDNCMemory(unittest.TestCase):
+    def test_store_and_retrieve(self):
+        torch.manual_seed(0)
+        mem = DNCMemory(memory_size=4, word_size=3)
+        data = torch.randn(2, 3)
+        mem.write(data, metadata=["a", "b"])
+        vec, meta = mem.read(data[0], k=1)
+        self.assertEqual(meta[0], "a")
+        self.assertEqual(vec.shape, (1, 3))
+        vec2, meta2 = mem.read(data[1], k=1)
+        self.assertEqual(meta2[0], "b")
+        self.assertEqual(vec2.shape, (1, 3))
+
+    def test_save_and_load(self):
+        torch.manual_seed(1)
+        mem = DNCMemory(memory_size=2, word_size=3)
+        data = torch.randn(1, 3)
+        mem.add(data, metadata=["x"])
+        path = "tmp_dnc.npz"
+        mem.save(path)
+        mem2 = DNCMemory.load(path)
+        vec, meta = mem2.search(data[0], k=1)
+        self.assertEqual(meta[0], "x")
+        self.assertTrue(torch.allclose(vec, data, atol=1e-6))
+        os.remove(path)
+
+    def test_reset(self):
+        mem = DNCMemory(memory_size=2, word_size=2)
+        mem.add(torch.ones(2, 2), metadata=["a", "b"])
+        self.assertEqual(len(mem), 2)
+        mem.reset()
+        self.assertEqual(len(mem), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `DNCMemory` with configurable device and dtype
- expose DNC device option in `HierarchicalMemory`
- mention improvements in the plan document
- expand DNC tests with save/load and reset cases

## Testing
- `python -m unittest tests.test_dnc_memory` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686bedb7c4008331b572119d5ac134ac