### PR TITLE
Improve fairness tools and dashboards

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -498,6 +498,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 60. **Adversarial robustness suite**: Generate gradient-based adversarial prompts and measure model degradation. Acceptable drop is <5% accuracy on the evaluation harness.
 61. **Bias-aware dataset filtering**: Add `DatasetBiasDetector` to compute representation metrics and filter skewed samples. Goal is <5% disparity across demographic slices after filtering.
 61a. **Dataset bias mitigation**: `DataBiasMitigator` reweights or filters entries based on these scores. `download_triples()` now applies the mitigator before storing new files.
+61b. **Fairness gap visualizer**: `fairness_visualizer.FairnessVisualizer` plots demographic parity and opportunity gaps. `dataset_summary.py --fairness-report` saves the charts under `docs/datasets/`; they appear in the lineage and memory dashboards for quick inspection.
 62. **Federated world-model training**: Train `world_model_rl` across multiple nodes via gradient averaging. Throughput should scale to four nodes with <1.2× single-node time.
 63. **Parameter-efficient model editing**: Implement `GradientPatchEditor` to fix wrong outputs with minimal updates; >90% targeted fix rate with <1% perplexity change.
 64. **Reasoning trace debugger**: Extend `GraphOfThought` with a debugger that flags contradictory steps, achieving >80% detection accuracy on synthetic traces.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -260,6 +260,7 @@ from .semantic_drift_detector import SemanticDriftDetector
 from .data_provenance_ledger import DataProvenanceLedger
 from .blockchain_provenance_ledger import BlockchainProvenanceLedger
 from .fairness_evaluator import FairnessEvaluator
+from .fairness_visualizer import FairnessVisualizer
 from .cross_lingual_fairness import CrossLingualFairnessEvaluator
 from .risk_dashboard import RiskDashboard
 from .alignment_dashboard import AlignmentDashboard

--- a/src/fairness_evaluator.py
+++ b/src/fairness_evaluator.py
@@ -1,31 +1,33 @@
 from __future__ import annotations
 from typing import Dict
 
+import numpy as np
+
 
 class FairnessEvaluator:
     """Compute simple fairness metrics."""
 
     def demographic_parity(self, label_counts: Dict[str, Dict[str, int]], positive_label: str = "1") -> float:
-        rates = []
-        for group, counts in label_counts.items():
-            total = sum(counts.values())
-            if total == 0:
-                continue
-            rates.append(counts.get(positive_label, 0) / total)
+        rates = [
+            counts.get(positive_label, 0) / total
+            for counts in label_counts.values()
+            if (total := sum(counts.values())) > 0
+        ]
         if not rates:
             return 0.0
-        return max(rates) - min(rates)
+        arr = np.asarray(rates, dtype=float)
+        return float(arr.max() - arr.min())
 
     def equal_opportunity(self, stats: Dict[str, Dict[str, int]]) -> float:
-        tpr = []
-        for group, counts in stats.items():
-            pos = counts.get("tp", 0) + counts.get("fn", 0)
-            if pos == 0:
-                continue
-            tpr.append(counts.get("tp", 0) / pos)
+        tpr = [
+            counts.get("tp", 0) / pos
+            for counts in stats.values()
+            if (pos := counts.get("tp", 0) + counts.get("fn", 0)) > 0
+        ]
         if not tpr:
             return 0.0
-        return max(tpr) - min(tpr)
+        arr = np.asarray(tpr, dtype=float)
+        return float(arr.max() - arr.min())
 
     def evaluate(self, stats: Dict[str, Dict[str, int]], positive_label: str = "1") -> Dict[str, float]:
         return {

--- a/src/fairness_visualizer.py
+++ b/src/fairness_visualizer.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import base64
+import io
+import json
+from functools import lru_cache
+from typing import Dict, Any
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from .fairness_evaluator import FairnessEvaluator
+
+
+class FairnessVisualizer:
+    """Render demographic parity and equal opportunity gaps.
+
+    Caches previously generated images keyed by the input stats so repeated
+    calls avoid redundant plotting work.
+    """
+
+    def __init__(self, evaluator: FairnessEvaluator | None = None) -> None:
+        self.evaluator = evaluator or FairnessEvaluator()
+        self._cache: Dict[str, str] = {}
+
+    # --------------------------------------------------------------
+    def _bar_plot(self, labels: list[str], dp: list[float], eo: list[float]) -> str:
+        fig, ax = plt.subplots(figsize=(max(2, len(labels)), 2))
+        x = range(len(labels))
+        ax.bar([i - 0.2 for i in x], dp, width=0.4, label="parity")
+        ax.bar([i + 0.2 for i in x], eo, width=0.4, label="opportunity")
+        ax.set_xticks(list(x))
+        ax.set_xticklabels(labels)
+        ax.set_ylabel("gap")
+        ax.legend()
+        plt.tight_layout()
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png")
+        plt.close(fig)
+        return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+    # --------------------------------------------------------------
+    def to_image(self, results: Dict[str, Any], positive_label: str = "1") -> str:
+        """Return a base64 PNG for ``results`` from ``FairnessEvaluator``."""
+        key = json.dumps(results, sort_keys=True) + positive_label
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+
+        # ``results`` can be raw stats or already-computed metrics.
+        if "demographic_parity" in results and "equal_opportunity" in results:
+            labels = ["dataset"]
+            dp_vals = [float(results["demographic_parity"])]
+            eo_vals = [float(results["equal_opportunity"])]
+            img = self._bar_plot(labels, dp_vals, eo_vals)
+            self._cache[key] = img
+            return img
+
+        # maybe multimodal metrics
+        first = next(iter(results.values()))
+        if isinstance(first, dict) and "demographic_parity" in first:
+            labels = []
+            dp_vals = []
+            eo_vals = []
+            for mod, vals in results.items():
+                labels.append(mod)
+                dp_vals.append(float(vals.get("demographic_parity", 0.0)))
+                eo_vals.append(float(vals.get("equal_opportunity", 0.0)))
+            img = self._bar_plot(labels, dp_vals, eo_vals)
+            self._cache[key] = img
+            return img
+
+        # assume raw stats mapping group->counts or modality->group->counts
+        if isinstance(first, dict) and any(isinstance(v, dict) for v in first.values()):
+            metrics = self.evaluator.evaluate_multimodal(results, positive_label)
+            img = self.to_image(metrics)
+            self._cache[key] = img
+            return img
+        metrics = self.evaluator.evaluate(results, positive_label)
+        img = self.to_image(metrics)
+        self._cache[key] = img
+        return img
+
+
+__all__ = ["FairnessVisualizer"]

--- a/tests/test_dataset_summary.py
+++ b/tests/test_dataset_summary.py
@@ -61,6 +61,20 @@ class TestDatasetSummary(unittest.TestCase):
             data = json.loads(result)
             self.assertIn('content_summaries', data)
 
+    def test_fairness_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            stats = {'g1': {'tp': 1, 'fn': 1}, 'g2': {'tp': 2, 'fn': 0}}
+            stats_file = root / 'fairness.json'
+            stats_file.write_text(json.dumps(stats))
+            out_dir = Path('docs/datasets')
+            if out_dir.exists():
+                for p in out_dir.iterdir():
+                    p.unlink()
+            summary_mod.main([str(root), '--fairness-report', str(stats_file)])
+            out_img = out_dir / f'{root.name}_fairness.png'
+            self.assertTrue(out_img.exists())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- cache fairness plots and use numpy for evaluation
- report missing stats when dataset summary can't find a file
- show latest fairness chart in memory dashboard
- document new dashboard integration

## Testing
- `python -m py_compile scripts/dataset_summary.py src/fairness_visualizer.py src/memory_dashboard.py src/fairness_evaluator.py`
- `python -m unittest tests.test_dataset_summary` *(fails: AttributeError: 'matrix' object has no attribute 'toarray')*
- `pytest -q` *(fails: many missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686c3cb94354833190c8942baf135a69