### PR TITLE
Add EphemeralVectorStore subclass with auto cleanup

### DIFF
--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -431,8 +431,10 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
      for vector search using `quantum_retrieval.amplify_search`. The accompanying
      `QuantumMemoryClient` lets peers push embeddings and query the server over
      the network.
-37c. **Ephemeral vector store**: `EphemeralVectorStore` keeps in-memory vectors
-     with a TTL and integrates into `HierarchicalMemory` via `store_type="ephemeral"`.
+37c. **Ephemeral vector store**: `EphemeralVectorStore` subclasses
+    `VectorStore`, tracks insert timestamps and automatically purges
+    expired embeddings. It integrates into `HierarchicalMemory` via
+    `store_type="ephemeral"`.
 37d. **Proof-carrying queries**: pass `proof=True` to `MemoryServer.query()` or
      `HierarchicalMemory.search()` to request verifiable results. The server
      encrypts stored vectors under an AES key and computes a

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -86,3 +86,11 @@
 ## PR 15
 - Renamed `tests/test_hpc_scheduler.py` to `tests/test_hpc_schedulers.py` for clarity.
 - Documented the import path `asi.hpc_schedulers` in `docs/Plan.md`.
+
+## PR 16
+- Reworked `EphemeralVectorStore` to inherit from `VectorStore` and reuse its
+  insertion logic.
+- Added timestamp tracking so expired vectors are purged automatically before
+  searching, deleting or checking the length.
+- Updated unit tests to rely on this implicit cleanup and noted the subclass in
+  `docs/Plan.md`.

--- a/tests/test_ephemeral_vector_store.py
+++ b/tests/test_ephemeral_vector_store.py
@@ -17,7 +17,6 @@ class TestEphemeralVectorStore(unittest.TestCase):
         store = EphemeralVectorStore(dim=2, ttl=0.1)
         store.add(np.array([[1.0, 0.0]]), metadata=["x"])
         time.sleep(0.2)
-        store.cleanup_expired()
         self.assertEqual(len(store), 0)
 
     def test_search_after_expire(self):


### PR DESCRIPTION
## Summary
- rework `EphemeralVectorStore` to subclass `VectorStore`
- purge expired vectors before search, delete and len
- update tests for implicit cleanup
- document the subclass in `Plan.md`
- record development steps

## Testing
- `python -m pytest -q tests/test_ephemeral_vector_store.py`

------
https://chatgpt.com/codex/tasks/task_e_6871755b1660833182f51c622717ace0