### PR TITLE
Add differentially private federated trainer

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -601,6 +601,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 85a. **FHE gradient aggregation**: `FHEFederatedTrainer` wraps the secure learner
      and uses `run_fhe` to decrypt TenSEAL-encrypted gradients. Reward on the RL
      benchmark should drop less than 5% versus plaintext training.
+85b. **Differentially private federated trainer**: `DPFederatedTrainer` applies
+     `DifferentialPrivacyOptimizer` to the aggregated gradients from
+     `SecureFederatedLearner`. Run `scripts/federated_world_model_train.py --dp`
+     or `scripts/federated_edge_rl_demo.py --dp` to enable this mode.
 86. **Offline memory replay**: `run_nightly_replay()` schedules daily sessions
     where embeddings from `HierarchicalMemory` and `ContextSummaryMemory` are
     reconstructed and passed through the model for consolidation. Integrated

--- a/scripts/federated_edge_rl_demo.py
+++ b/scripts/federated_edge_rl_demo.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import torch
 
+import argparse
+
 from asi.federated_edge_rl import FederatedEdgeRLTrainer, FederatedEdgeConfig
 from asi.compute_budget_tracker import ComputeBudgetTracker
 from asi.differential_privacy_optimizer import DifferentialPrivacyConfig
@@ -20,12 +22,16 @@ class ToyModel(torch.nn.Module):
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Federated edge RL demo")
+    parser.add_argument("--dp", action="store_true", help="apply differential privacy")
+    args = parser.parse_args()
+
     data1 = [(torch.randn(1, 2), torch.randn(1, 2)) for _ in range(4)]
     data2 = [(torch.randn(1, 2), torch.randn(1, 2)) for _ in range(4)]
 
     model = ToyModel()
     cfg = FederatedEdgeConfig(rounds=2, local_steps=2, lr=0.1)
-    dp_cfg = DifferentialPrivacyConfig(lr=cfg.lr, clip_norm=1.0, noise_std=0.01)
+    dp_cfg = DifferentialPrivacyConfig(lr=cfg.lr, clip_norm=1.0, noise_std=0.01) if args.dp else None
     budget = ComputeBudgetTracker(1.0)
     budget.start("edge")
     trainer = FederatedEdgeRLTrainer(model, cfg, dp_cfg=dp_cfg, budget=budget)

--- a/scripts/federated_world_model_train.py
+++ b/scripts/federated_world_model_train.py
@@ -6,6 +6,7 @@ from asi.federated_world_model_trainer import (
     FederatedTrainerConfig,
 )
 from asi.fhe_federated_trainer import FHEFederatedTrainer, FHEFederatedTrainerConfig
+from asi.dp_federated_trainer import DPFederatedTrainer, DPFederatedTrainerConfig
 import tenseal as ts
 
 def main() -> None:
@@ -13,6 +14,7 @@ def main() -> None:
     parser.add_argument("--rounds", type=int, default=1)
     parser.add_argument("--local-epochs", type=int, default=1, dest="local_epochs")
     parser.add_argument("--use-fhe", action="store_true", help="train with FHE-encrypted gradients")
+    parser.add_argument("--dp", action="store_true", help="apply differential privacy to aggregation")
     args = parser.parse_args()
 
     cfg = RLBridgeConfig(state_dim=4, action_dim=2)
@@ -39,6 +41,13 @@ def main() -> None:
             rounds=args.rounds, local_epochs=args.local_epochs, lr=tcfg.lr
         )
         trainer = FHEFederatedTrainer(cfg, [ds1, ds2], ctx, trainer_cfg=ftcfg)
+    elif args.dp:
+        dpcfg = DPFederatedTrainerConfig(
+            rounds=args.rounds,
+            local_epochs=args.local_epochs,
+            lr=tcfg.lr,
+        )
+        trainer = DPFederatedTrainer(cfg, [ds1, ds2], dp_cfg=dpcfg)
     else:
         trainer = FederatedWorldModelTrainer(cfg, [ds1, ds2], trainer_cfg=tcfg)
     model = trainer.train()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -234,6 +234,7 @@ from .federated_world_model_trainer import (
     FederatedTrainerConfig,
 )
 from .fhe_federated_trainer import FHEFederatedTrainer, FHEFederatedTrainerConfig
+from .dp_federated_trainer import DPFederatedTrainer, DPFederatedTrainerConfig
 from .adversarial_robustness import AdversarialRobustnessSuite
 from .graph_of_thought import ReasoningDebugger, AnalogicalReasoningDebugger
 from .multi_stage_oversight import MultiStageOversight

--- a/src/dp_federated_trainer.py
+++ b/src/dp_federated_trainer.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Callable, List
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from .world_model_rl import RLBridgeConfig, WorldModel, TransitionDataset
+from .secure_federated_learner import SecureFederatedLearner
+from .differential_privacy_optimizer import (
+    DifferentialPrivacyOptimizer,
+    DifferentialPrivacyConfig,
+)
+
+
+@dataclass
+class DPFederatedTrainerConfig:
+    """Configuration for federated training with differential privacy."""
+
+    rounds: int = 1
+    local_epochs: int = 1
+    lr: float = 1e-4
+    clip_norm: float = 1.0
+    noise_std: float = 0.01
+
+
+class DPFederatedTrainer:
+    """Federated world-model trainer that applies differential privacy."""
+
+    def __init__(
+        self,
+        cfg: RLBridgeConfig,
+        datasets: Iterable[Dataset],
+        learner: SecureFederatedLearner | None = None,
+        dp_cfg: DPFederatedTrainerConfig | None = None,
+        reward_sync_hook: Callable[[], Iterable[Iterable[float]]] | None = None,
+    ) -> None:
+        self.cfg = cfg
+        self.datasets = list(datasets)
+        self.learner = learner or SecureFederatedLearner()
+        self.dp_cfg = dp_cfg or DPFederatedTrainerConfig()
+        self.model = WorldModel(cfg)
+        self.reward_sync_hook = reward_sync_hook
+        dp_opt_cfg = DifferentialPrivacyConfig(
+            lr=self.dp_cfg.lr,
+            clip_norm=self.dp_cfg.clip_norm,
+            noise_std=self.dp_cfg.noise_std,
+        )
+        params = [p for p in self.model.parameters() if p.requires_grad]
+        self.dp_opt = DifferentialPrivacyOptimizer(params, dp_opt_cfg)
+
+    # --------------------------------------------------
+    def _local_gradients(self, dataset: Dataset) -> List[torch.Tensor]:
+        loader = DataLoader(dataset, batch_size=self.cfg.batch_size, shuffle=True)
+        params = [p for p in self.model.parameters() if p.requires_grad]
+        grads = [torch.zeros_like(p) for p in params]
+        opt = torch.optim.SGD(params, lr=self.dp_cfg.lr)
+        loss_fn = torch.nn.MSELoss()
+        for _ in range(self.dp_cfg.local_epochs):
+            for s, a, ns, r in loader:
+                pred_s, pred_r = self.model(s, a)
+                loss = loss_fn(pred_s, ns) + loss_fn(pred_r, r)
+                opt.zero_grad()
+                loss.backward()
+                for g, p in zip(grads, params):
+                    g += p.grad.detach().clone()
+                opt.step()
+        return [g / len(loader) for g in grads]
+
+    def train(self) -> WorldModel:
+        params = [p for p in self.model.parameters() if p.requires_grad]
+        for _ in range(self.dp_cfg.rounds):
+            if self.reward_sync_hook is not None:
+                rewards = self.reward_sync_hook()
+                for ds, rs in zip(self.datasets, rewards, strict=True):
+                    if isinstance(ds, TransitionDataset):
+                        ds.data = [
+                            (s, a, ns, float(r))
+                            for (s, a, ns, _), r in zip(ds.data, rs, strict=True)
+                        ]
+            enc_grads = []
+            for ds in self.datasets:
+                grads = self._local_gradients(ds)
+                flat = torch.cat([g.view(-1) for g in grads])
+                enc = self.learner.encrypt(flat)
+                enc_grads.append(enc)
+            agg = self.learner.aggregate([self.learner.decrypt(g) for g in enc_grads])
+            self.dp_opt.zero_grad()
+            start = 0
+            for p in params:
+                num = p.numel()
+                g = agg[start : start + num].view_as(p)
+                p.grad = g.clone()
+                start += num
+            self.dp_opt.step()
+        return self.model
+
+
+__all__ = ["DPFederatedTrainer", "DPFederatedTrainerConfig"]

--- a/tests/test_dp_federated_trainer.py
+++ b/tests/test_dp_federated_trainer.py
@@ -1,0 +1,43 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import torch
+from torch.utils.data import TensorDataset
+
+pkg = types.ModuleType("src")
+pkg.__path__ = ["src"]
+pkg.__spec__ = importlib.machinery.ModuleSpec("src", None, is_package=True)
+sys.modules["src"] = pkg
+
+mods = [
+    "world_model_rl",
+    "secure_federated_learner",
+    "dp_federated_trainer",
+]
+for m in mods:
+    loader = importlib.machinery.SourceFileLoader(f"src.{m}", f"src/{m}.py")
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "src"
+    sys.modules[f"src.{m}"] = mod
+    loader.exec_module(mod)
+
+RLBridgeConfig = sys.modules["src.world_model_rl"].RLBridgeConfig
+TransitionDataset = sys.modules["src.world_model_rl"].TransitionDataset
+DPFederatedTrainer = sys.modules["src.dp_federated_trainer"].DPFederatedTrainer
+DPFederatedTrainerConfig = sys.modules["src.dp_federated_trainer"].DPFederatedTrainerConfig
+
+
+class TestDPFederatedTrainer(unittest.TestCase):
+    def test_train_runs(self):
+        cfg = RLBridgeConfig(state_dim=2, action_dim=2, epochs=1, batch_size=2)
+        data = TensorDataset(torch.zeros(4, 2), torch.zeros(4, dtype=torch.long), torch.zeros(4, 2), torch.zeros(4))
+        trainer = DPFederatedTrainer(cfg, [data, data], dp_cfg=DPFederatedTrainerConfig(rounds=1, local_epochs=1))
+        model = trainer.train()
+        self.assertIsNotNone(model)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `DPFederatedTrainer` applying differential privacy during federated updates
- import new trainer in `asi` package
- add `--dp` flag to training demos so differentially private training can be enabled
- document usage in the plan
- add unit test for `DPFederatedTrainer`

## Testing
- `pytest tests/test_federated_world_model_trainer.py tests/test_dp_federated_trainer.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686c3ca8a1848331b269826a5f994408