### PR TITLE
Implement dataset watermarking

### DIFF
--- a/src/dataset_lineage_dashboard.py
+++ b/src/dataset_lineage_dashboard.py
@@ -38,7 +38,8 @@ class DatasetLineageDashboard:
             if out and out not in s.outputs:
                 continue
             if query:
-                hay = " ".join([s.note] + s.inputs + list(s.outputs.keys()) + list(s.outputs.values()))
+                vals = [str(v) for v in s.outputs.values()]
+                hay = " ".join([s.note] + s.inputs + list(s.outputs.keys()) + vals)
                 if query not in hay:
                     continue
             results.append(s)

--- a/src/dataset_watermarker.py
+++ b/src/dataset_watermarker.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image, PngImagePlugin, UnidentifiedImageError
+
+
+_TEXT_RE = re.compile(r"<WATERMARK:(.+?)>")
+
+
+def add_watermark(path: str | Path, wm_id: str) -> None:
+    """Embed ``wm_id`` into the file at ``path`` based on extension."""
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix in {".txt", ".json", ".csv"}:
+        text = p.read_text()
+        if not text.endswith("\n"):
+            text += "\n"
+        text += f"<WATERMARK:{wm_id}>"
+        p.write_text(text)
+    elif suffix in {".png", ".jpg", ".jpeg"}:
+        try:
+            with Image.open(p) as img:
+                info = PngImagePlugin.PngInfo()
+                for k, v in img.info.items():
+                    try:
+                        info.add_text(k, str(v))
+                    except Exception:
+                        pass
+                info.add_text("watermark", wm_id)
+                img.save(p, pnginfo=info)
+        except Exception:
+            return
+    elif suffix in {".wav"}:
+        with open(p, "ab") as f:
+            f.write(b"#WM:" + wm_id.encode() + b"\n")
+    else:
+        raise ValueError(f"Unsupported file type: {suffix}")
+
+
+def detect_watermark(path: str | Path) -> Optional[str]:
+    """Return the watermark ID embedded in ``path`` if present."""
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix in {".txt", ".json", ".csv"}:
+        m = _TEXT_RE.search(p.read_text())
+        return m.group(1) if m else None
+    elif suffix in {".png", ".jpg", ".jpeg"}:
+        try:
+            with Image.open(p) as img:
+                return img.info.get("watermark")
+        except Exception:
+            return None
+    elif suffix in {".wav"}:
+        data = p.read_bytes()
+        idx = data.rfind(b"#WM:")
+        if idx != -1:
+            end = data.find(b"\n", idx)
+            if end == -1:
+                end = len(data)
+            return data[idx + 4 : end].decode()
+        return None
+    else:
+        raise ValueError(f"Unsupported file type: {suffix}")
+
+
+__all__ = ["add_watermark", "detect_watermark"]

--- a/tests/test_dataset_lineage_manager.py
+++ b/tests/test_dataset_lineage_manager.py
@@ -36,6 +36,9 @@ class TestDatasetLineageManager(unittest.TestCase):
             self.assertEqual(data[0]["note"], "step1")
             self.assertEqual(data[0]["inputs"], [str(inp)])
             self.assertIn(str(outp), data[0]["outputs"])
+            entry = data[0]["outputs"][str(outp)]
+            self.assertIn("hash", entry)
+            self.assertIn("watermark_id", entry)
             steps = mgr.load()
             self.assertEqual(len(steps), 1)
             self.assertEqual(steps[0].note, "step1")

--- a/tests/test_dataset_watermarker.py
+++ b/tests/test_dataset_watermarker.py
@@ -1,0 +1,52 @@
+import tempfile
+import unittest
+from pathlib import Path
+import importlib.machinery
+import importlib.util
+import sys
+import types
+
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+src_pkg.__path__ = ['src']
+src_pkg.__spec__ = importlib.machinery.ModuleSpec('src', None, is_package=True)
+loader = importlib.machinery.SourceFileLoader('src.dataset_watermarker', 'src/dataset_watermarker.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+wm_mod = importlib.util.module_from_spec(spec)
+wm_mod.__package__ = 'src'
+sys.modules['src.dataset_watermarker'] = wm_mod
+loader.exec_module(wm_mod)
+add_watermark = wm_mod.add_watermark
+detect_watermark = wm_mod.detect_watermark
+
+from PIL import Image
+import numpy as np
+import wave
+
+
+class TestDatasetWatermarker(unittest.TestCase):
+    def test_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            txt = root / 't.txt'
+            txt.write_text('hello')
+            add_watermark(txt, 'id1')
+            self.assertEqual(detect_watermark(txt), 'id1')
+
+            img_path = root / 'i.png'
+            Image.fromarray(np.zeros((2, 2, 3), dtype=np.uint8)).save(img_path)
+            add_watermark(img_path, 'id2')
+            self.assertEqual(detect_watermark(img_path), 'id2')
+
+            aud_path = root / 'a.wav'
+            with wave.open(str(aud_path), 'wb') as w:
+                w.setnchannels(1)
+                w.setsampwidth(2)
+                w.setframerate(16000)
+                w.writeframes(np.zeros(10, dtype=np.int16).tobytes())
+            add_watermark(aud_path, 'id3')
+            self.assertEqual(detect_watermark(aud_path), 'id3')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add dataset watermarking utilities for text, image and audio files
- store optional CarbonFootprintTracker stub when psutil isn't available
- ensure image files are closed in `dataset_watermarker`
- record watermark IDs in lineage manager
- update search in lineage dashboard to include watermark info

## Testing
- `python -m unittest tests.test_data_ingest tests.test_dataset_lineage_manager tests.test_dataset_watermarker -v`


------
https://chatgpt.com/codex/tasks/task_e_686bee1cb0d08331998a8af8f6456328