### PR TITLE
Centralize cross-lingual embedding helper

### DIFF
--- a/src/cross_lingual_graph.py
+++ b/src/cross_lingual_graph.py
@@ -10,6 +10,7 @@ except Exception:  # pragma: no cover - torch optional
 
 from .graph_of_thought import GraphOfThought
 from .data_ingest import CrossLingualTranslator
+from .cross_lingual_utils import embed_text
 try:  # pragma: no cover - optional dependency
     from .context_summary_memory import ContextSummaryMemory
 except Exception:  # pragma: no cover - missing torch or other deps
@@ -20,10 +21,10 @@ from .reasoning_history import ReasoningHistoryLogger
 _EMBED_DIM = 8
 
 def _embed_text(text: str) -> np.ndarray:
-    """Return a deterministic embedding for ``text``."""
-    seed = abs(hash(text)) % (2 ** 32)
-    rng = np.random.default_rng(seed)
-    return rng.standard_normal(_EMBED_DIM).astype(np.float32)
+    vec = embed_text(text, _EMBED_DIM)
+    if torch is not None:
+        return vec.detach().cpu().numpy()
+    return np.asarray(vec, dtype=np.float32)
 
 def _cos_sim(a: np.ndarray, b: np.ndarray) -> float:
     """Return cosine similarity between ``a`` and ``b``."""

--- a/src/cross_lingual_memory.py
+++ b/src/cross_lingual_memory.py
@@ -85,31 +85,9 @@ except Exception:  # pragma: no cover - allow running without torch
 from .hierarchical_memory import HierarchicalMemory
 from .data_ingest import CrossLingualTranslator, CrossLingualSpeechTranslator
 from .quantum_retrieval import amplify_search
+from .cross_lingual_utils import embed_text as _embed_text
 
 
-_BASE_VECS = {
-    "man": torch.tensor([1.0, 0.0, 0.0]),
-    "woman": torch.tensor([0.0, 1.0, 0.0]),
-    "king": torch.tensor([1.0, 0.0, 1.0]),
-    "queen": torch.tensor([0.0, 1.0, 1.0]),
-    "france": torch.tensor([1.0, 0.0, 0.0]),
-    "germany": torch.tensor([0.0, 1.0, 0.0]),
-    "paris": torch.tensor([1.0, 0.0, 1.0]),
-    "berlin": torch.tensor([0.0, 1.0, 1.0]),
-}
-
-def _embed_text(text: str, dim: int) -> torch.Tensor:
-    """Deterministically embed ``text`` with simple seed vectors."""
-    base = text.split(" ")[-1]
-    if base in _BASE_VECS:
-        vec = _BASE_VECS[base]
-    else:
-        seed = abs(hash(text)) % (2 ** 32)
-        rng = np.random.default_rng(seed)
-        vec = torch.from_numpy(rng.standard_normal(dim).astype(np.float32))
-    if vec.numel() != dim:
-        vec = torch.nn.functional.pad(vec, (0, dim - vec.numel()))
-    return vec
 
 
 class CrossLingualMemory(HierarchicalMemory):

--- a/src/cross_lingual_utils.py
+++ b/src/cross_lingual_utils.py
@@ -1,0 +1,97 @@
+import numpy as np
+
+try:  # optional torch dependency
+    import torch
+except Exception:  # pragma: no cover - allow running without torch
+    import types
+
+    class _DummyTensor:
+        def __init__(self, data):
+            self.data = np.asarray(data, dtype=np.float32)
+
+        def dim(self) -> int:
+            return self.data.ndim
+
+        def unsqueeze(self, axis: int):
+            return _DummyTensor(np.expand_dims(self.data, axis))
+
+        def expand_as(self, other):
+            arr = self.data
+            if arr.shape[-1] != other.data.shape[-1]:
+                arr = arr[..., : other.data.shape[-1]]
+            return _DummyTensor(np.broadcast_to(arr, other.data.shape))
+
+        def clone(self):
+            return _DummyTensor(self.data.copy())
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return self.data
+
+        def __iter__(self):
+            if self.data.ndim == 0:
+                yield _DummyTensor(self.data)
+            else:
+                for row in self.data:
+                    yield _DummyTensor(row)
+
+        def size(self, dim=None):
+            return self.data.shape if dim is None else self.data.shape[dim]
+
+        def to(self, *args, **kwargs):
+            return self
+
+        @property
+        def device(self):
+            return "cpu"
+
+        def numel(self):
+            return self.data.size
+
+        def tolist(self):
+            return self.data.tolist()
+
+        def item(self):
+            return float(self.data)
+
+    class _DummyTorch(types.SimpleNamespace):
+        Tensor = _DummyTensor
+
+        def from_numpy(self, arr):
+            return _DummyTensor(arr)
+
+        def stack(self, seq):
+            return _DummyTensor(np.stack([s.data for s in seq]))
+
+    torch = _DummyTorch()
+
+_BASE_VECS = {
+    "man": torch.tensor([1.0, 0.0, 0.0]),
+    "woman": torch.tensor([0.0, 1.0, 0.0]),
+    "king": torch.tensor([1.0, 0.0, 1.0]),
+    "queen": torch.tensor([0.0, 1.0, 1.0]),
+    "france": torch.tensor([1.0, 0.0, 0.0]),
+    "germany": torch.tensor([0.0, 1.0, 0.0]),
+    "paris": torch.tensor([1.0, 0.0, 1.0]),
+    "berlin": torch.tensor([0.0, 1.0, 1.0]),
+}
+
+def embed_text(text: str, dim: int):
+    """Deterministically embed ``text`` with simple seed vectors."""
+    base = text.split(" ")[-1]
+    if base in _BASE_VECS:
+        vec = _BASE_VECS[base]
+    else:
+        seed = abs(hash(text)) % (2 ** 32)
+        rng = np.random.default_rng(seed)
+        vec = torch.from_numpy(rng.standard_normal(dim).astype(np.float32))
+    if vec.numel() != dim:
+        vec = torch.nn.functional.pad(vec, (0, dim - vec.numel()))
+    return vec
+
+__all__ = ["embed_text"]

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -15,3 +15,8 @@
 - Introduced `graph_visualizer_base.py` with helper functions for reading graph JSON, layout calculations and a reusable `WebSocketServer`.
 - Refactored `got_visualizer.py`, `got_3d_visualizer.py`, and `ar_got_overlay.py` to use the new helpers, eliminating duplicated code and adding fallback imports for tests.
 - Updated `docs/Plan.md` with a bullet about the shared base module.
+
+## PR 4
+- Created `cross_lingual_utils.embed_text` as shared deterministic text embedding helper.
+- Updated `cross_lingual_memory.py` and `cross_lingual_graph.py` to import this function instead of local implementations.
+- Adjusted tests to rely on the new module.

--- a/tests/test_crosslingual_graph_search.py
+++ b/tests/test_crosslingual_graph_search.py
@@ -27,6 +27,7 @@ def load(name, path):
 di = load('asi.data_ingest', 'src/data_ingest.py')
 goth = load('asi.graph_of_thought', 'src/graph_of_thought.py')
 cg = load('asi.cross_lingual_graph', 'src/cross_lingual_graph.py')
+clu = load('asi.cross_lingual_utils', 'src/cross_lingual_utils.py')
 
 CrossLingualReasoningGraph = cg.CrossLingualReasoningGraph
 CrossLingualTranslator = di.CrossLingualTranslator
@@ -41,9 +42,8 @@ class TestCrossLingualGraphSearch(unittest.TestCase):
         result = g.search('hola', 'es')
 
         def embed(text):
-            seed = abs(hash(text)) % (2 ** 32)
-            rng = np.random.default_rng(seed)
-            return rng.standard_normal(8)
+            vec = clu.embed_text(text, 8)
+            return vec.numpy() if hasattr(vec, 'numpy') else vec
 
         def cos(a, b):
             return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-8))


### PR DESCRIPTION
## Summary
- add `cross_lingual_utils.embed_text` for deterministic embeddings
- refactor cross-lingual memory and graph modules to use the shared helper
- update tests to reference the new module
- record the changes in `steps_summary.md`

## Testing
- `pytest tests/test_crosslingual_graph_search.py -q` *(fails: ModuleNotFoundError: No module named 'asi.privacy_guard')*

------
https://chatgpt.com/codex/tasks/task_e_686dd09064ec8331a0e19769e1c2c644