### PR TITLE
Refactor HPC schedulers with shared base

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -779,6 +779,9 @@ multiple clusters.  Its `submit_best()` helper returns the chosen cluster and jo
 ID, waiting for the optimal delay if necessary.  See the
 `scripts/hpc_multi_schedule.py` CLI for a minimal example that prints which
 cluster was selected.
+`hpc_base_scheduler.HPCBaseScheduler` now centralises queue management and job
+submission while delegating forecasts to pluggable strategies like the ARIMA and
+GNN schedulers.
 
 `transformer_forecast_scheduler.TransformerForecastScheduler` swaps the ARIMA
 model for a tiny two-layer Transformer trained on recent traces. The model

--- a/src/hpc_base_scheduler.py
+++ b/src/hpc_base_scheduler.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Base utilities for HPC job schedulers with pluggable forecasting."""
+
+from dataclasses import dataclass, field
+import time
+from typing import List, Protocol, Union, Dict
+
+from .hpc_scheduler import submit_job
+
+
+class ForecastStrategy(Protocol):
+    """Interface for forecasting cluster cost/carbon scores."""
+
+    def forecast_scores(
+        self,
+        scheduler: "HPCBaseScheduler",
+        max_delay: float,
+        clusters: Dict[str, "HPCBaseScheduler"] | None = None,
+    ) -> List[float]:
+        ...
+
+
+@dataclass
+class HPCBaseScheduler:
+    """Manage job queueing and submission using a forecasting strategy."""
+
+    carbon_history: List[float] = field(default_factory=list)
+    cost_history: List[float] = field(default_factory=list)
+    carbon_weight: float = 0.5
+    cost_weight: float = 0.5
+    backend: str = "slurm"
+    strategy: ForecastStrategy | None = field(default=None, repr=False)
+
+    _queue: List[Union[str, List[str]]] = field(default_factory=list, init=False, repr=False)
+
+    # --------------------------------------------------
+    def forecast_scores(
+        self, max_delay: float, clusters: Dict[str, "HPCBaseScheduler"] | None = None
+    ) -> List[float]:
+        """Delegate forecasting to the attached strategy."""
+        if self.strategy is None:
+            raise NotImplementedError("No forecasting strategy configured")
+        return self.strategy.forecast_scores(self, max_delay, clusters)
+
+    # --------------------------------------------------
+    def submit_at_optimal_time(
+        self, command: Union[str, List[str]], max_delay: float = 21600.0
+    ) -> str:
+        """Submit ``command`` when the forecast is most favourable."""
+        scores = self.forecast_scores(max_delay)
+        delay = 0.0
+        if scores:
+            idx = int(min(range(len(scores)), key=lambda i: scores[i]))
+            delay = idx * 3600.0
+        if delay and delay <= max_delay:
+            time.sleep(delay)
+        return submit_job(command, backend=self.backend)
+
+    # --------------------------------------------------
+    def queue_job(self, command: Union[str, List[str]]) -> None:
+        """Add a command to the local queue."""
+        self._queue.append(command)
+
+    # --------------------------------------------------
+    def run_queue(self, max_delay: float = 21600.0) -> List[str]:
+        """Submit all queued commands sequentially."""
+        results: List[str] = []
+        while self._queue:
+            cmd = self._queue.pop(0)
+            results.append(self.submit_at_optimal_time(cmd, max_delay))
+        return results
+
+
+__all__ = ["HPCBaseScheduler", "ForecastStrategy"]

--- a/src/hpc_forecast_scheduler.py
+++ b/src/hpc_forecast_scheduler.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 """Schedule HPC jobs based on ARIMA forecasts of cost and carbon intensity."""
 
 from dataclasses import dataclass, field
-import time
-from typing import List, Union, Tuple, Dict
+from typing import List, Tuple, Dict
 
 import numpy as np
 from statsmodels.tsa.arima.model import ARIMA
 
-from .hpc_scheduler import submit_job
+from .hpc_base_scheduler import HPCBaseScheduler, ForecastStrategy
 
 
 # --------------------------------------------------------------
@@ -30,50 +29,41 @@ def arima_forecast(series: List[float], steps: int = 1) -> List[float]:
         return [float(series[-1])] * steps
 
 
-@dataclass
-class HPCForecastScheduler:
-    """Schedule jobs at predicted low-cost/low-carbon times."""
+class ArimaStrategy(ForecastStrategy):
+    """ARIMA-based forecasting helper."""
 
-    carbon_history: List[float] = field(default_factory=list)
-    cost_history: List[float] = field(default_factory=list)
-    carbon_weight: float = 0.5
-    cost_weight: float = 0.5
-    backend: str = "slurm"
+    def __init__(self) -> None:
+        self._cache: Dict[Tuple[int, int, int], List[float]] = {}
 
-    # cache keyed by (len(carbon_history), len(cost_history), steps)
-    _cache: Dict[Tuple[int, int, int], List[float]] = field(default_factory=dict, init=False)
-
-    # --------------------------------------------------
-    def forecast_scores(self, max_delay: float, clusters=None) -> List[float]:
-        """Return combined carbon/cost forecasts for each hour."""
+    def forecast_scores(
+        self,
+        scheduler: HPCBaseScheduler,
+        max_delay: float,
+        clusters=None,
+    ) -> List[float]:
         steps = max(int(max_delay // 3600) + 1, 1)
-        key = (len(self.carbon_history), len(self.cost_history), steps)
+        key = (len(scheduler.carbon_history), len(scheduler.cost_history), steps)
         if key in self._cache:
             return list(self._cache[key])
-        carbon_pred = arima_forecast(self.carbon_history, steps=steps)
-        cost_pred = arima_forecast(self.cost_history, steps=steps)
+        carbon_pred = arima_forecast(scheduler.carbon_history, steps=steps)
+        cost_pred = arima_forecast(scheduler.cost_history, steps=steps)
         n = min(len(carbon_pred), len(cost_pred))
         scores = [
-            self.carbon_weight * carbon_pred[i] + self.cost_weight * cost_pred[i]
+            scheduler.carbon_weight * carbon_pred[i]
+            + scheduler.cost_weight * cost_pred[i]
             for i in range(n)
         ]
-        # keep only latest entry to avoid unbounded memory
         self._cache.clear()
         self._cache[key] = list(scores)
         return scores
 
-    # --------------------------------------------------
-    def submit_at_optimal_time(
-        self, command: Union[str, List[str]], max_delay: float = 21600.0
-    ) -> str:
-        scores = self.forecast_scores(max_delay)
-        delay = 0.0
-        if scores:
-            idx = int(min(range(len(scores)), key=lambda i: scores[i]))
-            delay = idx * 3600.0
-        if delay and delay <= max_delay:
-            time.sleep(delay)
-        return globals()["submit_job"](command, backend=self.backend)
+
+@dataclass
+class HPCForecastScheduler(HPCBaseScheduler):
+    """Schedule jobs at predicted low-cost/low-carbon times using ARIMA."""
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple init
+        self.strategy = ArimaStrategy()
 
 
-__all__ = ["arima_forecast", "HPCForecastScheduler"]
+__all__ = ["arima_forecast", "HPCForecastScheduler", "ArimaStrategy"]

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -20,3 +20,10 @@
 - Created `cross_lingual_utils.embed_text` as shared deterministic text embedding helper.
 - Updated `cross_lingual_memory.py` and `cross_lingual_graph.py` to import this function instead of local implementations.
 - Adjusted tests to rely on the new module.
+
+## PR 5
+- Introduced `hpc_base_scheduler.HPCBaseScheduler` to handle job queueing and submission.
+- Added `ArimaStrategy` and `GNNStrategy` as pluggable forecast components used by the base class.
+- Refactored `hpc_forecast_scheduler.py` and `hpc_gnn_scheduler.py` to inherit from the base scheduler.
+- Simplified `hpc_multi_scheduler.py` by calling `forecast_scores()` directly on each scheduler instance.
+- Documented the new architecture in `docs/Plan.md`.


### PR DESCRIPTION
## Summary
- add `HPCBaseScheduler` with queue management and submission helpers
- move ARIMA and GNN logic to pluggable strategies
- refactor forecast schedulers to subclass the base
- simplify `MultiClusterScheduler`
- document new design in `docs/Plan.md`

## Testing
- `pytest -q tests/test_hpc_forecast_scheduler.py tests/test_hpc_gnn_scheduler.py tests/test_hpc_multi_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_686dd94c9e348331963fb7a771e75fe8