### PR TITLE
Consolidate fairness modules

### DIFF
--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -1097,13 +1097,13 @@ the aggregator which can then be scraped by Prometheus.
 
 ## Fairness Evaluator
 
-`src/fairness_evaluator.py` computes demographic parity and equal opportunity gaps from per-group label statistics. The evaluation harness exposes these metrics via the `fairness_evaluator` entry.
+`src/fairness.py` defines `FairnessEvaluator` for demographic parity and equal opportunity metrics. The evaluation harness exposes these metrics via the `fairness_evaluator` entry.
 
 `data_ingest.paraphrase_multilingual()` generates translations and paraphrases
 in multiple languages. Outputs are filtered with `AutoDatasetFilter` and checked
 by `LicenseInspector` before being saved. The number of generated and retained
 files is logged through `DatasetLineageManager`. To quantify fairness gains,
-run `CrossLingualFairnessEvaluator` on the dataset before and after augmentation
+run `fairness.CrossLingualFairnessEvaluator` on the dataset before and after augmentation
 and compare the demographic parity gap.
 
 `src/dataset_weight_agent.py` maintains per-dataset weights by combining

--- a/docs/Plan.md
+++ b/docs/Plan.md
@@ -464,7 +464,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
     expands each text file with paraphrases in the translator's languages. The
     helper uses `AutoDatasetFilter` and `LicenseInspector` to keep only clean and
     compliant outputs while logging stats via `DatasetLineageManager`. Measure
-    fairness gains by running `CrossLingualFairnessEvaluator` on the dataset
+    fairness gains by running `fairness.CrossLingualFairnessEvaluator` on the dataset
     before and after augmentation—expect the demographic parity gap to shrink
     by at least 5%.
 40c. **Image and audio fairness metrics**: `FairnessEvaluator.evaluate_multimodal()`
@@ -477,7 +477,7 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
      ``LLM_PARSER_MODEL`` environment variable to customize loading. Calling
      `download_triples(use_llm_parser=True)` saves triples to
     ``*.triples.json`` files for downstream RAG pipelines ([arxiv.org][15]).
-40e. **Fairness feedback loop**: `fairness_feedback.FairnessFeedback` monitors
+40e. **Fairness feedback loop**: `fairness.FairnessFeedback` monitors
      cross-lingual demographic parity and equal opportunity. When the gap of
      either metric exceeds a configurable threshold it adjusts
      `ActiveDataSelector` or dataset weights through reinforcement learning and
@@ -564,11 +564,11 @@ Combine 1-4 and the *effective* context limit becomes hardware bandwidth, not mo
 60. **Adversarial robustness suite**: Generate gradient-based adversarial prompts and measure model degradation. Acceptable drop is <5% accuracy on the evaluation harness.
 61. **Bias-aware dataset filtering**: Add `DatasetBiasDetector` to compute representation metrics and filter skewed samples. Goal is <5% disparity across demographic slices after filtering.
 61a. **Dataset bias mitigation**: `DataBiasMitigator` reweights or filters entries based on these scores. `download_triples()` now applies the mitigator before storing new files.
-61b. **Fairness gap visualizer**: `fairness_visualizer.FairnessVisualizer` plots demographic parity and opportunity gaps. `dataset_summary.py --fairness-report` saves the charts under `docs/datasets/`; they appear in the lineage and memory dashboards for quick inspection.
+61b. **Fairness gap visualizer**: `fairness.FairnessVisualizer` plots demographic parity and opportunity gaps. `dataset_summary.py --fairness-report` saves the charts under `docs/datasets/`; they appear in the lineage and memory dashboards for quick inspection.
 
 61e. **Fairness adaptation pipeline**: `FairnessAdaptationPipeline` streams bias and cognitive load metrics during ingestion and adjusts `ActiveDataSelector` weights. Bias scores are cached and weight updates are vectorised for faster adaptation. `DatasetLineageManager` logs fairness before and after adaptation, showing improved demographic parity on toy datasets.
 
-61c. **Pre-ingest bias and fairness checks**: `StreamingDatasetWatcher.poll_once()` runs `DatasetBiasDetector` and `CrossLingualFairnessEvaluator` on newly discovered datasets before they are ingested. Reports are saved as `pre_ingest_analysis.json`. Example usage lives in `scripts/pre_ingest_pipeline.py`.
+61c. **Pre-ingest bias and fairness checks**: `StreamingDatasetWatcher.poll_once()` runs `DatasetBiasDetector` and `fairness.CrossLingualFairnessEvaluator` on newly discovered datasets before they are ingested. Reports are saved as `pre_ingest_analysis.json`. Example usage lives in `scripts/pre_ingest_pipeline.py`.
 61d. **Parallelized bias analysis**: `compute_word_freq()` now uses multithreading when available, roughly doubling analysis throughput for large datasets.
 
 62. **Federated world-model training**: Train `world_model_rl` across multiple nodes via gradient averaging. Throughput should scale to four nodes with <1.2× single-node time.

--- a/scripts/dataset_summary.py
+++ b/scripts/dataset_summary.py
@@ -89,7 +89,7 @@ def main(argv: list[str] | None = None) -> None:
         out_file.write_text(out)
         print(f"Wrote {out_file}")
     if args.fairness_report:
-        from asi.fairness_visualizer import FairnessVisualizer
+        from asi.fairness import FairnessVisualizer
 
         stats_path = Path(args.fairness_report)
         if not stats_path.is_file():

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -277,10 +277,13 @@ from .risk_scoreboard import RiskScoreboard
 from .semantic_drift_detector import SemanticDriftDetector
 from .data_provenance_ledger import DataProvenanceLedger
 from .blockchain_provenance_ledger import BlockchainProvenanceLedger
-from .fairness_evaluator import FairnessEvaluator
+from .fairness import (
+    FairnessEvaluator,
+    FairnessFeedback,
+    FairnessVisualizer,
+    CrossLingualFairnessEvaluator,
+)
 from .fairness_adaptation import FairnessAdaptationPipeline
-from .fairness_visualizer import FairnessVisualizer
-from .cross_lingual_fairness import CrossLingualFairnessEvaluator
 from .graph_neural_reasoner import GraphNeuralReasoner
 from .gnn_memory import GNNMemory
 from .temporal_reasoner import TemporalReasoner

--- a/src/dataset_weight_agent.py
+++ b/src/dataset_weight_agent.py
@@ -18,9 +18,9 @@ except Exception:  # pragma: no cover - during tests
     from license_inspector import LicenseInspector  # type: ignore
 
 try:
-    from .fairness_evaluator import FairnessEvaluator
+    from .fairness import FairnessEvaluator
 except Exception:  # pragma: no cover - during tests
-    from fairness_evaluator import FairnessEvaluator  # type: ignore
+    from fairness import FairnessEvaluator  # type: ignore
 
 
 class DatasetWeightAgent:

--- a/src/eval_harness.py
+++ b/src/eval_harness.py
@@ -303,7 +303,7 @@ def _collect_alignment_metrics() -> tuple[bool, list[str]]:
 
 
 def _eval_fairness_evaluator() -> Tuple[bool, str]:
-    from asi.fairness_evaluator import FairnessEvaluator
+    from asi.fairness import FairnessEvaluator
 
     stats = {
         "a": {"tp": 5, "fp": 5, "fn": 5, "tn": 5},
@@ -316,7 +316,7 @@ def _eval_fairness_evaluator() -> Tuple[bool, str]:
 
 
 def _eval_cross_lingual_fairness() -> Tuple[bool, str]:
-    from asi.cross_lingual_fairness import CrossLingualFairnessEvaluator
+    from asi.fairness import CrossLingualFairnessEvaluator
     from asi.data_ingest import CrossLingualTranslator
 
     stats = {

--- a/src/fairness.py
+++ b/src/fairness.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+class FairnessEvaluator:
+    """Compute simple fairness metrics."""
+
+    def demographic_parity(self, label_counts: Dict[str, Dict[str, int]], positive_label: str = "1") -> float:
+        rates = [
+            counts.get(positive_label, 0) / total
+            for counts in label_counts.values()
+            if (total := sum(counts.values())) > 0
+        ]
+        if not rates:
+            return 0.0
+        arr = np.asarray(rates, dtype=float)
+        return float(arr.max() - arr.min())
+
+    def equal_opportunity(self, stats: Dict[str, Dict[str, int]]) -> float:
+        tpr = [
+            counts.get("tp", 0) / pos
+            for counts in stats.values()
+            if (pos := counts.get("tp", 0) + counts.get("fn", 0)) > 0
+        ]
+        if not tpr:
+            return 0.0
+        arr = np.asarray(tpr, dtype=float)
+        return float(arr.max() - arr.min())
+
+    def evaluate(self, stats: Dict[str, Dict[str, int]], positive_label: str = "1") -> Dict[str, float]:
+        return {
+            "demographic_parity": self.demographic_parity(stats, positive_label),
+            "equal_opportunity": self.equal_opportunity(stats),
+        }
+
+    def evaluate_multimodal(
+        self, stats: Dict[str, Dict[str, Dict[str, int]]], positive_label: str = "1"
+    ) -> Dict[str, Dict[str, float]]:
+        """Return metrics for each modality in ``stats``.
+
+        ``stats`` maps modality → group → label counts.
+        """
+        results: Dict[str, Dict[str, float]] = {}
+        for modality, groups in stats.items():
+            results[modality] = self.evaluate(groups, positive_label)
+        return results
+
+
+# ---------------------------------------------------------------------------
+try:  # pragma: no cover - optional dependency
+    from .data_ingest import CrossLingualTranslator
+except Exception:  # pragma: no cover - missing torch
+    from .translator_fallback import CrossLingualTranslator
+
+
+class CrossLingualFairnessEvaluator:
+    """FairnessEvaluator that normalizes groups across languages."""
+
+    def __init__(
+        self,
+        translator: CrossLingualTranslator | None = None,
+        target_lang: str = "en",
+    ) -> None:
+        self.translator = translator
+        self.target_lang = target_lang
+        self.base = FairnessEvaluator()
+
+    def _translate(self, text: str) -> str:
+        if self.translator is None:
+            return text
+        return self.translator.translate(text, self.target_lang)
+
+    def _normalize(self, stats: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, int]]:
+        norm: Dict[str, Dict[str, int]] = {}
+        for group, counts in stats.items():
+            g = self._translate(group)
+            out = norm.setdefault(g, {})
+            for label, cnt in counts.items():
+                if label in {"tp", "fp", "fn", "tn"}:
+                    l = label
+                else:
+                    l = self._translate(label)
+                out[l] = out.get(l, 0) + cnt
+        return norm
+
+    def evaluate(self, stats: Dict[str, Dict[str, int]], positive_label: str = "1") -> Dict[str, float]:
+        norm = self._normalize(stats)
+        if positive_label in {"tp", "fp", "fn", "tn"}:
+            pos = positive_label
+        else:
+            pos = self._translate(positive_label)
+        return self.base.evaluate(norm, positive_label=pos)
+
+
+# ---------------------------------------------------------------------------
+DatasetWeightAgent = None
+ActiveDataSelector = None
+SampleWeightRL = None
+DatasetLineageManager = None
+
+
+class FairnessFeedback:
+    """Adjust dataset selection based on cross-lingual fairness metrics."""
+
+    def __init__(
+        self,
+        selector: ActiveDataSelector | None = None,
+        weight_agent: DatasetWeightAgent | None = None,
+        gap_threshold: float = 0.1,
+        lineage: DatasetLineageManager | None = None,
+        rl_lr: float = 0.1,
+        positive_label: str = "tp",
+        min_threshold: float = 0.1,
+        max_threshold: float = 10.0,
+    ) -> None:
+        global DatasetWeightAgent, ActiveDataSelector, SampleWeightRL, DatasetLineageManager
+        if DatasetWeightAgent is None:
+            try:
+                from .dataset_weight_agent import DatasetWeightAgent as _DWA
+            except Exception:  # pragma: no cover - during tests
+                from dataset_weight_agent import DatasetWeightAgent as _DWA  # type: ignore
+            DatasetWeightAgent = _DWA
+        if ActiveDataSelector is None:
+            try:
+                from .data_ingest import ActiveDataSelector as _ADS
+            except Exception:  # pragma: no cover - during tests
+                from data_ingest import ActiveDataSelector as _ADS  # type: ignore
+            ActiveDataSelector = _ADS
+        if SampleWeightRL is None:
+            try:
+                from .adaptive_curriculum import SampleWeightRL as _SWRL
+            except Exception:  # pragma: no cover - during tests
+                from adaptive_curriculum import SampleWeightRL as _SWRL  # type: ignore
+            SampleWeightRL = _SWRL
+        if DatasetLineageManager is None:
+            try:
+                from .dataset_lineage_manager import DatasetLineageManager as _DLM
+            except Exception:  # pragma: no cover - during tests
+                from dataset_lineage_manager import DatasetLineageManager as _DLM  # type: ignore
+            DatasetLineageManager = _DLM
+
+        self.selector = selector
+        self.weight_agent = weight_agent
+        self.gap_threshold = gap_threshold
+        self.lineage = lineage
+        self.pos_label = positive_label
+        self.evaluator = CrossLingualFairnessEvaluator()
+        self.rl = SampleWeightRL(2, lr=rl_lr) if selector is not None else None
+        self.min_threshold = min_threshold
+        self.max_threshold = max_threshold
+
+    # --------------------------------------------------------------
+    def update(
+        self,
+        stats: Dict[str, Dict[str, int]],
+        dataset: str = "dataset",
+        val_accuracy: float = 1.0,
+    ) -> Dict[str, float]:
+        """Update selection strategy using fairness ``stats`` and log results."""
+        metrics = self.evaluator.evaluate(stats, positive_label=self.pos_label)
+        gap = max(
+            metrics.get("demographic_parity", 0.0),
+            metrics.get("equal_opportunity", 0.0),
+        )
+        changed: Dict[str, Any] = {}
+        if gap > self.gap_threshold:
+            if self.weight_agent is not None:
+                self.weight_agent.observe(dataset, val_accuracy, stats)
+                self.weight_agent.update_db()
+                changed["weight"] = self.weight_agent.weight(dataset)
+            if self.selector is not None and self.rl is not None:
+                probs = self.rl.weights()
+                action = 0 if float(probs[0]) >= float(probs[1]) else 1
+                self.rl.update(action, 1.0 - gap)
+                if action == 0:
+                    self.selector.threshold *= 1.1
+                else:
+                    self.selector.threshold *= 0.9
+                self.selector.threshold = min(
+                    max(self.selector.threshold, self.min_threshold),
+                    self.max_threshold,
+                )
+                changed["threshold"] = self.selector.threshold
+        if self.lineage is not None and changed:
+            self.lineage.record(
+                [],
+                [],
+                note=f"fairness_feedback metrics={metrics} changed={changed}",
+            )
+        return metrics
+
+
+# ---------------------------------------------------------------------------
+import base64
+import io
+import json
+import matplotlib
+from functools import lru_cache
+from typing import Dict, Any
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+class FairnessVisualizer:
+    """Render demographic parity and equal opportunity gaps.
+
+    Caches previously generated images keyed by the input stats so repeated
+    calls avoid redundant plotting work.
+    """
+
+    def __init__(self, evaluator: FairnessEvaluator | None = None) -> None:
+        self.evaluator = evaluator or FairnessEvaluator()
+        self._cache: Dict[str, str] = {}
+
+    # --------------------------------------------------------------
+    def _bar_plot(self, labels: list[str], dp: list[float], eo: list[float]) -> str:
+        fig, ax = plt.subplots(figsize=(max(2, len(labels)), 2))
+        x = range(len(labels))
+        ax.bar([i - 0.2 for i in x], dp, width=0.4, label="parity")
+        ax.bar([i + 0.2 for i in x], eo, width=0.4, label="opportunity")
+        ax.set_xticks(list(x))
+        ax.set_xticklabels(labels)
+        ax.set_ylabel("gap")
+        ax.legend()
+        plt.tight_layout()
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png")
+        plt.close(fig)
+        return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+    # --------------------------------------------------------------
+    def to_image(self, results: Dict[str, Any], positive_label: str = "1") -> str:
+        """Return a base64 PNG for ``results`` from ``FairnessEvaluator``."""
+        key = json.dumps(results, sort_keys=True) + positive_label
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+
+        # ``results`` can be raw stats or already-computed metrics.
+        if "demographic_parity" in results and "equal_opportunity" in results:
+            labels = ["dataset"]
+            dp_vals = [float(results["demographic_parity"])]
+            eo_vals = [float(results["equal_opportunity"])]
+            img = self._bar_plot(labels, dp_vals, eo_vals)
+            self._cache[key] = img
+            return img
+
+        # maybe multimodal metrics
+        first = next(iter(results.values()))
+        if isinstance(first, dict) and "demographic_parity" in first:
+            labels = []
+            dp_vals = []
+            eo_vals = []
+            for mod, vals in results.items():
+                labels.append(mod)
+                dp_vals.append(float(vals.get("demographic_parity", 0.0)))
+                eo_vals.append(float(vals.get("equal_opportunity", 0.0)))
+            img = self._bar_plot(labels, dp_vals, eo_vals)
+            self._cache[key] = img
+            return img
+
+        # assume raw stats mapping group->counts or modality->group->counts
+        if isinstance(first, dict) and any(isinstance(v, dict) for v in first.values()):
+            metrics = self.evaluator.evaluate_multimodal(results, positive_label)
+            img = self.to_image(metrics)
+            self._cache[key] = img
+            return img
+        metrics = self.evaluator.evaluate(results, positive_label)
+        img = self.to_image(metrics)
+        self._cache[key] = img
+        return img
+
+
+__all__ = [
+    "FairnessEvaluator",
+    "CrossLingualFairnessEvaluator",
+    "FairnessFeedback",
+    "FairnessVisualizer",
+]

--- a/src/fairness_adaptation.py
+++ b/src/fairness_adaptation.py
@@ -7,7 +7,7 @@ from .data_ingest import ActiveDataSelector
 from .dataset_bias_detector import DatasetBiasDetector
 from .cognitive_load_monitor import CognitiveLoadMonitor
 from .dataset_lineage_manager import DatasetLineageManager
-from .fairness_evaluator import FairnessEvaluator
+from .fairness import FairnessEvaluator
 
 
 class FairnessAdaptationPipeline:

--- a/src/fairness_evaluator.py
+++ b/src/fairness_evaluator.py
@@ -1,50 +1,20 @@
 from __future__ import annotations
-from typing import Dict
 
-import numpy as np
+from importlib import import_module, util
+from pathlib import Path
+import sys
 
-
-class FairnessEvaluator:
-    """Compute simple fairness metrics."""
-
-    def demographic_parity(self, label_counts: Dict[str, Dict[str, int]], positive_label: str = "1") -> float:
-        rates = [
-            counts.get(positive_label, 0) / total
-            for counts in label_counts.values()
-            if (total := sum(counts.values())) > 0
-        ]
-        if not rates:
-            return 0.0
-        arr = np.asarray(rates, dtype=float)
-        return float(arr.max() - arr.min())
-
-    def equal_opportunity(self, stats: Dict[str, Dict[str, int]]) -> float:
-        tpr = [
-            counts.get("tp", 0) / pos
-            for counts in stats.values()
-            if (pos := counts.get("tp", 0) + counts.get("fn", 0)) > 0
-        ]
-        if not tpr:
-            return 0.0
-        arr = np.asarray(tpr, dtype=float)
-        return float(arr.max() - arr.min())
-
-    def evaluate(self, stats: Dict[str, Dict[str, int]], positive_label: str = "1") -> Dict[str, float]:
-        return {
-            "demographic_parity": self.demographic_parity(stats, positive_label),
-            "equal_opportunity": self.equal_opportunity(stats),
-        }
-
-    def evaluate_multimodal(
-        self, stats: Dict[str, Dict[str, Dict[str, int]]], positive_label: str = "1"
-    ) -> Dict[str, Dict[str, float]]:
-        """Return metrics for each modality in ``stats``.
-
-        ``stats`` maps modality → group → label counts.
-        """
-        results: Dict[str, Dict[str, float]] = {}
-        for modality, groups in stats.items():
-            results[modality] = self.evaluate(groups, positive_label)
-        return results
+try:
+    FairnessEvaluator = import_module(__package__ + '.fairness').FairnessEvaluator
+except Exception:  # pragma: no cover - fallback for direct file loading
+    path = Path(__file__).with_name('fairness.py')
+    spec = util.spec_from_file_location(
+        __package__ + '.fairness', path, submodule_search_locations=[str(path.parent)]
+    )
+    mod = util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, mod)
+    if spec.loader:
+        spec.loader.exec_module(mod)
+    FairnessEvaluator = mod.FairnessEvaluator
 
 __all__ = ["FairnessEvaluator"]

--- a/src/fairness_feedback.py
+++ b/src/fairness_feedback.py
@@ -1,96 +1,20 @@
 from __future__ import annotations
 
-from typing import Dict, Any
+from importlib import import_module, util
+from pathlib import Path
+import sys
 
 try:
-    from .cross_lingual_fairness import CrossLingualFairnessEvaluator
-except Exception:  # pragma: no cover - during tests
-    from cross_lingual_fairness import CrossLingualFairnessEvaluator  # type: ignore
-
-try:
-    from .dataset_weight_agent import DatasetWeightAgent
-except Exception:  # pragma: no cover - during tests
-    from dataset_weight_agent import DatasetWeightAgent  # type: ignore
-
-try:
-    from .data_ingest import ActiveDataSelector
-except Exception:  # pragma: no cover - during tests
-    from data_ingest import ActiveDataSelector  # type: ignore
-
-try:
-    from .adaptive_curriculum import SampleWeightRL
-except Exception:  # pragma: no cover - during tests
-    from adaptive_curriculum import SampleWeightRL  # type: ignore
-
-try:
-    from .dataset_lineage_manager import DatasetLineageManager
-except Exception:  # pragma: no cover - during tests
-    from dataset_lineage_manager import DatasetLineageManager  # type: ignore
-
-
-class FairnessFeedback:
-    """Adjust dataset selection based on cross-lingual fairness metrics."""
-
-    def __init__(
-        self,
-        selector: ActiveDataSelector | None = None,
-        weight_agent: DatasetWeightAgent | None = None,
-        gap_threshold: float = 0.1,
-        lineage: DatasetLineageManager | None = None,
-        rl_lr: float = 0.1,
-        positive_label: str = "tp",
-        min_threshold: float = 0.1,
-        max_threshold: float = 10.0,
-    ) -> None:
-        self.selector = selector
-        self.weight_agent = weight_agent
-        self.gap_threshold = gap_threshold
-        self.lineage = lineage
-        self.pos_label = positive_label
-        self.evaluator = CrossLingualFairnessEvaluator()
-        self.rl = SampleWeightRL(2, lr=rl_lr) if selector is not None else None
-        self.min_threshold = min_threshold
-        self.max_threshold = max_threshold
-
-    # --------------------------------------------------------------
-    def update(
-        self,
-        stats: Dict[str, Dict[str, int]],
-        dataset: str = "dataset",
-        val_accuracy: float = 1.0,
-    ) -> Dict[str, float]:
-        """Update selection strategy using fairness ``stats`` and log results."""
-        metrics = self.evaluator.evaluate(stats, positive_label=self.pos_label)
-        gap = max(
-            metrics.get("demographic_parity", 0.0),
-            metrics.get("equal_opportunity", 0.0),
-        )
-        changed: Dict[str, Any] = {}
-        if gap > self.gap_threshold:
-            if self.weight_agent is not None:
-                self.weight_agent.observe(dataset, val_accuracy, stats)
-                self.weight_agent.update_db()
-                changed["weight"] = self.weight_agent.weight(dataset)
-            if self.selector is not None and self.rl is not None:
-                probs = self.rl.weights()
-                action = 0 if float(probs[0]) >= float(probs[1]) else 1
-                self.rl.update(action, 1.0 - gap)
-                if action == 0:
-                    self.selector.threshold *= 1.1
-                else:
-                    self.selector.threshold *= 0.9
-                self.selector.threshold = min(
-                    max(self.selector.threshold, self.min_threshold),
-                    self.max_threshold,
-                )
-                changed["threshold"] = self.selector.threshold
-        if self.lineage is not None and changed:
-            self.lineage.record(
-                [],
-                [],
-                note=f"fairness_feedback metrics={metrics} changed={changed}",
-            )
-        return metrics
-
+    FairnessFeedback = import_module(__package__ + '.fairness').FairnessFeedback
+except Exception:  # pragma: no cover - fallback for direct file loading
+    path = Path(__file__).with_name('fairness.py')
+    spec = util.spec_from_file_location(
+        __package__ + '.fairness', path, submodule_search_locations=[str(path.parent)]
+    )
+    mod = util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, mod)
+    if spec.loader:
+        spec.loader.exec_module(mod)
+    FairnessFeedback = mod.FairnessFeedback
 
 __all__ = ["FairnessFeedback"]

--- a/src/fairness_visualizer.py
+++ b/src/fairness_visualizer.py
@@ -1,86 +1,20 @@
 from __future__ import annotations
 
-import base64
-import io
-import json
-from functools import lru_cache
-from typing import Dict, Any
+from importlib import import_module, util
+from pathlib import Path
+import sys
 
-import matplotlib
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-
-from .fairness_evaluator import FairnessEvaluator
-
-
-class FairnessVisualizer:
-    """Render demographic parity and equal opportunity gaps.
-
-    Caches previously generated images keyed by the input stats so repeated
-    calls avoid redundant plotting work.
-    """
-
-    def __init__(self, evaluator: FairnessEvaluator | None = None) -> None:
-        self.evaluator = evaluator or FairnessEvaluator()
-        self._cache: Dict[str, str] = {}
-
-    # --------------------------------------------------------------
-    def _bar_plot(self, labels: list[str], dp: list[float], eo: list[float]) -> str:
-        fig, ax = plt.subplots(figsize=(max(2, len(labels)), 2))
-        x = range(len(labels))
-        ax.bar([i - 0.2 for i in x], dp, width=0.4, label="parity")
-        ax.bar([i + 0.2 for i in x], eo, width=0.4, label="opportunity")
-        ax.set_xticks(list(x))
-        ax.set_xticklabels(labels)
-        ax.set_ylabel("gap")
-        ax.legend()
-        plt.tight_layout()
-        buf = io.BytesIO()
-        fig.savefig(buf, format="png")
-        plt.close(fig)
-        return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
-
-    # --------------------------------------------------------------
-    def to_image(self, results: Dict[str, Any], positive_label: str = "1") -> str:
-        """Return a base64 PNG for ``results`` from ``FairnessEvaluator``."""
-        key = json.dumps(results, sort_keys=True) + positive_label
-        cached = self._cache.get(key)
-        if cached is not None:
-            return cached
-
-        # ``results`` can be raw stats or already-computed metrics.
-        if "demographic_parity" in results and "equal_opportunity" in results:
-            labels = ["dataset"]
-            dp_vals = [float(results["demographic_parity"])]
-            eo_vals = [float(results["equal_opportunity"])]
-            img = self._bar_plot(labels, dp_vals, eo_vals)
-            self._cache[key] = img
-            return img
-
-        # maybe multimodal metrics
-        first = next(iter(results.values()))
-        if isinstance(first, dict) and "demographic_parity" in first:
-            labels = []
-            dp_vals = []
-            eo_vals = []
-            for mod, vals in results.items():
-                labels.append(mod)
-                dp_vals.append(float(vals.get("demographic_parity", 0.0)))
-                eo_vals.append(float(vals.get("equal_opportunity", 0.0)))
-            img = self._bar_plot(labels, dp_vals, eo_vals)
-            self._cache[key] = img
-            return img
-
-        # assume raw stats mapping group->counts or modality->group->counts
-        if isinstance(first, dict) and any(isinstance(v, dict) for v in first.values()):
-            metrics = self.evaluator.evaluate_multimodal(results, positive_label)
-            img = self.to_image(metrics)
-            self._cache[key] = img
-            return img
-        metrics = self.evaluator.evaluate(results, positive_label)
-        img = self.to_image(metrics)
-        self._cache[key] = img
-        return img
-
+try:
+    FairnessVisualizer = import_module(__package__ + '.fairness').FairnessVisualizer
+except Exception:  # pragma: no cover - fallback for direct file loading
+    path = Path(__file__).with_name('fairness.py')
+    spec = util.spec_from_file_location(
+        __package__ + '.fairness', path, submodule_search_locations=[str(path.parent)]
+    )
+    mod = util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, mod)
+    if spec.loader:
+        spec.loader.exec_module(mod)
+    FairnessVisualizer = mod.FairnessVisualizer
 
 __all__ = ["FairnessVisualizer"]

--- a/src/streaming_dataset_watcher.py
+++ b/src/streaming_dataset_watcher.py
@@ -12,7 +12,7 @@ import json
 from .dataset_discovery import DiscoveredDataset, _parse_rss, store_datasets
 from .dataset_summarizer import summarize_dataset
 from .dataset_bias_detector import compute_word_freq, bias_score
-from .cross_lingual_fairness import CrossLingualFairnessEvaluator
+from .fairness import CrossLingualFairnessEvaluator
 try:  # pragma: no cover - optional dependency
     from .data_ingest import CrossLingualTranslator
 except Exception:  # pragma: no cover - missing torch

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -174,4 +174,12 @@
 - Old modules now re-export the classes to keep backward compatibility.
 - Updated `hierarchical_memory.py` to import the unified `MemoryServer`.
 - Documented the change in `docs/Plan.md`.
-\n## PR 26\n- Unified various schedulers into `schedulers.py` and moved shared hardware checks to `scheduler_utils.py`.\n- Old scheduler modules now re-export from the new file to maintain compatibility.\n- Updated `__init__.py` imports accordingly.
+\n## PR 26
+- Unified various schedulers into `schedulers.py` and moved shared hardware checks to `scheduler_utils.py`.
+- Old scheduler modules now re-export from the new file to maintain compatibility.
+- Updated `__init__.py` imports accordingly.
+
+## PR 27
+- Consolidated fairness utilities into `src/fairness.py`.
+- Legacy modules now import classes from the unified file for backward compatibility.
+- Updated dependent modules, docs, and tests to reference the new path.


### PR DESCRIPTION
## Summary
- collect fairness utilities in a new `fairness.py`
- keep thin wrapper modules for backwards compatibility
- update imports and docs for the unified module
- adjust tests

## Testing
- `pytest tests/test_fairness_evaluator.py tests/test_cross_lingual_fairness.py tests/test_fairness_feedback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687302d1e3c88331ae9bea907b049dd3