### PR TITLE
Add 3D GraphOfThought viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository experiments with algorithms needed for self-improving AI. The bi
 - `scripts/dataset_summary.py` prints lineage and license info. Use `--content` to cluster dataset samples and store summaries under `docs/datasets/`.
 - `scripts/lineage_viewer.py <root>` serves an interactive graph of the dataset lineage.
 - `scripts/ar_robot_demo.py` streams predicted and actual robot trajectories to a WebSocket server for lightweight AR visualization. Pass `--show-graph` to also broadcast `GraphOfThought` nodes.
+- `scripts/got_3d_viewer.py <trace.json>` launches a pythreejs viewer for reasoning graphs. Connect to `ws://localhost:8090/ws` to stream updates.
 
 Example:
 

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -541,6 +541,9 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 82. **Graph-of-thought visualizer**: Use `src/got_visualizer.py` and the CLI
     `scripts/got_visualizer.py trace.json --out graph.html` to render reasoning
     traces for collaborative editing sessions.
+82a. **3D graph viewer**: `got_3d_visualizer.py` renders nodes with pythreejs.
+     Launch `scripts/got_3d_viewer.py trace.json` and push updates over
+     WebSockets from `ARDebugger` or `GraphUI` for real-time exploration.
 83. **Graph UI**: `GraphUI` serves interactive D3 graphs via FastAPI. When
     cognitive load exceeds a threshold the UI throttles update frequency and
     shortens node text. Visit `http://localhost:8070/graph` while the server is

--- a/scripts/got_3d_viewer.py
+++ b/scripts/got_3d_viewer.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import argparse
+import time
+
+try:  # pragma: no cover - prefer package imports
+    from asi.graph_of_thought import GraphOfThought
+    from asi.got_3d_visualizer import GOT3DVisualizer, GOT3DViewer
+except Exception:  # pragma: no cover - fallback for tests
+    from src.graph_of_thought import GraphOfThought  # type: ignore
+    from src.got_3d_visualizer import GOT3DVisualizer, GOT3DViewer  # type: ignore
+
+
+def main(path: str, port: int) -> None:
+    graph = GraphOfThought.from_json(path)
+    data = graph.to_json()
+    vis = GOT3DVisualizer(data.get("nodes", []), [(s, d) for s, d in data.get("edges", [])])
+    viewer = GOT3DViewer(vis)
+    viewer.start(port=port)
+    print(f"3D viewer running at http://localhost:{viewer.port}")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    viewer.stop()
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    parser = argparse.ArgumentParser(description="Launch 3D graph viewer")
+    parser.add_argument("trace", help="Path to graph JSON trace")
+    parser.add_argument("--port", type=int, default=8090)
+    args = parser.parse_args()
+    main(args.trace, args.port)

--- a/src/got_3d_visualizer.py
+++ b/src/got_3d_visualizer.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import math
+import socket
+import threading
+from typing import Any, Dict, Iterable, List, Tuple
+
+import numpy as np
+import time
+from aiohttp import web
+from ipywidgets import embed
+from pythreejs import (
+    AmbientLight,
+    BufferAttribute,
+    BufferGeometry,
+    Line,
+    LineBasicMaterial,
+    Mesh,
+    MeshLambertMaterial,
+    OrbitControls,
+    PerspectiveCamera,
+    Renderer,
+    Scene,
+    SphereGeometry,
+    Sprite,
+    SpriteMaterial,
+    TextTexture,
+)
+
+
+class GOT3DVisualizer:
+    """Render reasoning graphs in 3D using pythreejs."""
+
+    def __init__(self, nodes: Iterable[Dict[str, Any]], edges: Iterable[Tuple[str, str]]) -> None:
+        self.nodes = list(nodes)
+        self.edges = list(edges)
+        self._pos: Dict[str, Tuple[float, float, float]] | None = None
+        self._edge_arr: np.ndarray | None = None
+        self._html: str | None = None
+
+    @classmethod
+    def from_json(cls, path: str) -> "GOT3DVisualizer":
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        nodes = data.get("nodes", [])
+        raw_edges = data.get("edges", [])
+        if raw_edges and isinstance(raw_edges[0], dict):
+            edges = [(e["source"], e["target"]) for e in raw_edges]
+        else:
+            edges = [(src, dst) for src, dst in raw_edges]
+        return cls(nodes, edges)
+
+    # --------------------------------------------------------------
+    def _compute_layout(self) -> Dict[str, Tuple[float, float, float]]:
+        n = max(len(self.nodes), 1)
+        idx = np.arange(len(self.nodes)) + 0.5
+        phi = np.arccos(1 - 2 * idx / n)
+        theta = np.pi * (1 + math.sqrt(5.0)) * idx
+        r = 3.0
+        arr = np.stack(
+            [
+                r * np.sin(phi) * np.cos(theta),
+                r * np.sin(phi) * np.sin(theta),
+                r * np.cos(phi),
+            ],
+            axis=1,
+        )
+        pos = {str(node["id"]): tuple(p) for node, p in zip(self.nodes, arr)}
+        if self.edges:
+            pts = []
+            for src, dst in self.edges:
+                pts.extend(pos.get(str(src), (0.0, 0.0, 0.0)))
+                pts.extend(pos.get(str(dst), (0.0, 0.0, 0.0)))
+            self._edge_arr = np.array(pts, dtype="float32").reshape(-1, 3)
+        else:
+            self._edge_arr = np.zeros((0, 3), dtype="float32")
+        return pos
+
+    def _layout(self) -> Dict[str, Tuple[float, float, float]]:
+        if self._pos is None:
+            self._pos = self._compute_layout()
+        return self._pos
+
+    def invalidate(self) -> None:
+        self._pos = None
+        self._edge_arr = None
+        self._html = None
+
+    # --------------------------------------------------------------
+    def to_widget(self) -> Renderer:
+        pos = self._layout()
+        scene = Scene(children=[AmbientLight(intensity=0.5)])
+        for node in self.nodes:
+            nid = str(node["id"])
+            x, y, z = pos[nid]
+            label = str(node.get("text", nid))
+            sphere = Mesh(
+                geometry=SphereGeometry(radius=0.2, widthSegments=16, heightSegments=16),
+                material=MeshLambertMaterial(color="#1f77b4"),
+                position=[x, y, z],
+            )
+            tex = TextTexture(string=label)
+            sprite = Sprite(SpriteMaterial(map=tex, sizeAttenuation=False), position=[x, y, z + 0.3])
+            scene.add(sphere)
+            scene.add(sprite)
+        if self.edges:
+            if self._edge_arr is None:
+                self._compute_layout()
+            assert self._edge_arr is not None
+            geom = BufferGeometry(attributes={"position": BufferAttribute(self._edge_arr)})
+            line = Line(geometry=geom, material=LineBasicMaterial(color="black"))
+            scene.add(line)
+        camera = PerspectiveCamera(position=[4, 4, 4], up=[0, 0, 1])
+        controls = OrbitControls(controlling=camera)
+        renderer = Renderer(scene=scene, camera=camera, controls=[controls], width=600, height=400)
+        return renderer
+
+    # --------------------------------------------------------------
+    def to_html(self) -> str:
+        if self._html is None:
+            widget = self.to_widget()
+            buf = io.StringIO()
+            embed.embed_minimal_html(buf, views=[widget])
+            self._html = buf.getvalue()
+        return self._html
+
+
+class GOT3DViewer:
+    """Serve a 3D graph viewer with optional WebSocket updates."""
+
+    def __init__(self, graph: GOT3DVisualizer) -> None:
+        self.graph = graph
+        self.app = web.Application()
+        self.app.router.add_get("/", self._index)
+        self.app.router.add_get("/ws", self._ws_handler)
+        self.clients: List[web.WebSocketResponse] = []
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.runner: web.AppRunner | None = None
+        self.thread: threading.Thread | None = None
+        self.port: int | None = None
+
+    async def _index(self, request: web.Request) -> web.Response:
+        html = self.graph.to_html()
+        html += (
+            "<script>const ws=new WebSocket(`ws://${location.host}/ws`);"
+            "ws.onmessage=e=>{document.open();document.write(e.data);document.close();};"
+            "</script>"
+        )
+        return web.Response(text=html, content_type="text/html")
+
+    async def _ws_handler(self, request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        self.clients.append(ws)
+        try:
+            async for _ in ws:
+                pass
+        finally:
+            if ws in self.clients:
+                self.clients.remove(ws)
+        return ws
+
+    async def _broadcast(self, html: str) -> None:
+        if not self.clients:
+            return
+        results = await asyncio.gather(
+            *(ws.send_str(html) for ws in self.clients),
+            return_exceptions=True,
+        )
+        self.clients = [
+            ws for ws, res in zip(self.clients, results) if not isinstance(res, Exception)
+        ]
+
+    def send_graph(self) -> None:
+        if self.loop is None:
+            return
+        html = self.graph.to_html()
+        asyncio.run_coroutine_threadsafe(self._broadcast(html), self.loop)
+
+    def _run(self, host: str, port: int) -> None:
+        assert self.loop is not None
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_until_complete(self.runner.setup())
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind((host, port))
+        _, real_port = sock.getsockname()
+        self.port = real_port
+        site = web.SockSite(self.runner, sock)
+        self.loop.run_until_complete(site.start())
+        try:
+            self.loop.run_forever()
+        finally:
+            self.loop.run_until_complete(self.runner.cleanup())
+
+    def start(self, host: str = "localhost", port: int = 8090) -> None:
+        if self.thread is not None:
+            return
+        self.loop = asyncio.new_event_loop()
+        self.runner = web.AppRunner(self.app)
+        self.thread = threading.Thread(target=self._run, args=(host, port), daemon=True)
+        self.thread.start()
+        while self.port is None:
+            time.sleep(0.01)
+
+    def stop(self) -> None:
+        if self.thread is None or self.loop is None:
+            return
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join(timeout=1.0)
+        self.thread = None
+        self.runner = None
+        self.loop = None
+        self.port = None
+
+
+__all__ = ["GOT3DVisualizer", "GOT3DViewer"]

--- a/tests/test_got_3d_visualizer.py
+++ b/tests/test_got_3d_visualizer.py
@@ -1,0 +1,88 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+import json
+
+pkg = types.ModuleType('asi')
+sys.modules.setdefault('asi', pkg)
+src_pkg = types.ModuleType('src')
+src_pkg.__path__ = [str(Path('src'))]
+sys.modules.setdefault('src', src_pkg)
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+# Stub GraphOfThought to avoid torch dependency
+class GraphOfThought:
+    def __init__(self):
+        self.nodes = {}
+        self.edges = {}
+        self._next = 0
+    def add_step(self, text):
+        nid = self._next
+        self._next += 1
+        self.nodes[nid] = types.SimpleNamespace(id=nid, text=text, metadata=None)
+        self.edges.setdefault(nid, [])
+        return nid
+    def connect(self, src, dst):
+        self.edges.setdefault(src, []).append(dst)
+    def to_json(self):
+        nodes = [{"id": i, "text": n.text} for i, n in self.nodes.items()]
+        edges = [[s, d] for s, ds in self.edges.items() for d in ds]
+        return {"nodes": nodes, "edges": edges}
+
+loader = importlib.machinery.SourceFileLoader('got_3d_visualizer', 'src/got_3d_visualizer.py')
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mod
+loader.exec_module(mod)
+GOT3DVisualizer = mod.GOT3DVisualizer
+GOT3DViewer = mod.GOT3DViewer
+
+from aiohttp import ClientSession
+import asyncio
+
+
+class TestGOT3DVisualizer(unittest.TestCase):
+    def test_html(self):
+        nodes = [{"id": "0", "text": "start"}, {"id": "1", "text": "end"}]
+        edges = [("0", "1")]
+        vis = GOT3DVisualizer(nodes, edges)
+        html = vis.to_html()
+        self.assertIn("<html", html.lower())
+
+    def test_viewer_stream(self):
+        graph = GraphOfThought()
+        a = graph.add_step('a')
+        b = graph.add_step('b')
+        graph.connect(a, b)
+        data = graph.to_json()
+        vis = GOT3DVisualizer(data['nodes'], [(s, d) for s, d in data['edges']])
+        viewer = GOT3DViewer(vis)
+        viewer.start(port=0)
+        port = viewer.port
+
+        async def run_client() -> str:
+            assert port is not None
+            async with ClientSession() as sess:
+                async with sess.ws_connect(f'http://localhost:{port}/ws') as ws:
+                    viewer.send_graph()
+                    msg = await ws.receive()
+                    return msg.data
+
+        html = asyncio.get_event_loop().run_until_complete(run_client())
+        viewer.stop()
+        self.assertIn('html', html.lower())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- visualize reasoning graphs in 3D with pythreejs
- serve the viewer and broadcast updates over WebSockets
- provide CLI helper `got_3d_viewer.py`
- document the feature in the roadmap and README
- add regression tests for the 3D viewer
- optimize 3D viewer layout caching

## Testing
- `pytest tests/test_got_3d_visualizer.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests', plus 174 other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c3cb0f93c8331a10d7ac27adca637