### PR TITLE
Add normative reasoner enhancements

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -167,6 +167,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 - `src/chunkwise_retrainer.py` implements chunk-wise retraining on long transcripts.
 - `src/collective_constitution.py` aggregates crowd-sourced rules for **L-1**.
 - `src/deliberative_alignment.py` checks chain-of-thought steps for **L-2**.
+- `src/normative_reasoner.py` enforces configurable ethics rules for **L-2**. It
+  supports regular-expression rules and optional fuzzy matching to catch
+  near-miss violations.
 - `src/iter_align.py` runs a simple iterative alignment loop for **L-3**.
 - `src/critic_rlhf.py` provides a minimal critic-driven RLHF loop for **L-4**.
   See `docs/Implementation.md` and `docs/load_balance.md` for details.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,6 +10,7 @@ from .quantum_hpo import (
 )
 from .collective_constitution import CollectiveConstitution
 from .deliberative_alignment import DeliberativeAligner
+from .normative_reasoner import NormativeReasoner
 from .streaming_compression import ReservoirBuffer, StreamingCompressor
 from .hierarchical_memory import (
     HierarchicalMemory,

--- a/src/alignment_dashboard.py
+++ b/src/alignment_dashboard.py
@@ -13,18 +13,26 @@ class AlignmentDashboard:
         self.total = 0
         self.passed = 0
         self.flagged: list[str] = []
+        self.normative: list[str] = []
         self.httpd: HTTPServer | None = None
         self.thread: threading.Thread | None = None
         self.port: int | None = None
 
     # --------------------------------------------------------------
-    def record(self, passed: bool, flagged: Iterable[str] | None = None) -> None:
+    def record(
+        self,
+        passed: bool,
+        flagged: Iterable[str] | None = None,
+        normative: Iterable[str] | None = None,
+    ) -> None:
         """Record a single alignment check result."""
         self.total += 1
         if passed:
             self.passed += 1
         if flagged:
             self.flagged.extend([str(f) for f in flagged])
+        if normative:
+            self.normative.extend([str(n) for n in normative])
 
     # --------------------------------------------------------------
     def aggregate(self) -> Dict[str, Any]:
@@ -34,6 +42,7 @@ class AlignmentDashboard:
             "passed": float(self.passed),
             "pass_rate": float(rate),
             "flagged_examples": list(self.flagged[-10:]),
+            "normative_violations": list(self.normative[-10:]),
         }
 
     # --------------------------------------------------------------

--- a/src/deliberative_alignment.py
+++ b/src/deliberative_alignment.py
@@ -1,26 +1,44 @@
 import re
 from typing import Iterable, List
 
+from .normative_reasoner import NormativeReasoner
+
 
 class DeliberativeAligner:
     """Minimal chain-of-thought policy checker for Plan.md L-2."""
 
-    def __init__(self, policy_text: str) -> None:
+    def __init__(self, policy_text: str, normative_rules: Iterable[str] | None = None) -> None:
         raw_rules = [r.strip().lower() for r in policy_text.splitlines() if r.strip()]
         self.rules: List[str] = []
         for r in raw_rules:
             if r.startswith("no "):
                 r = r[3:]
             self.rules.append(r)
+        self.normative = NormativeReasoner(normative_rules)
 
     def check(self, steps: Iterable[str]) -> bool:
         """Return ``True`` if every reasoning step complies with the policy."""
+        ok, _ = self.normative.check(steps)
+        if not ok:
+            return False
         for step in steps:
             lower = step.lower()
             for rule in self.rules:
                 if rule and re.search(re.escape(rule), lower):
                     return False
         return True
+
+    def check_report(self, steps: Iterable[str]) -> tuple[bool, list[str]]:
+        """Return ``(passed, normative_flagged)`` for ``steps``."""
+        ok, flagged = self.normative.check(steps)
+        if not ok:
+            return False, flagged
+        for step in steps:
+            lower = step.lower()
+            for rule in self.rules:
+                if rule and re.search(re.escape(rule), lower):
+                    return False, []
+        return True, []
 
     def analyze(self, text: str) -> bool:
         """Split ``text`` into lines and check them sequentially."""

--- a/src/normative_reasoner.py
+++ b/src/normative_reasoner.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import re
+from difflib import SequenceMatcher
+from typing import Iterable, List, Tuple
+
+
+class NormativeReasoner:
+    """Validate reasoning steps against configurable ethics rules.
+
+    Parameters
+    ----------
+    rules:
+        Sequence of rules expressed as plain text or regular expressions.
+    use_regex:
+        Treat each rule as a raw regular expression instead of escaping it.
+    fuzzy_threshold:
+        When set, apply fuzzy matching using :class:`difflib.SequenceMatcher` and
+        flag any step with a similarity ratio greater than or equal to this
+        threshold.  Values are in ``[0.0, 1.0]``.
+    """
+
+    def __init__(
+        self,
+        rules: Iterable[str] | None = None,
+        *,
+        use_regex: bool = False,
+        fuzzy_threshold: float | None = None,
+    ) -> None:
+        cleaned: List[tuple[str, re.Pattern]] = []
+        for r in (rules or []):
+            raw = r.strip()
+            if raw.lower().startswith("no "):
+                raw = raw[3:]
+            if not raw:
+                continue
+            pattern_text = raw if use_regex else re.escape(raw)
+            cleaned.append((raw, re.compile(pattern_text, re.IGNORECASE)))
+
+        self.rules = cleaned
+        self.use_regex = use_regex
+        self.fuzzy_threshold = fuzzy_threshold
+
+    def check(self, steps: Iterable[str]) -> Tuple[bool, List[str]]:
+        """Return ``(passed, flagged)`` for ``steps``."""
+        flagged: List[str] = []
+        for step in steps:
+            for raw, pattern in self.rules:
+                if pattern.search(step):
+                    flagged.append(step)
+                    break
+                if self.fuzzy_threshold is not None:
+                    ratio = SequenceMatcher(None, raw.lower(), step.lower()).ratio()
+                    if ratio >= self.fuzzy_threshold:
+                        flagged.append(step)
+                        break
+        return (not flagged, flagged)
+
+    def analyze(self, text: str) -> Tuple[bool, List[str]]:
+        """Split ``text`` and check each line."""
+        steps = [s.strip() for s in text.splitlines() if s.strip()]
+        return self.check(steps)
+
+
+__all__ = ["NormativeReasoner"]

--- a/tests/test_alignment_dashboard.py
+++ b/tests/test_alignment_dashboard.py
@@ -25,7 +25,7 @@ AlignmentDashboard = _load('asi.alignment_dashboard', 'src/alignment_dashboard.p
 class TestAlignmentDashboard(unittest.TestCase):
     def test_server_and_record(self):
         dash = AlignmentDashboard()
-        dash.record(True, ["ok"])
+        dash.record(True, ["ok"], ["bad"])
         dash.start(port=0)
         port = dash.port
         conn = http.client.HTTPConnection("localhost", port)
@@ -33,6 +33,7 @@ class TestAlignmentDashboard(unittest.TestCase):
         data = json.loads(conn.getresponse().read())
         self.assertIn("pass_rate", data)
         self.assertEqual(data["flagged_examples"], ["ok"])
+        self.assertEqual(data["normative_violations"], ["bad"])
         dash.stop()
 
 

--- a/tests/test_deliberative_alignment.py
+++ b/tests/test_deliberative_alignment.py
@@ -1,6 +1,24 @@
 import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
 
-from asi.deliberative_alignment import DeliberativeAligner
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+DeliberativeAligner = _load('asi.deliberative_alignment', 'src/deliberative_alignment.py').DeliberativeAligner
 
 
 class TestDeliberativeAligner(unittest.TestCase):
@@ -11,6 +29,16 @@ class TestDeliberativeAligner(unittest.TestCase):
         self.assertFalse(aligner.check(["begin hacking sequence", "all good"]))
         text = "first step\ncommit violence"
         self.assertFalse(aligner.analyze(text))
+
+    def test_normative_rules(self):
+        aligner = DeliberativeAligner("", normative_rules=["no theft"])
+        self.assertFalse(aligner.check(["plan theft"]))
+
+    def test_check_report(self):
+        aligner = DeliberativeAligner("no hacking", normative_rules=["no theft"])
+        ok, flagged = aligner.check_report(["plan theft", "hack time"])
+        self.assertFalse(ok)
+        self.assertEqual(flagged, ["plan theft"])
 
 
 if __name__ == '__main__':

--- a/tests/test_normative_reasoner.py
+++ b/tests/test_normative_reasoner.py
@@ -1,0 +1,42 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+NormativeReasoner = _load('asi.normative_reasoner', 'src/normative_reasoner.py').NormativeReasoner
+
+
+def test_normative_reasoner_check():
+    nr = NormativeReasoner(["no theft", "no harm"])
+    steps = ["say hello", "plan theft"]
+    ok, flagged = nr.check(steps)
+    assert not ok
+    assert flagged == ["plan theft"]
+
+
+def test_normative_reasoner_regex():
+    nr = NormativeReasoner([r"plan\s+theft"], use_regex=True)
+    ok, flagged = nr.check(["ok", "plan    theft"])
+    assert not ok
+    assert flagged == ["plan    theft"]
+
+
+def test_normative_reasoner_fuzzy():
+    nr = NormativeReasoner(["theft"], fuzzy_threshold=0.8)
+    ok, flagged = nr.check(["thieft"])  # misspelled
+    assert not ok
+    assert flagged == ["thieft"]


### PR DESCRIPTION
## Summary
- enhance `NormativeReasoner` with regex and optional fuzzy matching
- add `check_report` method to `DeliberativeAligner`
- document new capabilities in Plan.md
- expand unit tests for normative reasoning

## Testing
- `pytest tests/test_normative_reasoner.py tests/test_deliberative_alignment.py tests/test_alignment_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686bedc9ad9483318df0738a097dfc93