### PR TITLE
Add analog context manager patch

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -108,6 +108,24 @@ PyTorch module and executes it on an attached FPGA when the optional
 `configure_fpga()` accepts an `FPGAConfig` with the target device index and
 optimisation flag.
 
+## Analog Acceleration
+
+`src/analog_backend.py` defines an `AnalogAccelerator` interface that calls out
+to an optional analog simulator for matrix multiplies. When no simulator is
+present the helper falls back to `torch.matmul`.
+
+Use it as a context manager to temporarily patch `torch.matmul`:
+
+```python
+from asi.analog_backend import AnalogAccelerator
+
+with AnalogAccelerator():
+    out = torch.matmul(a, b)
+```
+
+Enable the analog path by passing `use_analog=True` in
+`MultiModalWorldModelConfig` or `EdgeRLTrainer`.
+
 ## S-3 Scaling-law Breakpoint Model
 
 `src/scaling_law.py` defines ``BreakpointScalingLaw`` which fits a piecewise

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -183,6 +183,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
   consumption for CPU vs. Loihi execution through `TelemetryLogger`.
 - `src/fpga_backend.py` adds an `FPGAAccelerator` and optional `use_fpga`
   flag in `MultiModalWorldModelConfig` and `EdgeRLTrainer` for FPGA offload.
+- - `src/analog_backend.py` adds an `AnalogAccelerator` context manager for
+   analog matrix multiplies. Enable `use_analog=True` in
+   `MultiModalWorldModelConfig` or `EdgeRLTrainer` to patch `torch.matmul`
+   during training.
 - `src/cross_modal_fusion.py` encodes text, images and audio in a shared space
   with a contrastive training helper.
 - `src/multimodal_world_model.py` unifies these embeddings with actions for

--- a/scripts/benchmark_analog.py
+++ b/scripts/benchmark_analog.py
@@ -1,0 +1,42 @@
+import argparse
+import torch
+
+from asi.telemetry import TelemetryLogger
+from asi.analog_backend import AnalogAccelerator
+
+
+def run_cpu(a: torch.Tensor, b: torch.Tensor, steps: int) -> float:
+    logger = TelemetryLogger(interval=0.05, carbon_tracker=True)
+    logger.start()
+    for _ in range(steps):
+        _ = a @ b
+    logger.stop()
+    return logger.get_stats().get("energy_kwh", 0.0)
+
+
+def run_analog(a: torch.Tensor, b: torch.Tensor, steps: int) -> float:
+    accel = AnalogAccelerator()
+    logger = TelemetryLogger(interval=0.05, carbon_tracker=True)
+    logger.start()
+    with accel:
+        for _ in range(steps):
+            _ = torch.matmul(a, b)
+    logger.stop()
+    return logger.get_stats().get("energy_kwh", 0.0)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Analog vs CPU energy benchmark")
+    parser.add_argument("--dim", type=int, default=256, help="Matrix dimension")
+    parser.add_argument("--steps", type=int, default=10, help="Number of matmuls")
+    args = parser.parse_args()
+
+    a = torch.randn(args.dim, args.dim)
+    b = torch.randn(args.dim, args.dim)
+
+    cpu = run_cpu(a, b, args.steps)
+    analog = run_analog(a, b, args.steps)
+
+    print(f"CPU energy_kwh: {cpu:.6f}")
+    print(f"Analog energy_kwh: {analog:.6f}")
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -308,6 +308,13 @@ from .fpga_backend import (
     get_fpga_config,
     _HAS_FPGA,
 )
+from .analog_backend import (
+    AnalogAccelerator,
+    AnalogConfig,
+    configure_analog,
+    get_analog_config,
+    _HAS_ANALOG,
+)
 
 from .emotion_detector import detect_emotion
 from .bio_memory_replay import run_nightly_replay

--- a/src/analog_backend.py
+++ b/src/analog_backend.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import torch
+
+try:
+    import analogsim  # type: ignore
+    _HAS_ANALOG = True
+except Exception:  # pragma: no cover - optional dependency
+    analogsim = None  # type: ignore
+    _HAS_ANALOG = False
+
+
+@dataclass
+class AnalogConfig:
+    """Configuration options for analog simulation."""
+
+    noise: float = 0.0
+
+
+_CONFIG = AnalogConfig()
+
+
+def configure_analog(config: AnalogConfig) -> None:
+    """Set the global Analog configuration."""
+    global _CONFIG
+    _CONFIG = config
+
+
+def get_analog_config() -> AnalogConfig:
+    return _CONFIG
+
+
+class AnalogAccelerator:
+    """Offload matrix multiplies to an analog simulator when available."""
+
+    def __init__(self, config: AnalogConfig | None = None) -> None:
+        self.config = config or get_analog_config()
+        self._orig_matmul: callable | None = None
+
+    def matmul(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        if _HAS_ANALOG and hasattr(analogsim, "matmul"):
+            return analogsim.matmul(a, b, noise=self.config.noise)  # type: ignore
+        return a @ b
+
+    # --------------------------------------------------
+    def __enter__(self) -> "AnalogAccelerator":
+        """Monkey patch ``torch.matmul`` within this context."""
+        self._orig_matmul = torch.matmul
+        torch.matmul = self.matmul  # type: ignore
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._orig_matmul is not None:
+            torch.matmul = self._orig_matmul  # type: ignore
+            self._orig_matmul = None
+
+
+__all__ = [
+    "_HAS_ANALOG",
+    "AnalogConfig",
+    "configure_analog",
+    "get_analog_config",
+    "AnalogAccelerator",
+]
+

--- a/src/edge_rl_trainer.py
+++ b/src/edge_rl_trainer.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 from typing import Iterable, List, Tuple, Sequence
 
 import numpy as np
+from contextlib import nullcontext
 
 import torch
+from .analog_backend import AnalogAccelerator
 
 from .compute_budget_tracker import ComputeBudgetTracker
 from .adaptive_micro_batcher import AdaptiveMicroBatcher
@@ -24,6 +26,7 @@ class EdgeRLTrainer:
         *,
         use_loihi: bool = False,
         use_fpga: bool = False,
+        use_analog: bool = False,
     ) -> None:
         self.model = model
         self.opt = optimizer
@@ -33,7 +36,8 @@ class EdgeRLTrainer:
         self.bci_trainer = bci_trainer
         self.use_loihi = use_loihi
         self.use_fpga = use_fpga
-        self.power_usage: dict[str, float] = {"cpu": 0.0, "loihi": 0.0, "fpga": 0.0}
+        self.use_analog = use_analog
+        self.power_usage: dict[str, float] = {"cpu": 0.0, "loihi": 0.0, "fpga": 0.0, "analog": 0.0}
 
     def train(
         self,
@@ -50,20 +54,21 @@ class EdgeRLTrainer:
             batches = micro.micro_batches(data)
         else:
             batches = [[p] for p in data]
-
-        for batch in batches:
-            if self.budget.remaining(self.run_id) <= threshold:
-                break
-            states = torch.cat([s.unsqueeze(0) for s, _ in batch], dim=0)
-            targets = torch.cat([t.unsqueeze(0) for _, t in batch], dim=0)
-            pred = self.model(states)
-            loss = torch.nn.functional.mse_loss(pred, targets)
-            self.opt.zero_grad()
-            loss.backward()
-            self.opt.step()
-            steps += 1
-            if micro is not None:
-                micro.tick()
+        context = AnalogAccelerator() if self.use_analog else nullcontext()
+        with context:
+            for batch in batches:
+                if self.budget.remaining(self.run_id) <= threshold:
+                    break
+                states = torch.cat([s.unsqueeze(0) for s, _ in batch], dim=0)
+                targets = torch.cat([t.unsqueeze(0) for _, t in batch], dim=0)
+                pred = self.model(states)
+                loss = torch.nn.functional.mse_loss(pred, targets)
+                self.opt.zero_grad()
+                loss.backward()
+                self.opt.step()
+                steps += 1
+                if micro is not None:
+                    micro.tick()
 
         if micro is not None:
             micro.stop()
@@ -73,6 +78,8 @@ class EdgeRLTrainer:
             key = "loihi"
         elif self.use_fpga:
             key = "fpga"
+        elif self.use_analog:
+            key = "analog"
         else:
             key = "cpu"
         self.power_usage[key] += max(delta, 0.0)

--- a/src/multimodal_world_model.py
+++ b/src/multimodal_world_model.py
@@ -118,6 +118,7 @@ class MultiModalWorldModelConfig:
     use_spiking: bool = False
     use_loihi: bool = False
     use_fpga: bool = False
+    use_analog: bool = False
 
 
 class MultiModalWorldModel(nn.Module):

--- a/tests/test_analog_backend.py
+++ b/tests/test_analog_backend.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch
+import importlib
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import torch
+
+pkg = types.ModuleType('asi')
+sys_modules_backup = dict()
+for name in ['asi']:
+    sys_modules_backup[name] = __import__('sys').modules.get(name)
+__import__('sys').modules['asi'] = pkg
+loader = importlib.machinery.SourceFileLoader('asi.analog_backend', 'src/analog_backend.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+ab = importlib.util.module_from_spec(spec)
+ab.__package__ = 'asi'
+__import__('sys').modules['asi.analog_backend'] = ab
+loader.exec_module(ab)
+
+class TestAnalogBackend(unittest.TestCase):
+    def test_matmul_offload(self):
+        dummy = types.SimpleNamespace(matmul=lambda a, b, noise=0.0: a @ b + 1)
+        with patch.object(ab, '_HAS_ANALOG', True), patch.object(ab, 'analogsim', dummy):
+            accel = ab.AnalogAccelerator()
+            x = torch.eye(2)
+            y = torch.eye(2)
+            out = accel.matmul(x, y)
+            self.assertTrue(torch.allclose(out, dummy.matmul(x, y)))
+
+    def test_fallback_cpu(self):
+        x = torch.randn(2, 3)
+        y = torch.randn(3, 4)
+        accel = ab.AnalogAccelerator()
+        out = accel.matmul(x, y)
+        self.assertTrue(torch.allclose(out, x @ y))
+
+    def test_context_manager(self):
+        dummy = types.SimpleNamespace(matmul=lambda a, b, noise=0.0: a @ b + 1)
+        with patch.object(ab, '_HAS_ANALOG', True), patch.object(ab, 'analogsim', dummy):
+            accel = ab.AnalogAccelerator()
+            x = torch.eye(2)
+            y = torch.eye(2)
+            with accel:
+                out = torch.matmul(x, y)
+            self.assertTrue(torch.allclose(out, dummy.matmul(x, y)))
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_edge_rl_trainer.py
+++ b/tests/test_edge_rl_trainer.py
@@ -85,6 +85,31 @@ class TestEdgeRLTrainer(unittest.TestCase):
         trainer.train(data)
         self.assertGreater(trainer.power_usage["loihi"], 0)
 
+    def test_analog_logging(self):
+        class DummyLogger(TelemetryLogger):
+            def __init__(self):
+                super().__init__(interval=0.01)
+                self.vals = [0.0, 0.1]
+
+            def start(self):
+                pass
+
+            def stop(self):
+                pass
+
+            def get_stats(self):
+                v = self.vals.pop(0) if self.vals else 0.1
+                return {"energy_kwh": v}
+
+        logger = DummyLogger()
+        budget = ComputeBudgetTracker(float("inf"), telemetry=logger)
+        model = Toy()
+        opt = torch.optim.SGD(model.parameters(), lr=0.1)
+        trainer = EdgeRLTrainer(model, opt, budget, use_analog=True)
+        data = [(torch.zeros(1, 2), torch.zeros(1, 2))]
+        trainer.train(data)
+        self.assertGreater(trainer.power_usage["analog"], 0)
+
     def test_interactive_session(self):
         rl_cfg = mod.RLBridgeConfig(state_dim=2, action_dim=2, epochs=1, batch_size=2)
         bci = BCIFeedbackTrainer(rl_cfg)
@@ -101,3 +126,4 @@ class TestEdgeRLTrainer(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
## Summary
- support temporary monkey-patching of `torch.matmul` via `AnalogAccelerator`
- patch trainer loops with analog context when `use_analog=True`
- document analog usage and context manager
- update benchmark script to use patched `torch.matmul`
- test analog backend context manager

## Testing
- `python -m py_compile src/analog_backend.py src/edge_rl_trainer.py scripts/benchmark_analog.py tests/test_analog_backend.py tests/test_edge_rl_trainer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_686bedc3dbf4833180b5aa0a8a3a3119