### PR TITLE
Implement cross-lingual graph summaries

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -695,7 +695,10 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
 - Extend `CrossLingualReasoningGraph` with `summarize_old_steps()` which calls
   `ContextSummaryMemory` when traces grow beyond a threshold. Translated
   summaries are stored via `CrossLingualTranslator.translate_all` and can be
-  returned during planning through `GraphOfThought.plan_refactor(summary_memory=)`.
+  returned during planning through `GraphOfThought.plan_refactor(summary_memory)`.
+  `query_summary()` retrieves these summaries in any supported language and
+  `ReasoningHistoryLogger.log()` records which node ids were summarised along
+  with the memory location for later inspection.
 - Create a `WorldModelDistiller` module and a `scripts/distill_world_model.py`
   utility to train smaller student models from the large world model.
   **Implemented in `src/world_model_distiller.py` with the script

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -422,9 +422,11 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
      in the source language and translated forms. Results are translated back
      to the query language. See `docs/Implementation.md` for details.
 41b. **Cross-lingual reasoning graph**: `CrossLingualReasoningGraph` stores reasoning
-     steps with language tags. `GraphOfThoughtPlanner` can record ranked plans so
-     they are retrievable in multiple languages. Evaluate by confirming the same
-     plan is found in at least two languages.
+    steps with language tags. `GraphOfThoughtPlanner` can record ranked plans so
+    they are retrievable in multiple languages. Old steps are summarised into
+    `ContextSummaryMemory` with translations so `query_summary()` can return the
+    compressed trace in any language. Evaluate by confirming the same plan is
+    found in at least two languages.
 41c. **Multimodal reasoning graph**: `CrossLingualReasoningGraph.add_step()`
      accepts `image_embed` and `audio_embed`. Use `embed_modalities()` from
      `CrossModalFusion` to generate vectors. `ReasoningHistoryLogger` preserves

--- a/src/hierarchical_memory.py
+++ b/src/hierarchical_memory.py
@@ -558,8 +558,13 @@ class HierarchicalMemory:
                 out_meta = [out_meta[i] for i in order]
                 scores = [scores[i] for i in order]
         for m in out_meta:
-            if m in self._usage:
-                self._usage[m] += 1
+            try:
+                if m in self._usage:
+                    self._usage[m] += 1
+                else:
+                    self._usage[m] = 1
+            except TypeError:
+                pass
         self.hit_count += 1
         self.query_count += 1
         if (

--- a/src/reasoning_history.py
+++ b/src/reasoning_history.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Tuple, TYPE_CHECKING, Sequence
 import json
 from collections import Counter
 
@@ -17,10 +17,20 @@ class ReasoningHistoryLogger:
     entries: List[Tuple[str, Any]] = field(default_factory=list)
     translator: CrossLingualTranslator | None = None
 
-    def log(self, summary: str | Dict[str, Any]) -> None:
+    def log(
+        self,
+        summary: str | Dict[str, Any],
+        *,
+        nodes: Sequence[int] | None = None,
+        location: Any | None = None,
+    ) -> None:
         ts = datetime.utcnow().isoformat()
         if isinstance(summary, dict):
             entry = dict(summary)
+            if nodes is not None:
+                entry["nodes"] = list(nodes)
+            if location is not None:
+                entry["location"] = location
             if self.translator is not None and "translations" not in entry and "summary" in entry:
                 entry["translations"] = self.translator.translate_all(entry["summary"])
             if "image_vec" in entry and hasattr(entry["image_vec"], "tolist"):
@@ -34,6 +44,10 @@ class ReasoningHistoryLogger:
                     "summary": summary,
                     "translations": self.translator.translate_all(summary),
                 }
+                if nodes is not None:
+                    entry["nodes"] = list(nodes)
+                if location is not None:
+                    entry["location"] = location
                 self.entries.append((ts, entry))
             else:
                 self.entries.append((ts, summary))

--- a/tests/test_crosslingual_graph_summary.py
+++ b/tests/test_crosslingual_graph_summary.py
@@ -1,0 +1,74 @@
+import importlib.util
+import importlib.machinery
+import types
+import sys
+import unittest
+
+try:
+    import torch
+except Exception:  # pragma: no cover - torch optional
+    raise unittest.SkipTest("torch not available")
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+pkg.__path__ = ['src']
+
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+cs = load('asi.context_summary_memory', 'src/context_summary_memory.py')
+di = load('asi.data_ingest', 'src/data_ingest.py')
+cg = load('asi.cross_lingual_graph', 'src/cross_lingual_graph.py')
+rh = load('asi.reasoning_history', 'src/reasoning_history.py')
+
+ContextSummaryMemory = cs.ContextSummaryMemory
+CrossLingualTranslator = di.CrossLingualTranslator
+CrossLingualReasoningGraph = cg.CrossLingualReasoningGraph
+ReasoningHistoryLogger = rh.ReasoningHistoryLogger
+
+
+class DummySummarizer:
+    def summarize(self, text):
+        return 'sum'
+
+    def expand(self, text):
+        return torch.ones(2)
+
+
+class TestCrossLingualGraphSummary(unittest.TestCase):
+    def test_query_summary_translations(self):
+        tr = CrossLingualTranslator(['es', 'fr'])
+        mem = ContextSummaryMemory(
+            dim=2,
+            compressed_dim=1,
+            capacity=4,
+            summarizer=DummySummarizer(),
+            translator=tr,
+            encryption_key=b'0'*16,
+        )
+        logger = ReasoningHistoryLogger(translator=tr)
+        g = CrossLingualReasoningGraph(translator=tr, logger=logger)
+        ids = [g.add_step(f's{i}') for i in range(4)]
+        new = g.summarize_old_steps(ids, mem, threshold=2)
+        self.assertEqual(len(new), 3)
+        vec = mem.summarizer.expand('sum')
+        _v, meta = mem.search(vec, k=1, language='fr')
+        self.assertTrue(meta and meta[0].startswith('[fr]'))
+        summary = g.query_summary([new[0]], mem, lang='es')
+        self.assertEqual(summary, '[es] sum')
+        self.assertTrue(logger.entries)
+        entry = logger.entries[0][1]
+        self.assertIn('nodes', entry)
+        self.assertIn('location', entry)
+
+
+if __name__ == '__main__':  # pragma: no cover - test helper
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `CrossLingualReasoningGraph` with logger and summary storage
- allow `ReasoningHistoryLogger.log` to record summarized nodes
- guard usage tracking for unhashable metadata in `HierarchicalMemory`
- add unit test for cross‑lingual graph summarization

## Testing
- `pytest tests/test_crosslingual_graph_summary.py`

------
https://chatgpt.com/codex/tasks/task_e_686bee3183208331a4a8f764ee8d2384