### PR TITLE
Implement fairness feedback loop

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -455,7 +455,14 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
      heuristic fallback. The parser caches the loaded model and honors the
      ``LLM_PARSER_MODEL`` environment variable to customize loading. Calling
      `download_triples(use_llm_parser=True)` saves triples to
-     ``*.triples.json`` files for downstream RAG pipelines ([arxiv.org][15]).
+    ``*.triples.json`` files for downstream RAG pipelines ([arxiv.org][15]).
+40e. **Fairness feedback loop**: `fairness_feedback.FairnessFeedback` monitors
+     cross-lingual demographic parity and equal opportunity. When the gap of
+     either metric exceeds a configurable threshold it adjusts
+     `ActiveDataSelector` or dataset weights through reinforcement learning and
+     logs the action via `DatasetLineageManager` for reproducibility. Thresholds
+     are clamped to a safe range and updated weights are persisted via
+     `DatasetWeightAgent.update_db()`.
 41a. **Cross-lingual summarization memory**: `ContextSummaryMemory` stores summaries
      in the source language and translated forms. Results are translated back
      to the query language. See `docs/Implementation.md` for details.

--- a/src/fairness_feedback.py
+++ b/src/fairness_feedback.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+try:
+    from .cross_lingual_fairness import CrossLingualFairnessEvaluator
+except Exception:  # pragma: no cover - during tests
+    from cross_lingual_fairness import CrossLingualFairnessEvaluator  # type: ignore
+
+try:
+    from .dataset_weight_agent import DatasetWeightAgent
+except Exception:  # pragma: no cover - during tests
+    from dataset_weight_agent import DatasetWeightAgent  # type: ignore
+
+try:
+    from .data_ingest import ActiveDataSelector
+except Exception:  # pragma: no cover - during tests
+    from data_ingest import ActiveDataSelector  # type: ignore
+
+try:
+    from .adaptive_curriculum import SampleWeightRL
+except Exception:  # pragma: no cover - during tests
+    from adaptive_curriculum import SampleWeightRL  # type: ignore
+
+try:
+    from .dataset_lineage_manager import DatasetLineageManager
+except Exception:  # pragma: no cover - during tests
+    from dataset_lineage_manager import DatasetLineageManager  # type: ignore
+
+
+class FairnessFeedback:
+    """Adjust dataset selection based on cross-lingual fairness metrics."""
+
+    def __init__(
+        self,
+        selector: ActiveDataSelector | None = None,
+        weight_agent: DatasetWeightAgent | None = None,
+        gap_threshold: float = 0.1,
+        lineage: DatasetLineageManager | None = None,
+        rl_lr: float = 0.1,
+        positive_label: str = "tp",
+        min_threshold: float = 0.1,
+        max_threshold: float = 10.0,
+    ) -> None:
+        self.selector = selector
+        self.weight_agent = weight_agent
+        self.gap_threshold = gap_threshold
+        self.lineage = lineage
+        self.pos_label = positive_label
+        self.evaluator = CrossLingualFairnessEvaluator()
+        self.rl = SampleWeightRL(2, lr=rl_lr) if selector is not None else None
+        self.min_threshold = min_threshold
+        self.max_threshold = max_threshold
+
+    # --------------------------------------------------------------
+    def update(
+        self,
+        stats: Dict[str, Dict[str, int]],
+        dataset: str = "dataset",
+        val_accuracy: float = 1.0,
+    ) -> Dict[str, float]:
+        """Update selection strategy using fairness ``stats`` and log results."""
+        metrics = self.evaluator.evaluate(stats, positive_label=self.pos_label)
+        gap = max(
+            metrics.get("demographic_parity", 0.0),
+            metrics.get("equal_opportunity", 0.0),
+        )
+        changed: Dict[str, Any] = {}
+        if gap > self.gap_threshold:
+            if self.weight_agent is not None:
+                self.weight_agent.observe(dataset, val_accuracy, stats)
+                self.weight_agent.update_db()
+                changed["weight"] = self.weight_agent.weight(dataset)
+            if self.selector is not None and self.rl is not None:
+                probs = self.rl.weights()
+                action = 0 if float(probs[0]) >= float(probs[1]) else 1
+                self.rl.update(action, 1.0 - gap)
+                if action == 0:
+                    self.selector.threshold *= 1.1
+                else:
+                    self.selector.threshold *= 0.9
+                self.selector.threshold = min(
+                    max(self.selector.threshold, self.min_threshold),
+                    self.max_threshold,
+                )
+                changed["threshold"] = self.selector.threshold
+        if self.lineage is not None and changed:
+            self.lineage.record(
+                [],
+                [],
+                note=f"fairness_feedback metrics={metrics} changed={changed}",
+            )
+        return metrics
+
+
+__all__ = ["FairnessFeedback"]

--- a/tests/test_fairness_feedback.py
+++ b/tests/test_fairness_feedback.py
@@ -1,0 +1,92 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+import tempfile
+import sqlite3
+import json
+from pathlib import Path
+import unittest
+
+src_pkg = types.ModuleType('src')
+sys.modules['src'] = src_pkg
+src_pkg.__path__ = ['src']
+src_pkg.__spec__ = importlib.machinery.ModuleSpec('src', None, is_package=True)
+import numpy as np
+torch_stub = types.SimpleNamespace(
+    Tensor=np.ndarray,
+    float32=float,
+    nn=types.SimpleNamespace(Module=object),
+    zeros=lambda n, dtype=None: np.zeros(n, dtype=float),
+    softmax=lambda x, dim=0: np.exp(x) / np.exp(x).sum(),
+)
+sys.modules.setdefault('torch', torch_stub)
+sys.modules.setdefault('requests', types.ModuleType('requests'))
+sys.modules.setdefault('PIL', types.ModuleType('PIL'))
+sys.modules.setdefault('PIL.Image', types.ModuleType('PIL.Image'))
+sys.modules.setdefault('PIL.PngImagePlugin', types.ModuleType('PIL.PngImagePlugin'))
+sys.modules.setdefault('PIL.UnidentifiedImageError', type('E', (), {}))
+robot_skill_stub = types.ModuleType('src.robot_skill_transfer')
+robot_skill_stub.VideoPolicyDataset = list
+sys.modules.setdefault('src.robot_skill_transfer', robot_skill_stub)
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(f'src.{name}', path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = 'src'
+    sys.modules[f'src.{name}'] = mod
+    loader.exec_module(mod)
+    setattr(src_pkg, name.split('.')[-1], mod)
+    return mod
+
+# load dependencies
+
+_load('fairness_evaluator', 'src/fairness_evaluator.py')
+
+data_ingest = _load('data_ingest', 'src/data_ingest.py')
+_load('dataset_lineage_manager', 'src/dataset_lineage_manager.py')
+_load('adaptive_curriculum', 'src/adaptive_curriculum.py')
+_load('cross_lingual_fairness', 'src/cross_lingual_fairness.py')
+_load('dataset_weight_agent', 'src/dataset_weight_agent.py')
+ff_mod = _load('fairness_feedback', 'src/fairness_feedback.py')
+
+ActiveDataSelector = data_ingest.ActiveDataSelector
+DatasetLineageManager = sys.modules['src.dataset_lineage_manager'].DatasetLineageManager
+WeightAgent = sys.modules['src.dataset_weight_agent'].DatasetWeightAgent
+FairnessFeedback = ff_mod.FairnessFeedback
+
+
+class TestFairnessFeedback(unittest.TestCase):
+    def test_update_and_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / 'db.sqlite'
+            conn = sqlite3.connect(db)
+            conn.execute('CREATE TABLE datasets (name TEXT, source TEXT, url TEXT, license TEXT, license_text TEXT, weight REAL)')
+            conn.execute("INSERT INTO datasets VALUES('ds','src','u','MIT','','0')")
+            conn.commit()
+            conn.close()
+
+            lineage = DatasetLineageManager(tmp)
+            selector = ActiveDataSelector(threshold=1.0)
+            agent = WeightAgent(db)
+            fb = FairnessFeedback(selector, agent, gap_threshold=0.0, lineage=lineage)
+
+            stats = {'hola': {'tp': 1, 'fn': 0}, '[en] hola': {'tp': 0, 'fn': 1}}
+            metrics = fb.update(stats, dataset='src:ds', val_accuracy=1.0)
+            self.assertIn('demographic_parity', metrics)
+            self.assertNotEqual(selector.threshold, 1.0)
+
+            with sqlite3.connect(db) as c:
+                weight = c.execute('SELECT weight FROM datasets').fetchone()[0]
+            self.assertNotEqual(weight, 0.0)
+
+            log = json.loads((Path(tmp) / 'dataset_lineage.json').read_text())
+            self.assertEqual(len(log), 1)
+            self.assertIn('fairness_feedback', log[0]['note'])
+            self.assertIn('metrics', log[0]['note'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new `FairnessFeedback` module to adapt data selection based on cross-lingual fairness metrics
- document the feedback loop in the main plan
- test fairness feedback logic

## Testing
- `pytest tests/test_fairness_feedback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686c65d503c483318aa325c15be015d3