### PR TITLE
Add multilingual graph editor

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -458,6 +458,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     `ContextSummaryMemory` with translations so `query_summary()` can return the
     compressed trace in any language. Evaluate by confirming the same plan is
     found in at least two languages.
+41b1. **Multilingual Graph UI**: The HTML interface offers a language selector so
+      nodes are displayed and edited in the chosen language using
+      `CrossLingualReasoningGraph.translate_node()`.
 41c. **Multimodal reasoning graph**: `CrossLingualReasoningGraph.add_step()`
      accepts `image_embed` and `audio_embed`. Use `embed_modalities()` from
      `CrossModalFusion` to generate vectors. `ReasoningHistoryLogger` preserves


### PR DESCRIPTION
## Summary
- add a language selector to the Graph UI HTML
- translate nodes when serving graph data
- store language metadata on newly created nodes
- enable multilingual NL editing
- document multilingual graph UI capability

## Testing
- `pytest tests/test_graph_ui.py tests/test_cross_lingual_reasoning_graph.py -q` *(fails: ModuleNotFoundError: No module named 'asi.context_summary_memory')*
- `pytest tests/test_cross_lingual_reasoning_graph.py -q` *(skipped: torch not available)*

------
https://chatgpt.com/codex/tasks/task_e_686c3a4324288331ba9249d95433c30d