### PR TITLE
Remove duplicate query_remote import

### DIFF
--- a/src/federated_memory_server.py
+++ b/src/federated_memory_server.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
-from typing import Iterable, Any, Dict
+from typing import Iterable, Dict
 
 from dataclasses import dataclass
 
 import torch
 
 from .hierarchical_memory import HierarchicalMemory
-from .remote_memory import query_remote
 from .base_memory_server import BaseMemoryServer
-from .hierarchical_memory import (
-    HierarchicalMemory,
-    MemoryServer,
-)
 from .memory_clients import query_remote
 from .retrieval_proof import RetrievalProof
 

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -126,5 +126,11 @@
   `RemoteMemoryClient`, `QuantumMemoryClient`, `QuantizedMemoryClient` and
   `EdgeMemoryClient`. Updated modules, tests and docs accordingly.
 
+## PR 19
+- Removed the stale `query_remote` import from `remote_memory` in
+  `federated_memory_server.py`.
+- Kept the import from `memory_clients` and cleaned unused imports so `ruff`
+  passes.
+
 
 


### PR DESCRIPTION
## Summary
- clean up `federated_memory_server` imports
- update steps summary

## Testing
- `ruff check src/federated_memory_server.py`
- `pytest -q` *(fails: ModuleNotFoundError and other import errors)*
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6871b33aaae08331b1db2349c5c2496a