### PR TITLE
Extend LicenseInspector for dataset discovery

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -566,6 +566,23 @@ paraphrase_multilingual([Path("./data/text/0.txt")], translator, None, inspector
 Run `scripts/lineage_viewer.py ./data` to browse the recorded steps.
 ```
 
+After using `dataset_discovery.store_datasets()` the inspector can audit the
+resulting SQLite database and log a summary for each dataset:
+
+```python
+inspector = LicenseInspector(["mit"])  # allow only MIT
+lineage = DatasetLineageManager("./data")
+res = inspector.scan_discovered_db("./discovered.sqlite", lineage)
+print(res["hf:example"])  # True or False
+```
+
+`LicenseInspector` uses precompiled regex heuristics so scanning large discovery
+databases is quick even with thousands of entries.
+
+Each entry adds a note like ``inspect hf:example license=mit allowed=True`` to
+``dataset_lineage.json`` so compliance results are tracked alongside other
+ingestion steps.
+
 To inject noise for differential privacy, create a `PrivacyGuard` and pass it to
 `download_triples()`. After ingestion, inspect the remaining budget:
 

--- a/src/license_inspector.py
+++ b/src/license_inspector.py
@@ -3,9 +3,28 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
-from typing import Iterable, Dict
+import re
 import sqlite3
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import requests
+
+from .dataset_discovery import DiscoveredDataset
+from .dataset_lineage_manager import DatasetLineageManager
+
+
+# Mapping of canonical license tokens to regex patterns. Compiled once at module
+# import to avoid repeated construction inside methods.
+_LICENSE_PATTERNS: Tuple[Tuple[str, re.Pattern[str]], ...] = (
+    ("mit", re.compile(r"\bmit\b", re.I)),
+    ("apache", re.compile(r"\bapache(?:[- ]?2\.0)?\b", re.I)),
+    ("cc-by", re.compile(r"\bcc[- ]?by(?:-[sa0-9\.]+)?\b", re.I)),
+    ("cc0", re.compile(r"\bcc0\b", re.I)),
+    ("gpl", re.compile(r"\bgpl\b", re.I)),
+    ("bsd", re.compile(r"\bbsd\b", re.I)),
+    ("proprietary", re.compile(r"\bproprietary\b", re.I)),
+)
 
 
 class LicenseInspector:
@@ -14,11 +33,19 @@ class LicenseInspector:
     def __init__(self, allowed: Iterable[str] | None = None) -> None:
         self.allowed = {l.lower() for l in (allowed or ["mit", "apache", "cc-by"])}
 
+    # --------------------------------------------------------------
+    def _match_license(self, text: str) -> str:
+        """Return a license token if ``text`` mentions a known license."""
+        for token, pat in _LICENSE_PATTERNS:
+            if pat.search(text):
+                return token
+        return ""
+
     def inspect(self, meta_file: str | Path) -> bool:
         """Return ``True`` if ``meta_file`` has an allowed license."""
         data = json.loads(Path(meta_file).read_text())
-        lic = data.get("license", "").lower()
-        return any(a in lic for a in self.allowed)
+        lic = self._match_license(data.get("license", ""))
+        return lic in self.allowed
 
     def inspect_dir(self, directory: str | Path) -> Dict[str, bool]:
         """Check all ``*.json`` metadata files under ``directory``."""
@@ -30,16 +57,15 @@ class LicenseInspector:
     # --------------------------------------------------------------
     def inspect_db(self, db_path: str | Path) -> Dict[str, bool]:
         """Check all datasets stored in ``db_path`` SQLite database."""
-        conn = sqlite3.connect(db_path)
-        cur = conn.execute(
-            "SELECT name, source, license, license_text FROM datasets"
-        )
-        out: Dict[str, bool] = {}
-        for name, src, lic, lic_text in cur:
-            text = (lic or "") + " " + (lic_text or "")
-            text = text.lower()
-            out[f"{src}:{name}"] = any(a in text for a in self.allowed)
-        conn.close()
+        with sqlite3.connect(db_path) as conn:
+            cur = conn.execute(
+                "SELECT name, source, license, license_text FROM datasets"
+            )
+            out: Dict[str, bool] = {}
+            for name, src, lic, lic_text in cur:
+                text = f"{lic or ''} {lic_text or ''}"
+                token = self._match_license(text)
+                out[f"{src}:{name}"] = token in self.allowed
         return out
 
     # --------------------------------------------------------------
@@ -47,6 +73,49 @@ class LicenseInspector:
         """Write a JSON report for datasets in ``db_path``."""
         res = self.inspect_db(db_path)
         Path(out_file).write_text(json.dumps(res, indent=2))
+
+    # --------------------------------------------------------------
+    def inspect_discovered(
+        self,
+        dataset: DiscoveredDataset,
+        lineage: DatasetLineageManager | None = None,
+    ) -> bool:
+        """Check a :class:`DiscoveredDataset` and optionally log to lineage."""
+        text = f"{dataset.license} {dataset.license_text}"
+        if not text.strip() and dataset.url:
+            try:
+                resp = requests.get(dataset.url, timeout=5)
+                resp.raise_for_status()
+                text = resp.text
+            except Exception:
+                text = ""
+        lic = self._match_license(text)
+        allowed = lic in self.allowed
+        if lineage is not None:
+            note = f"inspect {dataset.source}:{dataset.name} license={lic or 'unknown'} allowed={allowed}"
+            try:
+                lineage.record([dataset.url], [], note=note)
+            except Exception:
+                pass
+        return allowed
+
+    # --------------------------------------------------------------
+    def scan_discovered_db(
+        self,
+        db_path: str | Path,
+        lineage: DatasetLineageManager | None = None,
+    ) -> Dict[str, bool]:
+        """Inspect all discovered datasets in ``db_path``."""
+        with sqlite3.connect(db_path) as conn:
+            cur = conn.execute(
+                "SELECT name, source, url, license, license_text FROM datasets"
+            )
+            out: Dict[str, bool] = {}
+            for name, source, url, lic, lic_text in cur:
+                d = DiscoveredDataset(name, url, source, lic or "", lic_text or "")
+                ok = self.inspect_discovered(d, lineage)
+                out[f"{source}:{name}"] = ok
+        return out
 
 
 __all__ = ["LicenseInspector"]

--- a/tests/test_dataset_discovery.py
+++ b/tests/test_dataset_discovery.py
@@ -22,7 +22,13 @@ DiscoveredDataset = dd.DiscoveredDataset
 parse_hf = dd.discover_huggingface
 store_datasets = dd.store_datasets
 
-from asi.license_inspector import LicenseInspector
+loader_li = importlib.machinery.SourceFileLoader('src.license_inspector', 'src/license_inspector.py')
+spec_li = importlib.util.spec_from_loader(loader_li.name, loader_li)
+li = importlib.util.module_from_spec(spec_li)
+li.__package__ = 'src'
+sys.modules['src.license_inspector'] = li
+loader_li.exec_module(li)
+LicenseInspector = li.LicenseInspector
 
 
 class TestDatasetDiscovery(unittest.TestCase):

--- a/tests/test_license_inspector.py
+++ b/tests/test_license_inspector.py
@@ -19,6 +19,23 @@ sys.modules['src.license_inspector'] = li
 loader.exec_module(li)
 LicenseInspector = li.LicenseInspector
 
+loader2 = importlib.machinery.SourceFileLoader('src.dataset_discovery', 'src/dataset_discovery.py')
+spec2 = importlib.util.spec_from_loader(loader2.name, loader2)
+dd = importlib.util.module_from_spec(spec2)
+dd.__package__ = 'src'
+sys.modules['src.dataset_discovery'] = dd
+loader2.exec_module(dd)
+DiscoveredDataset = dd.DiscoveredDataset
+store_datasets = dd.store_datasets
+
+loader3 = importlib.machinery.SourceFileLoader('src.dataset_lineage_manager', 'src/dataset_lineage_manager.py')
+spec3 = importlib.util.spec_from_loader(loader3.name, loader3)
+dlm = importlib.util.module_from_spec(spec3)
+dlm.__package__ = 'src'
+sys.modules['src.dataset_lineage_manager'] = dlm
+loader3.exec_module(dlm)
+DatasetLineageManager = dlm.DatasetLineageManager
+
 
 class TestLicenseInspector(unittest.TestCase):
     def test_inspect(self):
@@ -28,6 +45,25 @@ class TestLicenseInspector(unittest.TestCase):
             insp = LicenseInspector()
             res = insp.inspect_dir(tmp)
             self.assertTrue(res[str(meta)])
+
+    def test_scan_discovered(self):
+        rss = """<rss><channel>
+        <item><title>ds1</title><link>http://x/ds1</link><license>MIT</license></item>
+        <item><title>ds2</title><link>http://x/ds2</link><license>GPL</license></item>
+        </channel></rss>"""
+        dsets = dd._parse_rss(rss, 'hf')
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / 'db.sqlite'
+            store_datasets(dsets, db)
+            lin_root = Path(tmp) / 'lineage'
+            lin_root.mkdir()
+            lineage = DatasetLineageManager(lin_root)
+            insp = LicenseInspector(['mit'])
+            res = insp.scan_discovered_db(db, lineage)
+            self.assertTrue(res['hf:ds1'])
+            self.assertFalse(res['hf:ds2'])
+            data = json.loads((lin_root / 'dataset_lineage.json').read_text())
+            self.assertEqual(len(data), 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- extend `LicenseInspector` with `_match_license`, `inspect_discovered` and `scan_discovered_db`
- record license summaries in lineage manager during discovery checks
- document how to use `scan_discovered_db`
- adjust tests to cover new functionality
- optimize license checks using precompiled regexes

## Testing
- `pytest tests/test_license_inspector.py tests/test_dataset_discovery.py tests/test_dataset_lineage_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686c65609e0883318850fe5c37f2f79a