### PR TITLE
Add code refine pipeline

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -56,6 +56,7 @@ Citations point to the most recent public work so you can drill straight into th
 
 `SemanticDriftDetector` monitors predictions between checkpoints by computing KL divergence of output distributions. Call it from `WorldModelDebugger.check()` to flag unexpected behaviour changes before patching.
 - **Automated documentation**: run `python -m asi.doc_summarizer <module>` to keep module summaries under `docs/autodoc/` up to date.
+- **Code refinement pipeline**: run `scripts/code_refine.py <file>` to clean up LLM-generated Python before committing. The tool adds `Any` type hints, fixes `None`/`bool` comparisons and ensures future annotations.
 
 - **Reasoning graph merger**: `reasoning_merger.merge_graphs()` deduplicates nodes across agents and aligns timestamps. The `MultiAgentDashboard` now displays the merged trace.
 

--- a/scripts/code_refine.py
+++ b/scripts/code_refine.py
@@ -1,0 +1,31 @@
+"""CLI for ``CodeRefinePipeline``."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from asi.code_refine import CodeRefinePipeline
+
+
+def main() -> None:  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser(description="Refine generated Python code")
+    parser.add_argument("path", nargs="+", help="Python files to refine")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print refined code without modifying files",
+    )
+    args = parser.parse_args()
+
+    for path in args.path:
+        file = Path(path)
+        source = file.read_text()
+        refined = CodeRefinePipeline().refine(source)
+        if not args.dry_run:
+            file.write_text(refined)
+        print(refined)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -38,6 +38,7 @@ from .critic_rlhf import CriticScorer, CriticRLHFTrainer
 from .chunkwise_retrainer import ChunkWiseRetrainer
 from .secure_dataset_exchange import SecureDatasetExchange
 from .p2p_dataset_exchange import P2PDatasetExchange
+from .code_refine import CodeRefinePipeline
 from .self_healing_trainer import SelfHealingTrainer
 from .scaling_law import BreakpointScalingLaw
 from .link_slot_attention import LinkSlotAttention

--- a/src/code_refine.py
+++ b/src/code_refine.py
@@ -1,0 +1,107 @@
+"""Refine LLM-generated Python source via small AST transforms."""
+
+from __future__ import annotations
+
+import ast
+from typing import Any
+
+
+class CodeRefinePipeline:
+    """Apply minimal AST-level fixes to generated Python."""
+
+    def refine(self, source: str) -> str:
+        """Return refined ``source`` after applying transformations."""
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            return source
+        self._ensure_future_import(tree)
+        add_any = self._annotate_functions(tree)
+        self._fix_none_comparisons(tree)
+        self._fix_bool_comparisons(tree)
+        if add_any:
+            self._ensure_import(tree, "typing", ["Any"])
+        try:
+            refined = ast.unparse(tree)
+        except Exception:
+            return source
+        return refined.strip() + "\n"
+
+    # -----------------------------------------------------
+    def _annotate_functions(self, tree: ast.AST) -> bool:
+        add_any = False
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                all_args = (
+                    node.args.posonlyargs
+                    + node.args.args
+                    + node.args.kwonlyargs
+                )
+                if node.args.vararg:
+                    all_args.append(node.args.vararg)
+                if node.args.kwarg:
+                    all_args.append(node.args.kwarg)
+                for arg in all_args:
+                    if arg.annotation is None:
+                        arg.annotation = ast.Name(id="Any", ctx=ast.Load())
+                        add_any = True
+                if node.returns is None:
+                    node.returns = ast.Name(id="Any", ctx=ast.Load())
+                    add_any = True
+        return add_any
+
+    # -----------------------------------------------------
+    def _fix_none_comparisons(self, tree: ast.AST) -> None:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Compare):
+                # handle ``x == None`` and ``x != None``
+                for i, (op, cmp) in enumerate(zip(node.ops, node.comparators)):
+                    if isinstance(cmp, ast.Constant) and cmp.value is None:
+                        if isinstance(op, ast.Eq):
+                            node.ops[i] = ast.Is()
+                        elif isinstance(op, ast.NotEq):
+                            node.ops[i] = ast.IsNot()
+                # handle ``None == x`` and ``None != x``
+                if isinstance(node.left, ast.Constant) and node.left.value is None:
+                    op = node.ops[0]
+                    if isinstance(op, ast.Eq):
+                        node.ops[0] = ast.Is()
+                    elif isinstance(op, ast.NotEq):
+                        node.ops[0] = ast.IsNot()
+                    node.left, node.comparators[0] = node.comparators[0], node.left
+
+    # -----------------------------------------------------
+    def _fix_bool_comparisons(self, tree: ast.AST) -> None:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Compare):
+                for i, (op, cmp) in enumerate(zip(node.ops, node.comparators)):
+                    if isinstance(cmp, ast.Constant) and isinstance(cmp.value, bool):
+                        if isinstance(op, ast.Eq):
+                            node.ops[i] = ast.Is()
+                        elif isinstance(op, ast.NotEq):
+                            node.ops[i] = ast.IsNot()
+
+    # -----------------------------------------------------
+    def _ensure_import(self, tree: ast.Module, module: str, names: list[str]) -> None:
+        for stmt in tree.body:
+            if isinstance(stmt, ast.ImportFrom) and stmt.module == module:
+                existing = {n.name for n in stmt.names}
+                for name in names:
+                    if name not in existing:
+                        stmt.names.append(ast.alias(name=name, asname=None))
+                return
+        tree.body.insert(
+            0,
+            ast.ImportFrom(module=module, names=[ast.alias(name=n, asname=None) for n in names], level=0),
+        )
+
+    # -----------------------------------------------------
+    def _ensure_future_import(self, tree: ast.Module) -> None:
+        for stmt in tree.body:
+            if isinstance(stmt, ast.ImportFrom) and stmt.module == "__future__":
+                if any(n.name == "annotations" for n in stmt.names):
+                    return
+        tree.body.insert(
+            0,
+            ast.ImportFrom(module="__future__", names=[ast.alias(name="annotations", asname=None)], level=0),
+        )

--- a/tests/test_code_refine.py
+++ b/tests/test_code_refine.py
@@ -1,0 +1,70 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import runpy
+import sys
+from pathlib import Path
+
+loader = importlib.machinery.SourceFileLoader('asi.code_refine', 'src/code_refine.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mod
+loader.exec_module(mod)
+CodeRefinePipeline = mod.CodeRefinePipeline
+
+
+class TestCodeRefinePipeline(unittest.TestCase):
+    def test_refine_basic(self):
+        src = 'def foo(a,b):\n    if a == None:\n        return b\n'
+        refined = CodeRefinePipeline().refine(src)
+        self.assertIn('from __future__ import annotations', refined)
+        self.assertIn('from typing import Any', refined)
+        self.assertIn('a: Any', refined)
+        self.assertIn('b: Any', refined)
+        self.assertIn('a is None', refined)
+        self.assertNotIn('== None', refined)
+
+    def test_refine_extended(self):
+        src = (
+            'async def bar(*args, **kwargs):\n'
+            '    if None == kwargs.get("x") or kwargs.get("y") == True:\n'
+            '        return args\n'
+        )
+        refined = CodeRefinePipeline().refine(src)
+        self.assertIn('*args: Any', refined)
+        self.assertIn('**kwargs: Any', refined)
+        self.assertIn("kwargs.get('x') is None", refined)
+        self.assertIn("kwargs.get('y') is True", refined)
+
+    def test_cli_dry_run_and_write(self):
+        tmp = Path(self.tmpdir)
+        f = tmp / 'temp.py'
+        f.write_text('def foo():\n    return True == False\n')
+
+        self._run_cli([str(f), '--dry-run'])
+        self.assertIn('True == False', f.read_text())
+
+        self._run_cli([str(f)])
+        self.assertIn('True is False', f.read_text())
+
+    def _run_cli(self, argv):
+        saved = sys.argv
+        sys.argv = ['code_refine.py'] + argv
+        try:
+            runpy.run_path('scripts/code_refine.py', run_name='__main__')
+        finally:
+            sys.argv = saved
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `CodeRefinePipeline` for AST-based cleanup of generated Python
- provide `scripts/code_refine.py` CLI to run the pipeline
- cover the feature with unit tests
- document code refinement in the self‑improvement section of `docs/Plan.md`

## Testing
- `pytest tests/test_code_refine.py -q`
- `pytest -q` *(fails: ModuleNotFoundError for optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_686bedddffc08331af8f5916d4aab03e