### PR TITLE
Enable analog device scheduling

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -126,6 +126,25 @@ with AnalogAccelerator():
 Enable the analog path by passing `use_analog=True` in
 `MultiModalWorldModelConfig` or `EdgeRLTrainer`.
 
+### Analog Device Detection
+
+`hardware_detect.list_analog()` checks several sources to enumerate available
+analog accelerators so the `AdaptiveScheduler` can queue jobs on them. Detection
+proceeds in the following order:
+
+1. If the environment variable `ASI_ANALOG_DEVICES` is set it is parsed as a
+   comma-separated list of device identifiers.
+2. When the optional `analogsim` package exposes `list_devices()` or
+   `device_count()` these helpers are called to query the simulator for attached
+   analog hardware.
+3. If detection fails but `analog_backend._HAS_ANALOG` is `True` the fallback
+   identifier `analog0` is returned.
+
+The detected list is cached so repeated calls avoid querying the backend again.
+
+The scheduler includes these identifiers under the `"analog"` device type which
+means analog hardware can be selected via `add(job, device="analog")`.
+
 ## S-3 Scaling-law Breakpoint Model
 
 `src/scaling_law.py` defines ``BreakpointScalingLaw`` which fits a piecewise

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -556,6 +556,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 58. **Secure federated learner**: Train models across remote peers using encrypted gradient aggregation. Accuracy should stay within 2% of centralized training.
 59. **GPU-aware scheduler**: Monitor GPU memory and compute load to dispatch jobs dynamically. Combined with `ComputeBudgetTracker`, the new `AdaptiveScheduler` automatically pauses or resumes runs based on remaining GPU hours and historical improvement. *Carbon-intensity data now guide the scheduler to prefer lower-emission nodes, reducing the environmental footprint.*
 59a. **Heterogeneous accelerator scheduling**: `hardware_detect.list_*` enumerates CPUs, GPUs, FPGAs, Loihi and analog devices. `AdaptiveScheduler` now queues jobs per device type and picks the region/device with the lowest energy cost and carbon intensity via `TelemetryLogger`.
+    Analog device detection caches the discovered list to avoid repeated queries.
 60. **Adversarial robustness suite**: Generate gradient-based adversarial prompts and measure model degradation. Acceptable drop is <5% accuracy on the evaluation harness.
 61. **Bias-aware dataset filtering**: Add `DatasetBiasDetector` to compute representation metrics and filter skewed samples. Goal is <5% disparity across demographic slices after filtering.
 61a. **Dataset bias mitigation**: `DataBiasMitigator` reweights or filters entries based on these scores. `download_triples()` now applies the mitigator before storing new files.

--- a/tests/test_hardware_detect.py
+++ b/tests/test_hardware_detect.py
@@ -1,0 +1,52 @@
+import unittest
+import importlib.machinery
+import importlib.util
+import types
+import sys
+import os
+
+pkg = types.ModuleType('asi')
+sys.modules['asi'] = pkg
+sys.modules['asi.fpga_backend'] = types.SimpleNamespace(_HAS_FPGA=False, cl=None)
+sys.modules['asi.loihi_backend'] = types.SimpleNamespace(_HAS_LOIHI=False)
+sys.modules['asi.analog_backend'] = types.SimpleNamespace(
+    _HAS_ANALOG=True,
+    analogsim=types.SimpleNamespace()
+)
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = name.rpartition('.')[0]
+    sys.modules[name] = mod
+    loader.exec_module(mod)
+    return mod
+
+hardware_detect = _load('asi.hardware_detect', 'src/hardware_detect.py')
+
+
+class TestHardwareDetect(unittest.TestCase):
+    def tearDown(self):
+        os.environ.pop('ASI_ANALOG_DEVICES', None)
+
+    def test_env_override(self):
+        os.environ['ASI_ANALOG_DEVICES'] = 'd0,d1'
+        self.assertEqual(hardware_detect.list_analog(), ['d0', 'd1'])
+
+    def test_backend_list_devices(self):
+        hardware_detect.analog_backend.analogsim = types.SimpleNamespace(
+            list_devices=lambda: ['a0', 'a1']
+        )
+        self.assertEqual(hardware_detect.list_analog(), ['a0', 'a1'])
+
+    def test_device_count(self):
+        hardware_detect.analog_backend.analogsim = types.SimpleNamespace(
+            device_count=lambda: 2
+        )
+        self.assertEqual(hardware_detect.list_analog(), ['analog0', 'analog1'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/torch.py
+++ b/torch.py
@@ -1,5 +1,25 @@
 import numpy as _np
 
+class _DummyCuda:
+    @staticmethod
+    def is_available() -> bool:
+        return False
+
+    @staticmethod
+    def memory_allocated() -> int:
+        return 0
+
+    @staticmethod
+    def get_device_properties(_):
+        class _P:
+            total_memory = 1
+
+        return _P()
+
+    @staticmethod
+    def utilization() -> float:
+        return 0.0
+
 class Tensor:
     def __init__(self, data):
         self.data = _np.asarray(data, dtype=_np.float32)
@@ -37,10 +57,53 @@ class Tensor:
     def __repr__(self):
         return f"Tensor({self.data!r})"
 
+    def __matmul__(self, other):
+        if isinstance(other, Tensor):
+            other = other.data
+        return Tensor(self.data @ other)
+
 
 def randn(*shape):
     return Tensor(_np.random.randn(*shape))
 
+def eye(n):
+    return Tensor(_np.eye(n))
+
+def zeros(*shape, dtype=None):
+    return Tensor(_np.zeros(shape, dtype=_np.float32))
+
+def allclose(a, b):
+    if isinstance(a, Tensor):
+        a = a.data
+    if isinstance(b, Tensor):
+        b = b.data
+    return _np.allclose(a, b)
+
+def matmul(a, b):
+    if isinstance(a, Tensor):
+        a = a.data
+    if isinstance(b, Tensor):
+        b = b.data
+    return Tensor(a @ b)
+
+float32 = _np.float32
+long = int
+
 def tensor(data):
     return Tensor(data)
+
+cuda = _DummyCuda()
+
+__all__ = [
+    'Tensor',
+    'randn',
+    'tensor',
+    'eye',
+    'zeros',
+    'allclose',
+    'matmul',
+    'float32',
+    'long',
+    'cuda',
+]
 


### PR DESCRIPTION
## Summary
- expand analog device detection with caching
- wire analog utilization into AdaptiveScheduler
- document analog accelerator detection
- handle missing psutil in telemetry
- update tests and add hardware detection coverage

## Testing
- `pytest tests/test_hardware_detect.py tests/test_analog_backend.py tests/test_adaptive_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686d77f6fdc48331bc0853f61b1dd6c3