### PR TITLE
Refactor dashboard imports

### DIFF
--- a/src/cluster_carbon_dashboard.py
+++ b/src/cluster_carbon_dashboard.py
@@ -3,21 +3,24 @@ from __future__ import annotations
 import json
 from http.server import BaseHTTPRequestHandler
 from typing import Dict, Any, Type
-import importlib.util
-import sys
-from pathlib import Path
 
 try:
-    from .dashboard_base import BaseDashboard
+    from .dashboard_import_helper import load_base_dashboard
 except Exception:  # pragma: no cover - fallback when not packaged
+    import importlib.util
+    import sys
+    from pathlib import Path
+
     spec = importlib.util.spec_from_file_location(
-        "dashboard_base", Path(__file__).with_name("dashboard_base.py")
+        "dashboard_import_helper", Path(__file__).with_name("dashboard_import_helper.py")
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)  # type: ignore
-    sys.modules.setdefault("dashboard_base", module)
-    BaseDashboard = module.BaseDashboard  # type: ignore
+    sys.modules.setdefault("dashboard_import_helper", module)
+    load_base_dashboard = module.load_base_dashboard  # type: ignore
+
+BaseDashboard = load_base_dashboard(__file__)
 
 
 class ClusterCarbonDashboard(BaseDashboard):

--- a/src/dataset_lineage_dashboard.py
+++ b/src/dataset_lineage_dashboard.py
@@ -5,23 +5,24 @@ from dataclasses import asdict
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import parse_qs, urlparse
 from typing import Any, Iterable, List, Type
-import importlib.util
-import sys
-from pathlib import Path
 
 try:
-    from .dashboard_base import BaseDashboard
+    from .dashboard_import_helper import load_base_dashboard
 except Exception:  # pragma: no cover - fallback when not packaged
+    import importlib.util
+    import sys
+    from pathlib import Path
+
     spec = importlib.util.spec_from_file_location(
-        "dashboard_base", Path(__file__).with_name("dashboard_base.py")
+        "dashboard_import_helper", Path(__file__).with_name("dashboard_import_helper.py")
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)  # type: ignore
-    sys.modules.setdefault("dashboard_base", module)
-    BaseDashboard = module.BaseDashboard  # type: ignore
-except Exception:  # pragma: no cover - fallback when not packaged
-    from dashboard_base import BaseDashboard  # type: ignore
+    sys.modules.setdefault("dashboard_import_helper", module)
+    load_base_dashboard = module.load_base_dashboard  # type: ignore
+
+BaseDashboard = load_base_dashboard(__file__)
 
 from .dataset_lineage_manager import DatasetLineageManager, LineageStep
 

--- a/src/introspection_dashboard.py
+++ b/src/introspection_dashboard.py
@@ -3,21 +3,24 @@ from __future__ import annotations
 import json
 from http.server import BaseHTTPRequestHandler
 from typing import Any, Dict, Type
-import importlib.util
-import sys
-from pathlib import Path
 
 try:
-    from .dashboard_base import BaseDashboard
+    from .dashboard_import_helper import load_base_dashboard
 except Exception:  # pragma: no cover - fallback when not packaged
+    import importlib.util
+    import sys
+    from pathlib import Path
+
     spec = importlib.util.spec_from_file_location(
-        "dashboard_base", Path(__file__).with_name("dashboard_base.py")
+        "dashboard_import_helper", Path(__file__).with_name("dashboard_import_helper.py")
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)  # type: ignore
-    sys.modules.setdefault("dashboard_base", module)
-    BaseDashboard = module.BaseDashboard  # type: ignore
+    sys.modules.setdefault("dashboard_import_helper", module)
+    load_base_dashboard = module.load_base_dashboard  # type: ignore
+
+BaseDashboard = load_base_dashboard(__file__)
 
 from .graph_of_thought import GraphOfThought
 from .reasoning_history import ReasoningHistoryLogger

--- a/src/multi_agent_dashboard.py
+++ b/src/multi_agent_dashboard.py
@@ -5,21 +5,24 @@ from __future__ import annotations
 import json
 from http.server import BaseHTTPRequestHandler
 from typing import Any, Dict, Type
-import importlib.util
-import sys
-from pathlib import Path
 
 try:
-    from .dashboard_base import BaseDashboard
+    from .dashboard_import_helper import load_base_dashboard
 except Exception:  # pragma: no cover - fallback when not packaged
+    import importlib.util
+    import sys
+    from pathlib import Path
+
     spec = importlib.util.spec_from_file_location(
-        "dashboard_base", Path(__file__).with_name("dashboard_base.py")
+        "dashboard_import_helper", Path(__file__).with_name("dashboard_import_helper.py")
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)  # type: ignore
-    sys.modules.setdefault("dashboard_base", module)
-    BaseDashboard = module.BaseDashboard  # type: ignore
+    sys.modules.setdefault("dashboard_import_helper", module)
+    load_base_dashboard = module.load_base_dashboard  # type: ignore
+
+BaseDashboard = load_base_dashboard(__file__)
 
 from typing import TYPE_CHECKING
 

--- a/src/risk_dashboard.py
+++ b/src/risk_dashboard.py
@@ -1,21 +1,24 @@
 import json
 from http.server import BaseHTTPRequestHandler
 from typing import Iterable, Dict, Any, Type
-import importlib.util
-import sys
-from pathlib import Path
 
 try:
-    from .dashboard_base import BaseDashboard
+    from .dashboard_import_helper import load_base_dashboard
 except Exception:  # pragma: no cover - fallback when not packaged
+    import importlib.util
+    import sys
+    from pathlib import Path
+
     spec = importlib.util.spec_from_file_location(
-        "dashboard_base", Path(__file__).with_name("dashboard_base.py")
+        "dashboard_import_helper", Path(__file__).with_name("dashboard_import_helper.py")
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)  # type: ignore
-    sys.modules.setdefault("dashboard_base", module)
-    BaseDashboard = module.BaseDashboard  # type: ignore
+    sys.modules.setdefault("dashboard_import_helper", module)
+    load_base_dashboard = module.load_base_dashboard  # type: ignore
+
+BaseDashboard = load_base_dashboard(__file__)
 
 from .risk_scoreboard import RiskScoreboard
 from .memory_dashboard import MemoryDashboard

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -75,3 +75,10 @@
 - Updated all scheduler modules, tests and documentation to import from the new
   package path.
 - Confirmed scheduler-related tests run with pytest.
+
+## PR 14
+- Replaced manual BaseDashboard fallbacks in several dashboards with
+  `load_base_dashboard` from `dashboard_import_helper`.
+- Added helper import fallbacks and cleaned up unused imports.
+- Updated dashboard tests with lightweight stubs for missing dependencies so
+  they run without external packages.

--- a/tests/test_dataset_lineage_dashboard.py
+++ b/tests/test_dataset_lineage_dashboard.py
@@ -8,6 +8,14 @@ import importlib.util
 import sys
 import types
 
+pil = types.ModuleType('PIL')
+pil.Image = types.SimpleNamespace(open=lambda *a, **k: None)
+pil.PngImagePlugin = types.SimpleNamespace(PngInfo=lambda *a, **k: object())
+pil.UnidentifiedImageError = Exception
+sys.modules.setdefault('PIL', pil)
+sys.modules.setdefault('PIL.Image', pil.Image)
+sys.modules.setdefault('PIL.PngImagePlugin', pil.PngImagePlugin)
+
 src_pkg = types.ModuleType('src')
 sys.modules['src'] = src_pkg
 src_pkg.__path__ = ['src']

--- a/tests/test_interpretability_dashboard.py
+++ b/tests/test_interpretability_dashboard.py
@@ -2,6 +2,7 @@ import unittest
 import http.client
 import json
 import sys
+import types
 try:
     import torch
 except Exception:  # pragma: no cover - optional heavy dep

--- a/tests/test_introspection_dashboard.py
+++ b/tests/test_introspection_dashboard.py
@@ -14,8 +14,8 @@ def _load(name, path):
     loader = importlib.machinery.SourceFileLoader(name, path)
     spec = importlib.util.spec_from_loader(name, loader)
     mod = importlib.util.module_from_spec(spec)
-    loader.exec_module(mod)
     sys.modules[name] = mod
+    loader.exec_module(mod)
     return mod
 
 GraphOfThought = _load('asi.graph_of_thought', 'src/graph_of_thought.py').GraphOfThought

--- a/tests/test_multi_agent_dashboard.py
+++ b/tests/test_multi_agent_dashboard.py
@@ -6,17 +6,28 @@ import sys
 import json
 import http.client
 import time
+np = types.SimpleNamespace(argmax=lambda x: 0)
+sys.modules.setdefault('numpy', np)
 
 pkg = types.ModuleType('asi')
 sys.modules['asi'] = pkg
+meta_stub = types.ModuleType('asi.meta_rl_refactor')
+meta_stub.MetaRLRefactorAgent = type('A', (), {})
+sys.modules['asi.meta_rl_refactor'] = meta_stub
+rl_stub = types.ModuleType('asi.rl_decision_narrator')
+rl_stub.RLDecisionNarrator = type('R', (), {})
+sys.modules['asi.rl_decision_narrator'] = rl_stub
+ct_stub = types.ModuleType('asi.carbon_tracker')
+ct_stub.CarbonFootprintTracker = lambda *a, **k: None
+sys.modules['asi.carbon_tracker'] = ct_stub
 
 
 def _load(name, path):
     loader = importlib.machinery.SourceFileLoader(name, path)
     spec = importlib.util.spec_from_loader(name, loader)
     mod = importlib.util.module_from_spec(spec)
-    loader.exec_module(mod)
     sys.modules[name] = mod
+    loader.exec_module(mod)
     return mod
 
 MultiAgentDashboard = _load('asi.multi_agent_dashboard', 'src/multi_agent_dashboard.py').MultiAgentDashboard

--- a/tests/test_risk_dashboard.py
+++ b/tests/test_risk_dashboard.py
@@ -3,7 +3,35 @@ import importlib.machinery
 import importlib.util
 import types
 import sys
-import torch
+try:
+    import torch  # pragma: no cover - optional heavy dep
+except Exception:
+    torch = types.ModuleType('torch')
+sys.modules['torch'] = torch
+np = types.SimpleNamespace(mean=lambda x: sum(x)/len(x) if x else 0.0,
+                           corrcoef=lambda a,b: [[0,0],[0,0]],
+                           array=lambda x: x,
+                           ndarray=list)
+sys.modules.setdefault('numpy', np)
+sys.modules.setdefault('matplotlib', types.ModuleType('matplotlib'))
+sys.modules.setdefault('matplotlib.pyplot', types.SimpleNamespace())
+re_stub = types.ModuleType('asi.retrieval_explainer')
+re_stub.RetrievalExplainer = type('RE', (), {})
+rv_stub = types.ModuleType('asi.retrieval_visualizer')
+rv_stub.RetrievalVisualizer = type('RV', (), {})
+rts_stub = types.ModuleType('asi.retrieval_trust_scorer')
+rts_stub.RetrievalTrustScorer = type('RTS', (), {'score': staticmethod(lambda *a, **k: 0.0)})
+mtv_stub = types.ModuleType('asi.memory_timeline_viewer')
+mtv_stub.MemoryTimelineViewer = type('MTV', (), {})
+kgv_stub = types.ModuleType('asi.kg_visualizer')
+kgv_stub.KGVisualizer = type('KGV', (), {})
+sys.modules.update({
+    'asi.retrieval_explainer': re_stub,
+    'asi.retrieval_visualizer': rv_stub,
+    'asi.retrieval_trust_scorer': rts_stub,
+    'asi.memory_timeline_viewer': mtv_stub,
+    'asi.kg_visualizer': kgv_stub,
+})
 
 src_pkg = types.ModuleType('src')
 src_pkg.__path__ = ['src']


### PR DESCRIPTION
## Summary
- load BaseDashboard through dashboard_import_helper
- drop unused manual importlib logic
- adjust tests with lightweight stubs

## Testing
- `pytest tests/test_cluster_carbon_dashboard.py tests/test_dataset_lineage_dashboard.py tests/test_interpretability_dashboard.py tests/test_introspection_dashboard.py tests/test_multi_agent_dashboard.py tests/test_risk_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68715bc0909c8331a54e96be3f15177a