### PR TITLE
Add multi-agent self-play module

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -631,6 +631,9 @@ merged, issues = consensus_reasoner.compute_consensus(coord)
 print(consensus_reasoner.report_disagreements(issues))
 ```
 
+88. **Multi-agent self-play**: `run_multi_agent_self_play()` launches multiple `MetaRLRefactorAgent` instances inside `self_play_env`. `MultiAgentCoordinator` assigns each episode and aggregates rewards while `MultiAgentDashboard` logs the overall metrics to study cooperation vs. competition effects.
+
+
 
 
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -328,3 +328,5 @@ from .bio_memory_replay import run_nightly_replay
 from .sign_language import SignLanguageRecognizer
 from .reasoning_summary_translator import ReasoningSummaryTranslator
 
+from .multi_agent_self_play import MultiAgentSelfPlayConfig, run_multi_agent_self_play, MultiAgentSelfPlay
+

--- a/src/multi_agent_self_play.py
+++ b/src/multi_agent_self_play.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Run multiple MetaRLRefactorAgent instances in a self-play environment."""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict
+
+import torch
+
+from .self_play_env import SimpleEnv
+from .meta_rl_refactor import MetaRLRefactorAgent
+from .multi_agent_coordinator import MultiAgentCoordinator
+from .multi_agent_dashboard import MultiAgentDashboard
+
+
+@dataclass
+class MultiAgentSelfPlayConfig:
+    """Configuration for :func:`run_multi_agent_self_play`."""
+
+    num_agents: int = 2
+    env_state_dim: int = 4
+    steps: int = 10
+
+
+class MultiAgentSelfPlay:
+    """Wrapper managing agents, environments and telemetry."""
+
+    def __init__(self, cfg: MultiAgentSelfPlayConfig) -> None:
+        self.cfg = cfg
+        self.agents: Dict[str, MetaRLRefactorAgent] = {
+            f"agent{i}": MetaRLRefactorAgent() for i in range(cfg.num_agents)
+        }
+        self.envs: Dict[str, SimpleEnv] = {
+            name: SimpleEnv(cfg.env_state_dim) for name in self.agents
+        }
+        self.coordinator = MultiAgentCoordinator(self.agents)
+        self.dashboard = MultiAgentDashboard(self.coordinator)
+        actions = list(next(iter(self.agents.values())).actions)
+        self.action_map = {
+            act: torch.full((cfg.env_state_dim,), float(i))
+            for i, act in enumerate(actions)
+        }
+        self._last_reward: Dict[str, float] = {}
+
+    async def _apply(self, env_name: str, action: str) -> None:
+        env = self.envs[env_name]
+        step = env.step(self.action_map[action])
+        self._last_reward[env_name] = step.reward
+
+    def _reward(self, env_name: str, action: str) -> float:
+        return self._last_reward.get(env_name, 0.0)
+
+    async def run(self) -> None:
+        self.dashboard.start(port=0)
+        tasks = list(self.envs.keys())
+        for _ in range(self.cfg.steps):
+            await self.coordinator.schedule_round(tasks, self._apply, self._reward)
+        self.coordinator.train_agents()
+        self.dashboard.stop()
+
+
+def run_multi_agent_self_play(cfg: MultiAgentSelfPlayConfig) -> MultiAgentDashboard:
+    """Run self-play with ``cfg`` and return the dashboard."""
+    msp = MultiAgentSelfPlay(cfg)
+    asyncio.run(msp.run())
+    return msp.dashboard
+
+
+__all__ = ["MultiAgentSelfPlayConfig", "MultiAgentSelfPlay", "run_multi_agent_self_play"]
+

--- a/tests/test_multi_agent_self_play.py
+++ b/tests/test_multi_agent_self_play.py
@@ -1,0 +1,82 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+sys.modules['torch'] = types.SimpleNamespace(
+    full=lambda shape, val, **kw: [val] * shape[0],
+    zeros=lambda dim, device=None: [0.0] * dim,
+)
+
+class DummyEnv:
+    def __init__(self, state_dim, device=None):
+        self.state = [0.0] * state_dim
+    def reset(self):
+        self.state = [0.0] * len(self.state)
+        return self.state
+    def step(self, action):
+        self.state = [s + float(a) for s, a in zip(self.state, action)]
+        return types.SimpleNamespace(observation=self.state, reward=-1.0, done=False)
+
+class DummyAgent:
+    actions = ('a', 'b', 'c')
+    def select_action(self, state):
+        return 'a'
+    def update(self, s, a, r, ns):
+        pass
+    def train(self, entries):
+        pass
+
+class DummyCoordinator:
+    def __init__(self, agents):
+        self.agents = agents
+        self.log = []
+    async def schedule_round(self, tasks, apply_fn=None, reward_fn=None):
+        for t in tasks:
+            for name in self.agents:
+                if apply_fn:
+                    await apply_fn(name, 'a')
+                if reward_fn:
+                    reward_fn(name, 'a')
+                self.log.append((name, t, 'a', 0.0))
+    def train_agents(self):
+        pass
+
+class DummyDashboard:
+    def __init__(self, coord):
+        self.coord = coord
+    def start(self, port=0):
+        pass
+    def stop(self):
+        pass
+    def aggregate(self):
+        return {'assignments': self.coord.log}
+
+sys.modules['asi.meta_rl_refactor'] = types.SimpleNamespace(MetaRLRefactorAgent=DummyAgent)
+sys.modules['asi.self_play_env'] = types.SimpleNamespace(SimpleEnv=DummyEnv)
+sys.modules['asi.multi_agent_coordinator'] = types.SimpleNamespace(MultiAgentCoordinator=DummyCoordinator)
+sys.modules['asi.multi_agent_dashboard'] = types.SimpleNamespace(MultiAgentDashboard=DummyDashboard)
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+msp = _load('asi.multi_agent_self_play', 'src/multi_agent_self_play.py')
+MultiAgentSelfPlayConfig = msp.MultiAgentSelfPlayConfig
+run_multi_agent_self_play = msp.run_multi_agent_self_play
+
+class TestMultiAgentSelfPlay:
+    def test_run(self):
+        cfg = MultiAgentSelfPlayConfig(num_agents=2, steps=2, env_state_dim=3)
+        dash = run_multi_agent_self_play(cfg)
+        data = dash.aggregate()
+        assert 'assignments' in data
+        assert len(data['assignments']) > 0
+


### PR DESCRIPTION
## Summary
- implement `multi_agent_self_play` module for running several `MetaRLRefactorAgent` instances in self play
- export new helper via `__init__`
- document multi-agent self-play approach in the self-improvement roadmap
- test with stubbed dependencies

## Testing
- `pytest tests/test_multi_agent_self_play.py::TestMultiAgentSelfPlay::test_run -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3a520f888331ae49f110c2cb1fd2