### PR TITLE
Consolidate wrapper logic

### DIFF
--- a/src/accelerator_scheduler.py
+++ b/src/accelerator_scheduler.py
@@ -1,19 +1,8 @@
 """Backward compatibility wrapper for :mod:`schedulers`."""
 
 from importlib import import_module
-from pathlib import Path
-import sys
 
-pkg = sys.modules.get("asi")
-if pkg is None:
-    src_pkg = sys.modules.get("src")
-    if src_pkg is not None:
-        pkg = sys.modules["asi"] = src_pkg
-if pkg is not None and not getattr(pkg, "__path__", None):
-    pkg.__path__ = [str(Path(__file__).parent)]
-
-_schedulers = import_module("asi.schedulers")
-AcceleratorScheduler = _schedulers.AcceleratorScheduler
+from .scheduler_wrappers import AcceleratorScheduler
 psutil = import_module("asi.scheduler_utils").psutil
 if psutil is None:
     import types

--- a/src/adaptive_scheduler.py
+++ b/src/adaptive_scheduler.py
@@ -1,20 +1,9 @@
 """Backward compatibility wrapper for :mod:`schedulers`."""
 
-from importlib import import_module
-from pathlib import Path
-import sys
-
-pkg = sys.modules.get("asi")
-if pkg is None:
-    src_pkg = sys.modules.get("src")
-    if src_pkg is not None:
-        pkg = sys.modules["asi"] = src_pkg
-if pkg is not None and not getattr(pkg, "__path__", None):
-    pkg.__path__ = [str(Path(__file__).parent)]
-
-_sched = import_module("asi.schedulers")
-AdaptiveScheduler = _sched.AdaptiveScheduler
-EnergyAwareScheduler = _sched.EnergyAwareScheduler
-BatteryAwareScheduler = _sched.BatteryAwareScheduler
+from .scheduler_wrappers import (
+    AdaptiveScheduler,
+    EnergyAwareScheduler,
+    BatteryAwareScheduler,
+)
 
 __all__ = ["AdaptiveScheduler", "EnergyAwareScheduler", "BatteryAwareScheduler"]

--- a/src/base_memory_server.py
+++ b/src/base_memory_server.py
@@ -1,3 +1,3 @@
-from .memory_servers import BaseMemoryServer
+from .memory_server_wrappers import BaseMemoryServer
 
 __all__ = ["BaseMemoryServer"]

--- a/src/battery_aware_scheduler.py
+++ b/src/battery_aware_scheduler.py
@@ -1,18 +1,5 @@
 """Backward compatibility wrapper for :mod:`schedulers`."""
 
-from importlib import import_module
-from pathlib import Path
-import sys
-
-pkg = sys.modules.get("asi")
-if pkg is None:
-    src_pkg = sys.modules.get("src")
-    if src_pkg is not None:
-        pkg = sys.modules["asi"] = src_pkg
-if pkg is not None and not getattr(pkg, "__path__", None):
-    pkg.__path__ = [str(Path(__file__).parent)]
-
-_sched = import_module("asi.schedulers")
-BatteryAwareScheduler = _sched.BatteryAwareScheduler
+from .scheduler_wrappers import BatteryAwareScheduler
 
 __all__ = ["BatteryAwareScheduler"]

--- a/src/cross_lingual_fairness.py
+++ b/src/cross_lingual_fairness.py
@@ -1,22 +1,5 @@
 from __future__ import annotations
 
-from importlib import import_module, util
-from pathlib import Path
-import sys
-
-try:
-    CrossLingualFairnessEvaluator = (
-        import_module(__package__ + '.fairness').CrossLingualFairnessEvaluator
-    )
-except Exception:  # pragma: no cover - fallback for direct file loading
-    path = Path(__file__).with_name('fairness.py')
-    spec = util.spec_from_file_location(
-        __package__ + '.fairness', path, submodule_search_locations=[str(path.parent)]
-    )
-    mod = util.module_from_spec(spec)
-    sys.modules.setdefault(spec.name, mod)
-    if spec.loader:
-        spec.loader.exec_module(mod)
-    CrossLingualFairnessEvaluator = mod.CrossLingualFairnessEvaluator
+from .fairness_wrappers import CrossLingualFairnessEvaluator
 
 __all__ = ["CrossLingualFairnessEvaluator"]

--- a/src/energy_aware_scheduler.py
+++ b/src/energy_aware_scheduler.py
@@ -1,18 +1,5 @@
 """Backward compatibility wrapper for :mod:`schedulers`."""
 
-from importlib import import_module
-from pathlib import Path
-import sys
-
-pkg = sys.modules.get("asi")
-if pkg is None:
-    src_pkg = sys.modules.get("src")
-    if src_pkg is not None:
-        pkg = sys.modules["asi"] = src_pkg
-if pkg is not None and not getattr(pkg, "__path__", None):
-    pkg.__path__ = [str(Path(__file__).parent)]
-
-_sched = import_module("asi.schedulers")
-EnergyAwareScheduler = _sched.EnergyAwareScheduler
+from .scheduler_wrappers import EnergyAwareScheduler
 
 __all__ = ["EnergyAwareScheduler"]

--- a/src/fairness_evaluator.py
+++ b/src/fairness_evaluator.py
@@ -1,20 +1,5 @@
 from __future__ import annotations
 
-from importlib import import_module, util
-from pathlib import Path
-import sys
-
-try:
-    FairnessEvaluator = import_module(__package__ + '.fairness').FairnessEvaluator
-except Exception:  # pragma: no cover - fallback for direct file loading
-    path = Path(__file__).with_name('fairness.py')
-    spec = util.spec_from_file_location(
-        __package__ + '.fairness', path, submodule_search_locations=[str(path.parent)]
-    )
-    mod = util.module_from_spec(spec)
-    sys.modules.setdefault(spec.name, mod)
-    if spec.loader:
-        spec.loader.exec_module(mod)
-    FairnessEvaluator = mod.FairnessEvaluator
+from .fairness_wrappers import FairnessEvaluator
 
 __all__ = ["FairnessEvaluator"]

--- a/src/fairness_feedback.py
+++ b/src/fairness_feedback.py
@@ -1,20 +1,5 @@
 from __future__ import annotations
 
-from importlib import import_module, util
-from pathlib import Path
-import sys
-
-try:
-    FairnessFeedback = import_module(__package__ + '.fairness').FairnessFeedback
-except Exception:  # pragma: no cover - fallback for direct file loading
-    path = Path(__file__).with_name('fairness.py')
-    spec = util.spec_from_file_location(
-        __package__ + '.fairness', path, submodule_search_locations=[str(path.parent)]
-    )
-    mod = util.module_from_spec(spec)
-    sys.modules.setdefault(spec.name, mod)
-    if spec.loader:
-        spec.loader.exec_module(mod)
-    FairnessFeedback = mod.FairnessFeedback
+from .fairness_wrappers import FairnessFeedback
 
 __all__ = ["FairnessFeedback"]

--- a/src/fairness_visualizer.py
+++ b/src/fairness_visualizer.py
@@ -1,20 +1,5 @@
 from __future__ import annotations
 
-from importlib import import_module, util
-from pathlib import Path
-import sys
-
-try:
-    FairnessVisualizer = import_module(__package__ + '.fairness').FairnessVisualizer
-except Exception:  # pragma: no cover - fallback for direct file loading
-    path = Path(__file__).with_name('fairness.py')
-    spec = util.spec_from_file_location(
-        __package__ + '.fairness', path, submodule_search_locations=[str(path.parent)]
-    )
-    mod = util.module_from_spec(spec)
-    sys.modules.setdefault(spec.name, mod)
-    if spec.loader:
-        spec.loader.exec_module(mod)
-    FairnessVisualizer = mod.FairnessVisualizer
+from .fairness_wrappers import FairnessVisualizer
 
 __all__ = ["FairnessVisualizer"]

--- a/src/fairness_wrappers.py
+++ b/src/fairness_wrappers.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from importlib import import_module, util
+from pathlib import Path
+import sys
+
+
+def _load(name: str):
+    """Load ``name`` from :mod:`fairness` with fallback for direct file usage."""
+    try:
+        mod = import_module(__package__ + '.fairness')
+        return getattr(mod, name)
+    except Exception:
+        path = Path(__file__).with_name('fairness.py')
+        spec = util.spec_from_file_location(
+            __package__ + '.fairness', path, submodule_search_locations=[str(path.parent)]
+        )
+        mod = util.module_from_spec(spec)
+        sys.modules.setdefault(spec.name, mod)
+        if spec.loader:
+            spec.loader.exec_module(mod)
+        return getattr(mod, name)
+
+
+FairnessEvaluator = _load('FairnessEvaluator')
+CrossLingualFairnessEvaluator = _load('CrossLingualFairnessEvaluator')
+FairnessFeedback = _load('FairnessFeedback')
+FairnessVisualizer = _load('FairnessVisualizer')
+
+__all__ = [
+    'FairnessEvaluator',
+    'CrossLingualFairnessEvaluator',
+    'FairnessFeedback',
+    'FairnessVisualizer',
+]

--- a/src/federated_memory_server.py
+++ b/src/federated_memory_server.py
@@ -1,3 +1,3 @@
-from .memory_servers import FederatedMemoryServer
+from .memory_server_wrappers import FederatedMemoryServer
 
 __all__ = ["FederatedMemoryServer"]

--- a/src/fhe_memory_server.py
+++ b/src/fhe_memory_server.py
@@ -1,3 +1,3 @@
-from .memory_servers import FHEMemoryServer, FHEMemoryClient
+from .memory_server_wrappers import FHEMemoryServer, FHEMemoryClient
 
 __all__ = ["FHEMemoryServer", "FHEMemoryClient"]

--- a/src/memory_server_wrappers.py
+++ b/src/memory_server_wrappers.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from .memory_servers import (
+    BaseMemoryServer,
+    MemoryServer,
+    FederatedMemoryServer,
+    FHEMemoryServer,
+    FHEMemoryClient,
+    QuantizedMemoryServer,
+    QuantumMemoryServer,
+    ZeroTrustMemoryServer,
+)
+
+__all__ = [
+    'BaseMemoryServer',
+    'MemoryServer',
+    'FederatedMemoryServer',
+    'FHEMemoryServer',
+    'FHEMemoryClient',
+    'QuantizedMemoryServer',
+    'QuantumMemoryServer',
+    'ZeroTrustMemoryServer',
+]

--- a/src/quantized_memory_server.py
+++ b/src/quantized_memory_server.py
@@ -1,3 +1,3 @@
-from .memory_servers import QuantizedMemoryServer
+from .memory_server_wrappers import QuantizedMemoryServer
 
 __all__ = ["QuantizedMemoryServer"]

--- a/src/quantum_memory_server.py
+++ b/src/quantum_memory_server.py
@@ -1,3 +1,3 @@
-from .memory_servers import QuantumMemoryServer
+from .memory_server_wrappers import QuantumMemoryServer
 
 __all__ = ["QuantumMemoryServer"]

--- a/src/scheduler_wrappers.py
+++ b/src/scheduler_wrappers.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+import sys
+
+pkg = sys.modules.get('asi')
+if pkg is None:
+    src_pkg = sys.modules.get('src')
+    if src_pkg is not None:
+        pkg = sys.modules['asi'] = src_pkg
+if pkg is not None and not getattr(pkg, '__path__', None):
+    pkg.__path__ = [str(Path(__file__).parent)]
+
+_sched = import_module('asi.schedulers')
+
+AcceleratorScheduler = _sched.AcceleratorScheduler
+AdaptiveScheduler = _sched.AdaptiveScheduler
+EnergyAwareScheduler = _sched.EnergyAwareScheduler
+BatteryAwareScheduler = _sched.BatteryAwareScheduler
+
+__all__ = [
+    'AcceleratorScheduler',
+    'AdaptiveScheduler',
+    'EnergyAwareScheduler',
+    'BatteryAwareScheduler',
+]

--- a/src/zero_trust_memory_server.py
+++ b/src/zero_trust_memory_server.py
@@ -1,3 +1,3 @@
-from .memory_servers import ZeroTrustMemoryServer
+from .memory_server_wrappers import ZeroTrustMemoryServer
 
 __all__ = ["ZeroTrustMemoryServer"]

--- a/steps_summary.md
+++ b/steps_summary.md
@@ -183,3 +183,8 @@
 - Consolidated fairness utilities into `src/fairness.py`.
 - Legacy modules now import classes from the unified file for backward compatibility.
 - Updated dependent modules, docs, and tests to reference the new path.
+
+## PR 28
+- Created `fairness_wrappers.py`, `scheduler_wrappers.py`, and `memory_server_wrappers.py` to consolidate repetitive wrapper logic.
+- Updated individual wrapper modules to import from these new files.
+- This removes duplicated import boilerplate while keeping backward compatibility.


### PR DESCRIPTION
## Summary
- add consolidated `fairness_wrappers`, `scheduler_wrappers`, and `memory_server_wrappers`
- refactor individual wrapper modules to import from these helpers
- document the consolidation in `steps_summary.md`

## Testing
- `python -m unittest tests.test_fairness_evaluator` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_687307f8759083318db69be7d2365d76