### PR TITLE
Add reasoning graph diff tools

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -928,6 +928,11 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   `/graph/recompute` so reasoning graphs can be edited interactively. Each edit
   records a new summary via `ReasoningHistoryLogger`. The script
   `scripts/graph_playground.py` launches this playground.
+- `GraphOfThought.to_json()` now emits a deterministic `stable_id` for each
+  node so snapshots can be diffed across runs. `ReasoningHistoryLogger.save_graph()`
+  persists a graph to disk and logs the path. `scripts/graph_diff.py` compares
+  two saved graphs and reports added or changed nodes and edges. The logger's
+  `analyze()` method returns these diffs alongside step clusters.
 - Provide a `ResourceBroker` module coordinating multiple clusters and a demo
   script `scripts/resource_broker_demo.py`. The broker now reports per-accelerator
   utilisation via `get_load()` and allows allocating jobs to specific

--- a/scripts/graph_diff.py
+++ b/scripts/graph_diff.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""Compute differences between two reasoning graphs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from asi.reasoning_history import _diff_graph_data
+
+
+def load_json(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Diff two GraphOfThought JSON files")
+    parser.add_argument("old_graph", help="Path to the older graph JSON")
+    parser.add_argument("new_graph", help="Path to the newer graph JSON")
+    args = parser.parse_args()
+
+    old = load_json(args.old_graph)
+    new = load_json(args.new_graph)
+    diff = _diff_graph_data(old, new)
+
+    print(f"Added nodes: {len(diff['added_nodes'])}")
+    if diff["added_nodes"]:
+        print(" - " + "\n - ".join(n.get("text", "") for n in diff["added_nodes"]))
+    print(f"Changed nodes: {len(diff['changed_nodes'])}")
+    print(f"Added edges: {len(diff['added_edges'])}")
+    print(f"Changed edges: {len(diff['changed_edges'])}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    main()

--- a/src/graph_of_thought.py
+++ b/src/graph_of_thought.py
@@ -60,6 +60,20 @@ class GraphOfThought:
         self.analyzer = analyzer
         self.layer = layer
 
+    # --------------------------------------------------------------
+    @staticmethod
+    def _stable_id(text: str, meta: Dict[str, Any] | None = None) -> str:
+        """Return a stable hash for a node."""
+        import hashlib
+
+        h = hashlib.sha256(text.encode())
+        if meta:
+            try:
+                h.update(json.dumps(meta, sort_keys=True).encode())
+            except Exception:
+                h.update(str(meta).encode())
+        return h.hexdigest()[:16]
+
     def add_step(
         self,
         text: str,
@@ -200,6 +214,7 @@ class GraphOfThought:
         nodes = [
             {
                 "id": n.id,
+                "stable_id": self._stable_id(n.text, n.metadata),
                 "text": n.text,
                 "metadata": n.metadata,
                 "timestamp": n.timestamp,


### PR DESCRIPTION
## Summary
- include stable node IDs in GraphOfThought JSON
- persist graphs per run via ReasoningHistoryLogger.save_graph
- surface graph diffs from consecutive runs in ReasoningHistoryLogger.analyze
- provide scripts/graph_diff.py for diffing two graph files
- document the new workflow

## Testing
- `pytest -q` *(fails: AttributeError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686c529c019883318f05cb496ce9876c