### PR TITLE
Add async dataset gap search

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -596,6 +596,11 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
      Run `python -m asi.streaming_dataset_watcher db.sqlite <rss-url>` to start
      watching feeds.
 
+82b. **Dataset gap search**: `dataset_gap_search.run_gap_search_async` formulates
+    queries for missing languages or domains and fetches candidate URLs
+    concurrently using a search API. The discovered URLs are logged with
+    `DatasetLineageManager` for reproducibility.
+
 83. **Analogy-based retrieval evaluation**: Use `analogical_retrieval.analogy_search()`
     on a small word-analogy dataset. For each tuple `(A, B, Q)` compute the
     offset `B - A` and query `HierarchicalMemory.search(mode="analogy")`. Report

--- a/src/dataset_gap_search.py
+++ b/src/dataset_gap_search.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable, List
+import aiohttp
+import requests
+
+from .dataset_lineage_manager import DatasetLineageManager
+
+
+@dataclass
+class CandidateURL:
+    url: str
+    title: str
+    snippet: str
+    language: str | None = None
+    domain: str | None = None
+
+
+def _slugify(text: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in text)[:50]
+
+
+def formulate_gap_queries(
+    datasets: Iterable[dict],
+    languages: Iterable[str],
+    domains: Iterable[str],
+) -> List[str]:
+    """Return search queries for missing languages or domains."""
+    existing_langs = {d.get("language") for d in datasets if d.get("language")}
+    existing_domains = {d.get("domain") for d in datasets if d.get("domain")}
+
+    missing_langs = [l for l in languages if l not in existing_langs]
+    missing_domains = [d for d in domains if d not in existing_domains]
+
+    queries: set[str] = set()
+    for lang in missing_langs:
+        queries.add(f"{lang} language dataset")
+        for dom in domains:
+            queries.add(f"{lang} {dom} dataset")
+    for dom in missing_domains:
+        queries.add(f"{dom} dataset")
+    return sorted(queries)
+
+
+def search_candidates(
+    query: str,
+    api_url: str = "https://api.duckduckgo.com/",
+    max_results: int = 5,
+) -> List[CandidateURL]:
+    """Return candidate URLs for ``query`` using a web search API."""
+    try:
+        resp = requests.get(
+            api_url, params={"q": query, "format": "json"}, timeout=10
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return []
+
+    results: List[CandidateURL] = []
+    for item in data.get("results", [])[:max_results]:
+        results.append(
+            CandidateURL(
+                url=item.get("url", ""),
+                title=item.get("title", ""),
+                snippet=item.get("snippet", ""),
+            )
+        )
+    return results
+
+
+async def search_candidates_async(
+    query: str,
+    session: aiohttp.ClientSession,
+    api_url: str = "https://api.duckduckgo.com/",
+    max_results: int = 5,
+) -> List[CandidateURL]:
+    """Asynchronously return candidate URLs for ``query``."""
+    try:
+        async with session.get(api_url, params={"q": query, "format": "json"}, timeout=10) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+    except Exception:
+        return []
+
+    results: List[CandidateURL] = []
+    for item in data.get("results", [])[:max_results]:
+        results.append(
+            CandidateURL(
+                url=item.get("url", ""),
+                title=item.get("title", ""),
+                snippet=item.get("snippet", ""),
+            )
+        )
+    return results
+
+
+def run_gap_search(
+    datasets: Iterable[dict],
+    languages: Iterable[str],
+    domains: Iterable[str],
+    out_dir: str | Path,
+    lineage: DatasetLineageManager,
+    api_url: str = "https://api.duckduckgo.com/",
+) -> List[CandidateURL]:
+    """Search the web for missing data and log results."""
+    queries = formulate_gap_queries(datasets, languages, domains)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    results: List[CandidateURL] = []
+    for q in queries:
+        found = search_candidates(q, api_url=api_url)
+        results.extend(found)
+        if not found:
+            continue
+        path = out_dir / f"{_slugify(q)}.json"
+        path.write_text(json.dumps([asdict(c) for c in found], indent=2))
+        lineage.record([], [path], note=f"gap search: {q}")
+    return results
+
+
+async def run_gap_search_async(
+    datasets: Iterable[dict],
+    languages: Iterable[str],
+    domains: Iterable[str],
+    out_dir: str | Path,
+    lineage: DatasetLineageManager,
+    api_url: str = "https://api.duckduckgo.com/",
+) -> List[CandidateURL]:
+    """Asynchronously search the web for missing data and log results."""
+    queries = formulate_gap_queries(datasets, languages, domains)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    results: List[CandidateURL] = []
+    async with aiohttp.ClientSession() as session:
+        tasks = [search_candidates_async(q, session, api_url=api_url) for q in queries]
+        query_results = await asyncio.gather(*tasks)
+
+    for q, found in zip(queries, query_results):
+        results.extend(found)
+        if not found:
+            continue
+        path = out_dir / f"{_slugify(q)}.json"
+        path.write_text(json.dumps([asdict(c) for c in found], indent=2))
+        lineage.record([], [path], note=f"gap search: {q}")
+    return results
+
+
+__all__ = [
+    "CandidateURL",
+    "formulate_gap_queries",
+    "search_candidates",
+    "search_candidates_async",
+    "run_gap_search",
+    "run_gap_search_async",
+]

--- a/tests/test_dataset_gap_search.py
+++ b/tests/test_dataset_gap_search.py
@@ -1,0 +1,82 @@
+import json
+import tempfile
+import unittest
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+import types
+import sys
+
+# Stub out dataset_watermarker to avoid optional Pillow dependency
+wm_stub = types.ModuleType("asi.dataset_watermarker")
+wm_stub.detect_watermark = lambda path: None
+sys.modules["asi.dataset_watermarker"] = wm_stub
+
+from asi.dataset_gap_search import (
+    formulate_gap_queries,
+    run_gap_search,
+    run_gap_search_async,
+    CandidateURL,
+)
+from asi.dataset_lineage_manager import DatasetLineageManager
+
+
+class TestDatasetGapSearch(unittest.TestCase):
+    def test_formulate_gap_queries(self):
+        datasets = [
+            {"language": "en", "domain": "news"},
+            {"language": "fr", "domain": "science"},
+        ]
+        queries = formulate_gap_queries(datasets, ["en", "de"], ["news", "health"])
+        self.assertIn("de language dataset", queries)
+        self.assertIn("de news dataset", queries)
+        self.assertIn("de health dataset", queries)
+        self.assertIn("health dataset", queries)
+        self.assertNotIn("en news dataset", queries)
+
+    def test_run_gap_search(self):
+        data = [{"language": "en", "domain": "news"}]
+        cand = CandidateURL(url="http://x", title="t", snippet="s")
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr = DatasetLineageManager(tmp)
+            with patch(
+                "asi.dataset_gap_search.search_candidates", return_value=[cand]
+            ):
+                res = run_gap_search(
+                    data,
+                    ["de"],
+                    ["health"],
+                    tmp,
+                    mgr,
+                )
+            self.assertEqual(len(res), 3)
+            out_file = Path(tmp) / "de_health_dataset.json"
+            self.assertTrue(out_file.exists())
+            log = json.loads((Path(tmp) / "dataset_lineage.json").read_text())
+            self.assertEqual(log[0]["note"], "gap search: de health dataset")
+
+    def test_run_gap_search_async(self):
+        data = [{"language": "en", "domain": "news"}]
+        cand = CandidateURL(url="http://x", title="t", snippet="s")
+
+        async def fake_search(*args, **kwargs):
+            return [cand]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr = DatasetLineageManager(tmp)
+            with patch(
+                "asi.dataset_gap_search.search_candidates_async", side_effect=fake_search
+            ):
+                res = asyncio.run(
+                    run_gap_search_async(data, ["de"], ["health"], tmp, mgr)
+                )
+
+            self.assertEqual(len(res), 3)
+            out_file = Path(tmp) / "de_health_dataset.json"
+            self.assertTrue(out_file.exists())
+            log = json.loads((Path(tmp) / "dataset_lineage.json").read_text())
+            self.assertEqual(log[0]["note"], "gap search: de health dataset")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement async dataset gap search for parallel URL discovery
- update Plan documentation for async version
- test async gap search workflow

## Testing
- `PYTHONPATH=. pytest tests/test_dataset_gap_search.py -q`
- `pytest -q` *(fails: ModuleNotFoundError for many optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_686c655a60148331a73b6461a3727c66