### PR TITLE
Improve cross-lingual search performance

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -781,6 +781,10 @@ python scripts/attention_analysis.py --model model.pt --input sample.txt --out-d
   `query_summary()` retrieves these summaries in any supported language and
   `ReasoningHistoryLogger.log()` records which node ids were summarised along
   with the memory location for later inspection.
+- Extend `CrossLingualReasoningGraph` with `search(query, lang)` which
+  translates ``query`` to each node's language, embeds the texts using a
+  deterministic hash and returns node IDs ranked by cosine similarity.
+  Embeddings are cached per-language so subsequent searches reuse them.
 - Create a `WorldModelDistiller` module and a `scripts/distill_world_model.py`
   utility to train smaller student models from the large world model.
   **Implemented in `src/world_model_distiller.py` with the script

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -468,6 +468,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 41b1. **Multilingual Graph UI**: The HTML interface offers a language selector so
       nodes are displayed and edited in the chosen language using
       `CrossLingualReasoningGraph.translate_node()`.
+41b2. **Cross-lingual graph search**: `CrossLingualReasoningGraph.search()`
+      translates the query language, embeds all nodes and returns IDs ordered by
+      similarity. Embeddings are cached per language to speed up repeated
+      queries.
 41c. **Multimodal reasoning graph**: `CrossLingualReasoningGraph.add_step()`
      accepts `image_embed` and `audio_embed`. Use `embed_modalities()` from
      `CrossModalFusion` to generate vectors. `ReasoningHistoryLogger` preserves

--- a/src/cross_lingual_graph.py
+++ b/src/cross_lingual_graph.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Sequence
+import numpy as np
 
 try:  # pragma: no cover - optional heavy dep
     import torch
@@ -14,6 +15,19 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - missing torch or other deps
     from typing import Any as ContextSummaryMemory  # type: ignore
 from .reasoning_history import ReasoningHistoryLogger
+
+# deterministic text embedding dimension
+_EMBED_DIM = 8
+
+def _embed_text(text: str) -> np.ndarray:
+    """Return a deterministic embedding for ``text``."""
+    seed = abs(hash(text)) % (2 ** 32)
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal(_EMBED_DIM).astype(np.float32)
+
+def _cos_sim(a: np.ndarray, b: np.ndarray) -> float:
+    """Return cosine similarity between ``a`` and ``b``."""
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-8))
 
 
 class CrossLingualReasoningGraph(GraphOfThought):
@@ -39,6 +53,7 @@ class CrossLingualReasoningGraph(GraphOfThought):
     ) -> int:
         meta = dict(metadata or {})
         meta["lang"] = lang
+        meta.setdefault("embeddings", {lang: _embed_text(text).tolist()})
         if image_embed is not None:
             meta["image_vec"] = list(image_embed)
         if audio_embed is not None:
@@ -95,6 +110,7 @@ class CrossLingualReasoningGraph(GraphOfThought):
             translations[target_lang] = text
         else:
             node.metadata["translations"] = {target_lang: text}
+        node.metadata.setdefault("embeddings", {})[target_lang] = _embed_text(text).tolist()
         return text
 
     def get_translations(self, node_id: int) -> Dict[str, str]:
@@ -104,6 +120,18 @@ class CrossLingualReasoningGraph(GraphOfThought):
         if self.translator is None:
             return {node.metadata.get("lang", ""): node.text}
         return self.translator.translate_all(node.text)
+
+    def _node_embedding(self, node_id: int, lang: str) -> np.ndarray:
+        """Return cached embedding for ``node_id`` in ``lang``."""
+        node = self.nodes[node_id]
+        embeds = node.metadata.setdefault("embeddings", {})
+        vec = embeds.get(lang)
+        if vec is not None:
+            return np.asarray(vec, dtype=np.float32)
+        text = self.translate_node(node_id, lang) if lang != node.metadata.get("lang") else node.text
+        vec = _embed_text(text)
+        embeds[lang] = vec.tolist()
+        return vec
 
     def summarize_trace(self, trace: Sequence[int], lang: str | None = None) -> str:
         if lang is None:
@@ -132,6 +160,20 @@ class CrossLingualReasoningGraph(GraphOfThought):
         if translator is not None and lang != "en":
             return translator.translate(text, lang)
         return text
+
+    # ------------------------------------------------------------
+    def search(self, query: str, lang: str = "en") -> list[int]:
+        """Return node ids ranked by similarity to ``query`` in ``lang``."""
+        if not self.nodes:
+            return []
+        q_vec = _embed_text(query)
+        q_norm = q_vec / (np.linalg.norm(q_vec) + 1e-8)
+        ids = list(self.nodes)
+        embeds = np.stack([self._node_embedding(i, lang) for i in ids], axis=0)
+        embeds /= np.linalg.norm(embeds, axis=1, keepdims=True) + 1e-8
+        sims = embeds @ q_norm
+        order = np.argsort(-sims)
+        return [ids[i] for i in order]
 
 
 __all__ = ["CrossLingualReasoningGraph"]

--- a/tests/test_crosslingual_graph_search.py
+++ b/tests/test_crosslingual_graph_search.py
@@ -1,0 +1,63 @@
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import unittest
+import numpy as np
+
+try:
+    import torch
+except Exception:  # pragma: no cover - torch optional
+    raise unittest.SkipTest("torch not available")
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+
+
+def load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'asi'
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    setattr(pkg, name.split('.')[-1], mod)
+    return mod
+
+di = load('asi.data_ingest', 'src/data_ingest.py')
+goth = load('asi.graph_of_thought', 'src/graph_of_thought.py')
+cg = load('asi.cross_lingual_graph', 'src/cross_lingual_graph.py')
+
+CrossLingualReasoningGraph = cg.CrossLingualReasoningGraph
+CrossLingualTranslator = di.CrossLingualTranslator
+
+
+class TestCrossLingualGraphSearch(unittest.TestCase):
+    def test_search_ranking(self):
+        tr = CrossLingualTranslator(['es'])
+        g = CrossLingualReasoningGraph(translator=tr)
+        n0 = g.add_step('hello')
+        n1 = g.add_step('goodbye')
+        result = g.search('hola', 'es')
+
+        def embed(text):
+            seed = abs(hash(text)) % (2 ** 32)
+            rng = np.random.default_rng(seed)
+            return rng.standard_normal(8)
+
+        def cos(a, b):
+            return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-8))
+
+        q_vec = embed('hola')
+        sims = {
+            n0: cos(embed(tr.translate('hello', 'es')), q_vec),
+            n1: cos(embed(tr.translate('goodbye', 'es')), q_vec),
+        }
+        expected = [nid for nid, _ in sorted(sims.items(), key=lambda kv: kv[1], reverse=True)]
+        self.assertEqual(result, expected)
+        self.assertIn('es', g.nodes[n0].metadata['embeddings'])
+        self.assertIn('es', g.nodes[n1].metadata['embeddings'])
+
+
+if __name__ == '__main__':  # pragma: no cover - test helper
+    unittest.main()


### PR DESCRIPTION
## Summary
- cache text embeddings per language for faster repeated search
- vectorize similarity computation in `search`
- document caching in the implementation notes and project plan
- test embedding caching

## Testing
- `pytest tests/test_cross_lingual_reasoning_graph.py tests/test_crosslingual_graph_summary.py tests/test_crosslingual_graph_search.py -q` *(tests skipped: torch missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c6578653c8331b0394d075da44c26