### PR TITLE
Add reasoning graph knowledge bridge

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -462,6 +462,12 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
      accepts `image_embed` and `audio_embed`. Use `embed_modalities()` from
      `CrossModalFusion` to generate vectors. `ReasoningHistoryLogger` preserves
      `image_vec` and `audio_vec` when saving histories.
+41d. **Reasoning-graph knowledge bridge**: `reasoning_kb_bridge.graph_to_triples()`
+     converts graph nodes and edges into `(subject, predicate, object)` triples
+     for `KnowledgeGraphMemory`. `HistoryKGExporter` periodically pushes
+     `ReasoningHistoryLogger` summaries into the knowledge graph with
+     timestamps so planners can query past reasoning steps via
+     `get_following_steps()`.
 42. **World-model distillation**: Implement a `WorldModelDistiller` that
     compresses the large world model into a smaller student network. Target
     <5% reward loss on the embodied RL benchmarks while reducing model size by

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -327,4 +327,10 @@ from .emotion_detector import detect_emotion
 from .bio_memory_replay import run_nightly_replay
 from .sign_language import SignLanguageRecognizer
 from .reasoning_summary_translator import ReasoningSummaryTranslator
+from .reasoning_kb_bridge import (
+    graph_to_triples,
+    HistoryKGExporter,
+    get_following_steps,
+    get_step_metadata,
+)
 

--- a/src/reasoning_kb_bridge.py
+++ b/src/reasoning_kb_bridge.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from datetime import datetime
+from threading import Event, Thread
+from typing import Iterable, List, Sequence
+
+from .graph_of_thought import GraphOfThought
+from .knowledge_graph_memory import KnowledgeGraphMemory, TimedTriple
+from .reasoning_history import ReasoningHistoryLogger
+
+
+def graph_to_triples(graph: GraphOfThought) -> List[TimedTriple]:
+    """Convert graph nodes and edges into ``TimedTriple`` objects."""
+    triples: List[TimedTriple] = []
+    for node in graph.nodes.values():
+        ts = node.metadata.get("timestamp") if node.metadata else None
+        triples.append(TimedTriple(node.text, "node_id", str(node.id), ts))
+        if node.metadata:
+            for k, v in node.metadata.items():
+                if k == "timestamp":
+                    continue
+                triples.append(TimedTriple(node.text, k, str(v), ts))
+    for src, dsts in graph.edges.items():
+        src_text = graph.nodes[src].text
+        ts = graph.nodes[src].metadata.get("timestamp") if graph.nodes[src].metadata else None
+        for dst in dsts:
+            dst_text = graph.nodes[dst].text
+            triples.append(TimedTriple(src_text, "leads_to", dst_text, ts))
+    return triples
+
+
+class HistoryKGExporter:
+    """Periodically export ``ReasoningHistoryLogger`` entries to a knowledge graph."""
+
+    def __init__(self, logger: ReasoningHistoryLogger, kg: KnowledgeGraphMemory, interval: float = 60.0) -> None:
+        self.logger = logger
+        self.kg = kg
+        self.interval = interval
+        self._stop = Event()
+        self._thread: Thread | None = None
+        self._index = 0
+
+    def export_once(self) -> None:
+        entries = self.logger.get_history()
+        new = entries[self._index :]
+        triples: List[TimedTriple] = []
+        for ts, summary in new:
+            text = summary["summary"] if isinstance(summary, dict) else summary
+            try:
+                ts_val = datetime.fromisoformat(ts).timestamp()
+            except Exception:
+                ts_val = None
+            triples.append(TimedTriple("reasoning", "summary", str(text), ts_val))
+        if triples:
+            self.kg.add_triples(triples)
+        self._index = len(entries)
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+
+        def loop() -> None:
+            while not self._stop.is_set():
+                self.export_once()
+                self._stop.wait(self.interval)
+
+        self._thread = Thread(target=loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._thread is None:
+            return
+        self._stop.set()
+        self._thread.join(timeout=self.interval)
+        self._thread = None
+        self._stop.clear()
+
+
+def get_following_steps(
+    kg: KnowledgeGraphMemory,
+    step: str,
+    *,
+    start_time: float | None = None,
+    end_time: float | None = None,
+) -> List[str]:
+    """Return steps that historically followed ``step``."""
+    triples = kg.query_triples(
+        subject=step,
+        predicate="leads_to",
+        start_time=start_time,
+        end_time=end_time,
+    )
+    return [t.object for t in triples]
+
+
+def get_step_metadata(
+    kg: KnowledgeGraphMemory,
+    step: str,
+    key: str,
+) -> List[str]:
+    """Return metadata values for ``step`` stored under ``key``."""
+    triples = kg.query_triples(subject=step, predicate=key)
+    return [t.object for t in triples]
+
+
+__all__ = [
+    "graph_to_triples",
+    "HistoryKGExporter",
+    "get_following_steps",
+    "get_step_metadata",
+]

--- a/tests/test_reasoning_kb_bridge.py
+++ b/tests/test_reasoning_kb_bridge.py
@@ -1,0 +1,56 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    loader.exec_module(mod)
+    sys.modules[name] = mod
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+GraphOfThought = load('asi.graph_of_thought', 'src/graph_of_thought.py').GraphOfThought
+KnowledgeGraphMemory = load('asi.knowledge_graph_memory', 'src/knowledge_graph_memory.py').KnowledgeGraphMemory
+ReasoningHistoryLogger = load('asi.reasoning_history', 'src/reasoning_history.py').ReasoningHistoryLogger
+bridge = load('asi.reasoning_kb_bridge', 'src/reasoning_kb_bridge.py')
+
+graph_to_triples = bridge.graph_to_triples
+HistoryKGExporter = bridge.HistoryKGExporter
+get_following_steps = bridge.get_following_steps
+get_step_metadata = bridge.get_step_metadata
+
+
+class TestReasoningKGBride(unittest.TestCase):
+    def test_graph_conversion_and_query(self):
+        g = GraphOfThought()
+        a = g.add_step('start', metadata={'timestamp': 1.0})
+        b = g.add_step('end', metadata={'timestamp': 2.0})
+        g.connect(a, b)
+        kg = KnowledgeGraphMemory()
+        kg.add_triples(graph_to_triples(g))
+        next_steps = get_following_steps(kg, 'start')
+        self.assertEqual(next_steps, ['end'])
+        meta = get_step_metadata(kg, 'start', 'node_id')
+        self.assertEqual(meta, [str(a)])
+
+    def test_history_exporter(self):
+        logger = ReasoningHistoryLogger()
+        logger.log('first')
+        kg = KnowledgeGraphMemory()
+        exporter = HistoryKGExporter(logger, kg, interval=0.01)
+        exporter.export_once()
+        triples = kg.query_triples(subject='reasoning')
+        self.assertEqual(len(triples), 1)
+        exporter.stop()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert reasoning graphs to knowledge graph triples
- export ReasoningHistoryLogger summaries into the knowledge graph
- helper queries for past reasoning
- document reasoning-graph bridge in Plan

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'onnxruntime')*

------
https://chatgpt.com/codex/tasks/task_e_686c3cc113a08331a8fb6b5b2c1011dd