### PR TITLE
Add multilingual self reflection translator

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -706,6 +706,14 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Implement a `ContextSummaryMemory` that replaces far-past vectors with text summaries and re-expands them when retrieved. Unit test `tests/test_context_summary_memory.py` verifies summarization and expansion.
   **Implemented in `src/context_summary_memory.py` with tests.**
 - Extend `ContextSummaryMemory` with a `translator` argument so summaries are stored in multiple languages and returned in the query language. Tested in `tests/test_cross_lingual_summary_memory.py`.
+- Add a `ReasoningSummaryTranslator` that clusters reasoning steps via `ReasoningHistoryLogger.analyze()` and translates the final report using `CrossLingualTranslator`. `self_reflection.main()` now prints these multilingual summaries. Example output:
+  ```bash
+  $ python -m asi.self_reflection history.json
+  Reasoning step clusters:
+  - start: 1
+  Translations:
+  - [es] Reasoning step clusters:\n- start: 1
+  ```
 - Extend `analogical_retrieval.analogy_search` with a `language` argument and update `HierarchicalMemory.search(mode="analogy")` so `ContextSummaryMemory` can return translated vectors. Tested in `tests/test_cross_lingual_analogy.py`.
 - Implement a `KnowledgeGraphMemory` that stores `(subject, predicate, object)` triples and hooks into `HierarchicalMemory` via `use_kg=True`. Unit tests cover insertion and retrieval.
   **Implemented in `src/knowledge_graph_memory.py` with `tests/test_knowledge_graph_memory.py`.**

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -312,4 +312,5 @@ from .fpga_backend import (
 from .emotion_detector import detect_emotion
 from .bio_memory_replay import run_nightly_replay
 from .sign_language import SignLanguageRecognizer
+from .reasoning_summary_translator import ReasoningSummaryTranslator
 

--- a/src/reasoning_summary_translator.py
+++ b/src/reasoning_summary_translator.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .data_ingest import CrossLingualTranslator
+from .reasoning_history import ReasoningHistoryLogger
+
+
+class ReasoningSummaryTranslator:
+    """Summarize reasoning histories and translate the summary."""
+
+    def __init__(self, translator: CrossLingualTranslator) -> None:
+        self.translator = translator
+
+    # --------------------------------------------------------------
+    def summarize(self, logger: ReasoningHistoryLogger) -> Dict[str, object]:
+        """Return cluster summary and translations."""
+        results = logger.analyze()
+        lines = ["Reasoning step clusters:"]
+        for step, count in sorted(
+            results.clusters.items(), key=lambda x: (-x[1], x[0])
+        ):
+            lines.append(f"- {step}: {count}")
+        if results.inconsistencies:
+            lines.append("Inconsistencies:")
+            for a, b in results.inconsistencies:
+                lines.append(f"- {a} vs {b}")
+        summary = "\n".join(lines)
+        return {
+            "summary": summary,
+            "translations": self.translator.translate_all(summary),
+        }
+
+
+__all__ = ["ReasoningSummaryTranslator"]

--- a/src/self_reflection.py
+++ b/src/self_reflection.py
@@ -23,6 +23,28 @@ def main(argv: Sequence[str] | None = None) -> None:
         lines.append("Inconsistencies:")
         for a, b in analysis.inconsistencies:
             lines.append(f"- {a} vs {b}")
+
+    languages: set[str] = set()
+    for _ts, entry in logger.get_history():
+        if isinstance(entry, dict):
+            languages.update(entry.get("translations", {}).keys())
+
+    translations: dict[str, str] = {}
+    if languages:
+        from .data_ingest import CrossLingualTranslator
+        from .reasoning_summary_translator import ReasoningSummaryTranslator
+
+        translator = CrossLingualTranslator(sorted(languages))
+        rst = ReasoningSummaryTranslator(translator)
+        info = rst.summarize(logger)
+        lines = info["summary"].split("\n")
+        translations = info["translations"]
+
+    if translations:
+        lines.append("Translations:")
+        for lang, txt in translations.items():
+            lines.append(f"- [{lang}] {txt}")
+
     print("\n".join(lines))
 
 

--- a/tests/test_self_reflection_translation.py
+++ b/tests/test_self_reflection_translation.py
@@ -5,9 +5,23 @@ import sys
 import tempfile
 import unittest
 import types
-import json
+from pathlib import Path
 
-from asi.reasoning_history import ReasoningHistoryLogger
+import importlib.machinery
+import importlib.util
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+loader_rh = importlib.machinery.SourceFileLoader(
+    'asi.reasoning_history', 'src/reasoning_history.py'
+)
+spec_rh = importlib.util.spec_from_loader(loader_rh.name, loader_rh)
+rh_mod = importlib.util.module_from_spec(spec_rh)
+rh_mod.__package__ = 'asi'
+sys.modules['asi.reasoning_history'] = rh_mod
+loader_rh.exec_module(rh_mod)
+ReasoningHistoryLogger = rh_mod.ReasoningHistoryLogger
 
 
 class CrossLingualTranslator:
@@ -27,6 +41,16 @@ dummy = types.ModuleType('asi.data_ingest')
 dummy.CrossLingualTranslator = CrossLingualTranslator
 sys.modules['asi.data_ingest'] = dummy
 
+loader = importlib.machinery.SourceFileLoader(
+    'asi.reasoning_summary_translator', 'src/reasoning_summary_translator.py'
+)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+rst_mod = importlib.util.module_from_spec(spec)
+rst_mod.__package__ = 'asi'
+sys.modules['asi.reasoning_summary_translator'] = rst_mod
+loader.exec_module(rst_mod)
+ReasoningSummaryTranslator = rst_mod.ReasoningSummaryTranslator
+
 
 class TestHistoryTranslation(unittest.TestCase):
     def test_logger_translates(self):
@@ -38,24 +62,67 @@ class TestHistoryTranslation(unittest.TestCase):
         self.assertEqual(entries[0][1]["translations"]["es"], "[es] start -> end")
 
 
+class TestSummaryTranslator(unittest.TestCase):
+    def test_summary_translation(self):
+        logger = ReasoningHistoryLogger()
+        logger.log("start -> end")
+        tr = CrossLingualTranslator(["es"])
+        st = ReasoningSummaryTranslator(tr)
+        info = st.summarize(logger)
+        self.assertIn("start", info["summary"])
+        self.assertTrue(info["translations"]["es"].startswith("[es]"))
+
+
 class TestSelfReflectionCLITranslations(unittest.TestCase):
     def test_cli_with_translations(self):
         tr = CrossLingualTranslator(["es"])
         logger = ReasoningHistoryLogger(translator=tr)
         logger.log("start -> not start")
-        with tempfile.NamedTemporaryFile("w", delete=False) as f:
-            json.dump(logger.entries, f)
-            fname = f.name
-        try:
-            proc = subprocess.run(
-                [sys.executable, "-m", "asi.self_reflection", fname],
-                capture_output=True,
-                text=True,
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg = Path(tmpdir) / "asi"
+            pkg.mkdir()
+            repo = Path('.').resolve()
+            (pkg / "__init__.py").write_text(
+                "import sys\n"
+                f"sys.path.append('{repo}')\n"
+                f"__path__.append('{(repo / 'src').as_posix()}')\n"
             )
-            self.assertEqual(proc.returncode, 0)
-            self.assertIn("Inconsistencies", proc.stdout)
-        finally:
-            os.unlink(fname)
+            (pkg / "data_ingest.py").write_text(
+                "class CrossLingualTranslator:\n"
+                "    def __init__(self, languages):\n"
+                "        self.languages = list(languages)\n"
+                "    def translate(self, text, lang):\n"
+                "        return f'[{lang}] {text}'\n"
+                "    def translate_all(self, text):\n"
+                "        return {l: self.translate(text, l) for l in self.languages}\n"
+            )
+            np_pkg = Path(tmpdir) / "numpy"
+            np_pkg.mkdir()
+            (np_pkg / "__init__.py").write_text("")
+
+            with tempfile.NamedTemporaryFile("w", delete=False) as f:
+                json.dump(logger.entries, f)
+                fname = f.name
+            env = os.environ.copy()
+            env["PYTHONPATH"] = f"{tmpdir}:{Path('.').resolve()}"
+            try:
+                proc = subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        "from asi.self_reflection import main; main([\"%s\"])"
+                        % fname,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                    cwd=tmpdir,
+                )
+                self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+                self.assertIn("Inconsistencies", proc.stdout)
+                self.assertIn("[es]", proc.stdout)
+            finally:
+                os.unlink(fname)
 
 
 if __name__ == "__main__":  # pragma: no cover - test helper


### PR DESCRIPTION
## Summary
- implement `ReasoningSummaryTranslator` for summarising and translating reasoning histories
- integrate translator with self reflection reporting
- expand translation tests with lightweight package stubs
- refine sorting of summary clusters

## Testing
- `pytest tests/test_self_reflection_translation.py -q`
- `python -m unittest tests.test_self_reflection_translation -v`


------
https://chatgpt.com/codex/tasks/task_e_686bee1221d8833187bfd9cd7129abee